### PR TITLE
Bugfix/iac 748 change projectid between organizations should fetch projectid from restclient instead of configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 * [vropkg] vropkg-not-working-offline / vropkg had a missing dependency that was not bundled
+* [artifact-manager] IAC-748 / Change project id between organizations to use restClient instead of config.
+
 ### Enhancements
 * [polyglot] IAC-604 / vRBT to support downloading powershell modules through 'Ssl3' | 'Tls' | 'Tls11' | 'Tls12' | 'Tls13' .
 * [polyglot] IAC-604 / Using Import-Module must always be in the format of Import-Module <module name> without -Name and ; at the end of the line to avoid confusion .

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStore.java
@@ -391,7 +391,7 @@ public class VraNgCustomResourceStore extends AbstractVraNgStore {
 	}
 
 	private void changeProjectIdBetweenOrganizations(final JsonObject customResourceJsonElement) {
-		String defaultProjectId = this.config.getProjectId();
+		String defaultProjectId = this.restClient.getProjectId();
 		if (defaultProjectId != null) {
 			if (customResourceJsonElement.get("projectId") != null
 				&& !customResourceJsonElement.get("projectId").getAsString().equals("")) {

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStoreTest.java
@@ -135,7 +135,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder = new CustomResourceMockBuilder();
 		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
 
-		when( config.getProjectId() ).thenReturn(PROJECT_ID);
+		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
 		when( restClient.getVraWorkflowIntegration( any()) ).thenReturn( vro );
 		when( restClient.getAllCustomResources() ).thenReturn( new HashMap<String, VraNgCustomResource>() );
 		doNothing().when( restClient ).importCustomResource( anyString(), anyString() );
@@ -147,7 +147,7 @@ public class VraNgCustomResourceStoreTest {
 		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
 
 		// VERIFY
-		verify( config, times( 3 ) ).getProjectId();
+		verify( restClient, times( 3 ) ).getProjectId();
 		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
 		verify( restClient, times( 1 ) ).getAllCustomResources();
 		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
@@ -179,7 +179,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder	= new CustomResourceMockBuilder();
 		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
 
-		when( config.getProjectId() ).thenReturn( PROJECT_ID );
+		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
 		when( restClient.getAllCustomResources() ).thenReturn( new HashMap<String, VraNgCustomResource>() );
 		doNothing().when( restClient ).importCustomResource( anyString(), anyString() );
@@ -191,7 +191,7 @@ public class VraNgCustomResourceStoreTest {
 		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
 
 		// VERIFY
-		verify( config, times( 3 ) ).getProjectId();
+		verify( restClient, times( 3 ) ).getProjectId();
 		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
 		verify( restClient, times( 1 ) ).getAllCustomResources();
 		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
@@ -241,7 +241,7 @@ public class VraNgCustomResourceStoreTest {
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
 
-		when( config.getProjectId() ).thenReturn( PROJECT_ID );
+		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
 		when( config.getOrgId() ).thenReturn( ORG_ID );
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
 		when( restClient.getAllCustomResources() ).thenReturn( map );
@@ -287,7 +287,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder = new CustomResourceMockBuilder();
 		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson();
 
-		when( config.getProjectId() ).thenReturn( PROJECT_ID );
+		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
 		when( restClient.getAllCustomResources() ).thenReturn( map );
 		doNothing().when( restClient ).importCustomResource( any(), anyString() );
@@ -299,7 +299,7 @@ public class VraNgCustomResourceStoreTest {
 		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
 
 		// VERIFY
-		verify( config, times( 3 ) ).getProjectId();
+		verify( restClient, times( 3 ) ).getProjectId();
 		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
 		verify( restClient, times( 1 ) ).getAllCustomResources();
 		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
@@ -341,7 +341,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder = new CustomResourceMockBuilder();
 		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
 
-		when( config.getProjectId() ).thenReturn( PROJECT_ID );
+		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
 		when( restClient.getAllCustomResources() ).thenReturn( map );
 		doNothing().when( restClient ).importCustomResource( any(), anyString() );
@@ -352,7 +352,7 @@ public class VraNgCustomResourceStoreTest {
 		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( config, times( 3 ) ).getProjectId();
+		verify( restClient, times( 3 ) ).getProjectId();
 		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
 		verify( restClient, times( 1 ) ).getAllCustomResources();
 		verify( restClient, times(1) ).importCustomResource( any(), anyString() );
@@ -395,7 +395,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder = new CustomResourceMockBuilder();
 		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
 
-		when( config.getProjectId() ).thenReturn(PROJECT_ID);
+		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn(vro);
 		when( restClient.getAllCustomResources() ).thenReturn(map);
 		doNothing().when( restClient ).importCustomResource( any(), anyString());
@@ -407,7 +407,7 @@ public class VraNgCustomResourceStoreTest {
 		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
 
 		// VERIFY
-		verify( config, times( 3 ) ).getProjectId();
+		verify( restClient, times( 3 ) ).getProjectId();
 		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
 		verify( restClient, times( 1 ) ).getAllCustomResources();
 		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
@@ -451,7 +451,7 @@ public class VraNgCustomResourceStoreTest {
 		mockBuilder = new CustomResourceMockBuilder();
 		String comparator = mockBuilder.setOrgId( ORG_ID ).removeFormDefinitionIds().withoutIdInRawData().build().getJson().toString();
 
-		when( config.getProjectId() ).thenReturn(PROJECT_ID);
+		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
 		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn(vro);
 		when( restClient.getAllCustomResources() ).thenReturn(map);
 		doNothing().when( restClient ).importCustomResource( any(), anyString());


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
restClient used to get project id and test related fixed.
<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x ] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [ ] My changes have been rebased and squashed to the minimal number of relevant commits
- [ x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->
Tests failed after the changes was fixed.
### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
