### PR TITLE
[IAC-742] Fixed helper files exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Fixes
+* [vrotest] IAC-742 / *.helper.[tj]s files will now be excluded from code coverage reports
+
+### Enhancements
+* [artifact-manager] IAC-693 / vRBT to support new content sharing policies.
+
 ## v2.30.0 - 10 Mar 2023
 
 ### Fixes
@@ -13,7 +19,6 @@
 * [artifact-manager] IAC-733 / Add an Option for Overwriting Existing vRLI Content Packs.
 * [artifact-manager] IAC-741 / mvn vrealize:clean now will not fail if not supported
 * [artifact-manager] IAC-745 / VRLI Alerts Fallback Object Set to LogInsight Only During Push
-* [artifact-manager] IAC-693 / vRBT to support new content sharing policies.
 
 ## v2.29.2 - 24 Feb 2023
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -65,6 +65,20 @@ The project id is now fetched from the restClient, which checks if we have proje
 #### Relevant Documentation:
 None
 
+### *.helper.[tj]s files will now be excluded from code coverage reports*
+Helper files are meant to contain fixture or other helper methods and they are not supposed to be part of the code coverage report.
+
+#### Previous Behavior
+The `.nycrc` configuration that controls the code coverage did not contain an exclude for the helpers
+
+#### New Behavior
+`"**/*.helper.[tj]s"` was added to the configuration to facilitate exclusion of helpers
+
+#### Relevant Documentation:
+* None
+
+
+
 ## Upgrade procedure:
 [//]: # (Explain in details if something needs to be done)
 

--- a/typescript/vrotest/package.json
+++ b/typescript/vrotest/package.json
@@ -57,6 +57,6 @@
 		"iconv-lite",
 		"jasmine",
 		"nyc",
-    "browserslist"
+		"browserslist"
 	]
 }

--- a/typescript/vrotest/src/build.ts
+++ b/typescript/vrotest/src/build.ts
@@ -10,9 +10,9 @@ import * as pkg from "./package";
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -358,7 +358,8 @@ export default async function (flags: BuildCommandFlags) {
                 "src"
             ],
             "exclude": [
-                "**/*_helper.js"
+                "**/*_helper.js",
+                "**/*.helper.[tj]s",
             ],
             "reporter": (flags["coverage-reports"] || "text").split(",").map(x => x.trim()),
             "report-dir": "coverage",


### PR DESCRIPTION
### Description
Helper files are meant to contain fixture or other helper methods and they are not supposed to be part of the code coverage report.


### Checklist


- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Locally

### Release Notes

### *.helper.[tj]s files will now be excluded from code coverage reports*
Helper files are meant to contain fixture or other helper methods and they are not supposed to be part of the code coverage report.

#### Previous Behavior
The `.nycrc` configuration that controls the code coverage did not contain an exclude for the helpers

#### New Behavior
`"**/*.helper.[tj]s"` was added to the configuration to facilitate exclusion of helpers

#### Relevant Documentation:
* None

### Related issues and PRs

