### PR TITLE
[IAC-755] Removed helper.d.ts generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixes
+* [vrotsc] IAC-755 / *.helper.ts files will now be excluded from type definitions
+
 ## v2.31.0 - 29 Mar 2023
 
 ### Fixes

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -28,16 +28,21 @@
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
-[//]: # (### *Improvement Name* )
-[//]: # (Talk ONLY regarding the improvement)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### Previous Behavior)
-[//]: # (Explain how it used to behave, regarding to the change)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### New Behavior)
-[//]: # (Explain how it behaves now, regarding to the change)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
+
+
+
+### **.helper.ts files will now be excluded from type definitions* 
+Currently the *.helper.ts files are being transpiled, and definitions are being generated. This shouldn't be happening, 
+as there is no reason to have helper files as part of the definitions, since they are test related only.
+
+#### Previous Behavior
+The helper.ts files had type definitions generated for them since vrotsc did not detect them correctly.
+
+#### New Behavior
+The helper.ts are now being correctly filtered out by vrtosc, by excluding files that end with: `.helper.ts`.
+
+#### Relevant Documentation:
+* None
 
 
 

--- a/typescript/vrotsc/e2e/expect/export-helpers/types/actions/index.d.ts
+++ b/typescript/vrotsc/e2e/expect/export-helpers/types/actions/index.d.ts
@@ -1,3 +1,2 @@
 import * as normalAction from "./normalAction";
-import * as testhelper from "./test.helper";
-export { normalAction, testhelper };
+export { normalAction };

--- a/typescript/vrotsc/e2e/expect/export-helpers/types/actions/test.helper.d.ts
+++ b/typescript/vrotsc/e2e/expect/export-helpers/types/actions/test.helper.d.ts
@@ -1,1 +1,0 @@
-export default function (): number;

--- a/typescript/vrotsc/src/compiler/transformers/declaration.ts
+++ b/typescript/vrotsc/src/compiler/transformers/declaration.ts
@@ -6,9 +6,9 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -109,6 +109,10 @@ namespace vrotsc {
 
     export function canCreateDeclarationForFile(file: FileDescriptor, rootDir: string): boolean {
         if (!file.fileName.toLowerCase().endsWith(".ts")) {
+            return false;
+        }
+
+        if (file.fileName.toLowerCase().endsWith(".helper.ts")) {
             return false;
         }
 


### PR DESCRIPTION
### Description

Currently the *.helper.ts files are being transpiled, and definitions are being generated. This shouldn't be happening, as there is no reason to have helper files as part of the definitions, since they are test related only.

### Checklist


- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested with a typescript project check attached pic
<img width="268" alt="image" src="https://user-images.githubusercontent.com/17056014/228573588-9b61ba7c-6ab6-4f44-8d49-dc821ceccc40.png">


### Release Notes

The helper.ts are now being correctly filtered out by vrtosc, by excluding files that end with: `.helper.ts`.


### Related issues and PRs

https://jira.pscoe.vmware.com/browse/IAC-755
