### PR TITLE
[Task IAC-761] Activate / Deactivate vROPs Dashboards for Users / Groups

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/AuthUserDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/AuthUserDTO.java
@@ -1,0 +1,328 @@
+package com.vmware.pscoe.iac.artifact.rest.model.vrops;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "id", "username", "firstName", "lastName", "password", "emailAddress", "distinguishedName", "enabled", "groupIds", "roleNames",
+		"role-permissions", "lastLoginTime", "links" })
+public class AuthUserDTO {
+
+	@JsonProperty("id")
+	private String id;
+
+	@JsonProperty("username")
+	private String username;
+
+	@JsonProperty("firstName")
+	private String firstName;
+
+	@JsonProperty("lastName")
+	private String lastName;
+
+	@JsonProperty("password")
+	private Object password;
+
+	@JsonProperty("emailAddress")
+	private String emailAddress;
+
+	@JsonProperty("distinguishedName")
+	private String distinguishedName;
+
+	@JsonProperty("enabled")
+	private Boolean enabled;
+
+	@JsonProperty("groupIds")
+	private List<String> groupIds;
+
+	@JsonProperty("roleNames")
+	private List<String> roleNames;
+
+	@JsonProperty("role-permissions")
+	private List<RolePermission> rolePermissions;
+
+	@JsonProperty("lastLoginTime")
+	private Long lastLoginTime;
+
+	@JsonProperty("links")
+	private List<Link> links;
+
+	@JsonIgnore
+	private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+	@JsonProperty("id")
+	public String getId() {
+		return id;
+	}
+
+	@JsonProperty("id")
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@JsonProperty("username")
+	public String getUsername() {
+		return username;
+	}
+
+	@JsonProperty("username")
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	@JsonProperty("firstName")
+	public String getFirstName() {
+		return firstName;
+	}
+
+	@JsonProperty("firstName")
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	@JsonProperty("lastName")
+	public String getLastName() {
+		return lastName;
+	}
+
+	@JsonProperty("lastName")
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	@JsonProperty("password")
+	public Object getPassword() {
+		return password;
+	}
+
+	@JsonProperty("password")
+	public void setPassword(Object password) {
+		this.password = password;
+	}
+
+	@JsonProperty("emailAddress")
+	public String getEmailAddress() {
+		return emailAddress;
+	}
+
+	@JsonProperty("emailAddress")
+	public void setEmailAddress(String emailAddress) {
+		this.emailAddress = emailAddress;
+	}
+
+	@JsonProperty("distinguishedName")
+	public String getDistinguishedName() {
+		return distinguishedName;
+	}
+
+	@JsonProperty("distinguishedName")
+	public void setDistinguishedName(String distinguishedName) {
+		this.distinguishedName = distinguishedName;
+	}
+
+	@JsonProperty("enabled")
+	public Boolean getEnabled() {
+		return enabled;
+	}
+
+	@JsonProperty("enabled")
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	@JsonProperty("groupIds")
+	public List<String> getGroupIds() {
+		return groupIds;
+	}
+
+	@JsonProperty("groupIds")
+	public void setGroupIds(List<String> groupIds) {
+		this.groupIds = groupIds;
+	}
+
+	@JsonProperty("roleNames")
+	public List<String> getRoleNames() {
+		return roleNames;
+	}
+
+	@JsonProperty("roleNames")
+	public void setRoleNames(List<String> roleNames) {
+		this.roleNames = roleNames;
+	}
+
+	@JsonProperty("role-permissions")
+	public List<RolePermission> getRolePermissions() {
+		return rolePermissions;
+	}
+
+	@JsonProperty("role-permissions")
+	public void setRolePermissions(List<RolePermission> rolePermissions) {
+		this.rolePermissions = rolePermissions;
+	}
+
+	@JsonProperty("lastLoginTime")
+	public Long getLastLoginTime() {
+		return lastLoginTime;
+	}
+
+	@JsonProperty("lastLoginTime")
+	public void setLastLoginTime(Long lastLoginTime) {
+		this.lastLoginTime = lastLoginTime;
+	}
+
+	@JsonProperty("links")
+	public List<Link> getLinks() {
+		return links;
+	}
+
+	@JsonProperty("links")
+	public void setLinks(List<Link> links) {
+		this.links = links;
+	}
+
+	@JsonAnyGetter
+	public Map<String, Object> getAdditionalProperties() {
+		return this.additionalProperties;
+	}
+
+	@JsonAnySetter
+	public void setAdditionalProperty(String name, Object value) {
+		this.additionalProperties.put(name, value);
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "roleName", "scopeId", "allowAllObjects" })
+	public static class RolePermission {
+
+		@JsonProperty("roleName")
+		private String roleName;
+
+		@JsonProperty("scopeId")
+		private String scopeId;
+
+		@JsonProperty("allowAllObjects")
+		private Boolean allowAllObjects;
+		@JsonIgnore
+		private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+		@JsonProperty("roleName")
+		public String getRoleName() {
+			return roleName;
+		}
+
+		@JsonProperty("roleName")
+		public void setRoleName(String roleName) {
+			this.roleName = roleName;
+		}
+
+		@JsonProperty("scopeId")
+		public String getScopeId() {
+			return scopeId;
+		}
+
+		@JsonProperty("scopeId")
+		public void setScopeId(String scopeId) {
+			this.scopeId = scopeId;
+		}
+
+		@JsonProperty("allowAllObjects")
+		public Boolean getAllowAllObjects() {
+			return allowAllObjects;
+		}
+
+		@JsonProperty("allowAllObjects")
+		public void setAllowAllObjects(Boolean allowAllObjects) {
+			this.allowAllObjects = allowAllObjects;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperty(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "href", "rel", "name" })
+	public static class Link {
+
+		@JsonProperty("href")
+		private String href;
+
+		@JsonProperty("rel")
+		private String rel;
+
+		@JsonProperty("name")
+		private String name;
+
+		@JsonIgnore
+		private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+		@JsonProperty("href")
+		public String getHref() {
+			return href;
+		}
+
+		@JsonProperty("href")
+		public void setHref(String href) {
+			this.href = href;
+		}
+
+		@JsonProperty("rel")
+		public String getRel() {
+			return rel;
+		}
+
+		@JsonProperty("rel")
+		public void setRel(String rel) {
+			this.rel = rel;
+		}
+
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+
+		@JsonProperty("name")
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperty(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+}

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/AuthUsersDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/AuthUsersDTO.java
@@ -1,0 +1,58 @@
+
+package com.vmware.pscoe.iac.artifact.rest.model.vrops;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "users" })
+public class AuthUsersDTO {
+
+	@JsonProperty("users")
+	private List<AuthUserDTO> users;
+
+	@JsonIgnore
+	private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+	@JsonProperty("users")
+	public List<AuthUserDTO> getUsers() {
+		return users;
+	}
+
+	@JsonProperty("users")
+	public void setUsers(List<AuthUserDTO> users) {
+		this.users = users;
+	}
+
+	@JsonAnyGetter
+	public Map<String, Object> getAdditionalProperties() {
+		return this.additionalProperties;
+	}
+
+	@JsonAnySetter
+	public void setAdditionalProperty(String name, Object value) {
+		this.additionalProperties.put(name, value);
+	}
+}

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
@@ -55,6 +55,9 @@ public class PackageMocked {
 		String dashResourceProp = dashboardName + "=" + dashboardName + "\n" + dashboardName + ".Something=Somevalue";
 
 		String alertDefsJson = "{\"id\": \"1\"}";
+		String shareMetadata = "{ \"share\": {\""+dashboardName+"\" : [\"group1\"]}, \"unshare\" : {} }";
+		String activateUserMetadata = "{ \"activate\": {\""+dashboardName+"\" : [\"user1\"]}, \"deactivate\" : {} }";
+		String activateGroupMetadata = "{ \"activate\": {\""+dashboardName+"\" : [\"group1\"]}, \"deactivate\" : {} }";
 
 		File tempZip = new File(dir, UUID.randomUUID() + ".zip");
 		FileOutputStream fos = new FileOutputStream(tempZip);
@@ -68,9 +71,21 @@ public class PackageMocked {
 		zipOut.putNextEntry(resourcePropZipEntry);
 		zipOut.write(resourceProp.getBytes(StandardCharsets.UTF_8));
 
-		ZipEntry dashbaordZipEntry = new ZipEntry("/dashboards/" + dashboardName + ".xml");
-		zipOut.putNextEntry(dashbaordZipEntry);
+		ZipEntry dashboardZipEntry = new ZipEntry("/dashboards/" + dashboardName + ".xml");
+		zipOut.putNextEntry(dashboardZipEntry);
 		zipOut.write(dashboardsJson.getBytes(StandardCharsets.UTF_8));
+
+		ZipEntry dashboardShareMetadataZipEntry = new ZipEntry("/dashboards/metadata/dashboardSharingMetadata.vrops.json");
+		zipOut.putNextEntry(dashboardShareMetadataZipEntry);
+		zipOut.write(shareMetadata.getBytes(StandardCharsets.UTF_8));
+
+		ZipEntry dashboardUserActivateMetadataZipEntry = new ZipEntry("/dashboards/metadata/dashboardUserActivationMetadata.vrops.json");
+		zipOut.putNextEntry(dashboardUserActivateMetadataZipEntry);
+		zipOut.write(activateUserMetadata.getBytes(StandardCharsets.UTF_8));
+
+		ZipEntry dashboardGroupActivateMetadataZipEntry = new ZipEntry("/dashboards/metadata/dashboardGroupActivationMetadata.vrops.json");
+		zipOut.putNextEntry(dashboardGroupActivateMetadataZipEntry);
+		zipOut.write(activateGroupMetadata.getBytes(StandardCharsets.UTF_8));
 
 		resourcePropZipEntry = new ZipEntry("/dashboards/resources/resources.properties");
 		zipOut.putNextEntry(resourcePropZipEntry);

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -24,7 +24,41 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+## Add Support for Activating / Deactivating of vROPs Dashboards for Users / Groups
+If there is a metadata file for activating / deactivating of vROPs dashboards it will be used for activation / deactivation of the imported dashboards for certain users / groups.
 
+#### Previous Behavior
+There was no support for activating / deactivating of vROPs dashboards for specific users / groups.
+
+#### New Behavior
+There is support for activating / deactivating of vROPs dashboards for specific users / groups.
+
+#### Relevant Documentation
+In order activating of vROPs dashboards for specific users / groups the following files should be present in the dashboards/metadata directory:
+* dashboards/metadata/dashboardUserActivationMetadata.vrops  - activate / deactivate dashboards for specific users 
+* dashboards/metadata/dashboardGroupActivationMetadata.vrops - activate / deactivate dashboards for specific groups
+With the following content:
+* dashboards/metadata/dashboardUserActivationMetadata.vrops - activation for specific users
+{
+	"activate": {
+		"dashboard name": ["user1", "user2" ]
+	},
+	"deactivate": {
+		"dashboard name": ["user3, user4" ]
+	}
+}
+
+* dashboards/metadata/dashboardGroupActivationMetadata.vrops - activation for specific groups
+{
+	"activate": {
+		"dashboard name": ["group1", "group2" ]
+	},
+	"deactivate": {
+		"dashboard name": ["group3, group4" ]
+	}
+}
+The users / groups must exist on the target system, otherwise an error will be thrown stating that the users / groups do not exist on the target vROPs system.
+For convenience during pulling of dashboard from a vROPs system a set of activation metadata files will be generated with list of dashboards and an empty array of users / groups.
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements

--- a/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/PackageMojo.java
+++ b/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/PackageMojo.java
@@ -47,7 +47,10 @@ import edu.emory.mathcs.backport.java.util.Arrays;
 @Mojo(name = "package", defaultPhase = LifecyclePhase.PACKAGE)
 public class PackageMojo extends AbstractMojo {
     private static final String POLICY_METADATA_FILE_NAME = "policiesMetadata.vrops.json";
-    private static final String DASHBOARD_SHARE_METADATA_FILENAME = "dashboardSharingMetadata.vrops.json";
+    private static final String DASHBOARD_SHARE_METADATA_FILENAME = "metadata/dashboardSharingMetadata.vrops.json";
+    private static final String DASHBOARD_USER_ACTIVATE_METADATA_FILENAME = "metadata/dashboardUserActivationMetadata.vrops.json";
+    private static final String DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME = "metadata/dashboardGroupActivationMetadata.vrops.json";
+    
     private static final String ZIP_FILE_TYPE = "zip";
     private static final String XML_FILE_TYPE = "xml";
     private static final String JSON_FILE_TYPE = "json";
@@ -86,7 +89,7 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
-    private File filterSourcesByContentYaml(File sources, VropsPackageDescriptor contentYaml, File filteredDir) throws IOException {
+    private File filterSourcesByContentYaml(final File sources, final VropsPackageDescriptor contentYaml, final File filteredDir) throws IOException {
         if (filteredDir.exists()) {
             FileUtils.deleteDirectory(filteredDir);
         }
@@ -94,26 +97,26 @@ public class PackageMojo extends AbstractMojo {
             throw new IOException("Cannot create directory \"" + filteredDir + "\" or some of its parents. Please check file system permisions.");
         }
 
-        File srcDashboardsDir = new File(sources, "dashboards");
-        File destDashboardsDir = new File(filteredDir, "dashboards");
-        File srcViewsDir = new File(sources, "views");
-        File destViewsDir = new File(filteredDir, "views");
-        File srcReportsDir = new File(sources, "reports");
-        File destReportsDir = new File(filteredDir, "reports");
-        File srcAlertDefsDir = new File(sources, "alert_definitions");
-        File destAlertDefsDir = new File(filteredDir, "alert_definitions");
-        File srcSymptomDefsDir = new File(sources, "symptom_definitions");
-        File destSymptomDefsDir = new File(filteredDir, "symptom_definitions");
-        File srcPoliciesDir = new File(sources, "policies");
-        File destPoliciesDir = new File(filteredDir, "policies");
-        File srcSuperMetricsDir = new File(sources, "supermetrics");
-        File destSuperMetricsDir = new File(filteredDir, "supermetrics");
-        File srcRecommendationsDir = new File(sources, "recommendations");
-        File destRecommendationsDir = new File(filteredDir, "recommendations");
-        File srcMetricConfigsDir = new File(sources, "metricconfigs");
-        File destMetricConfigsDir = new File(filteredDir, "metricconfigs");
-        File srcCustomGroupDir = new File(sources, "custom_groups");
-        File destCustomGroupDir = new File(filteredDir, "custom_groups");
+        final File srcDashboardsDir = new File(sources, "dashboards");
+        final File destDashboardsDir = new File(filteredDir, "dashboards");
+        final File srcViewsDir = new File(sources, "views");
+        final File destViewsDir = new File(filteredDir, "views");
+        final File srcReportsDir = new File(sources, "reports");
+        final File destReportsDir = new File(filteredDir, "reports");
+        final File srcAlertDefsDir = new File(sources, "alert_definitions");
+        final File destAlertDefsDir = new File(filteredDir, "alert_definitions");
+        final File srcSymptomDefsDir = new File(sources, "symptom_definitions");
+        final File destSymptomDefsDir = new File(filteredDir, "symptom_definitions");
+        final File srcPoliciesDir = new File(sources, "policies");
+        final File destPoliciesDir = new File(filteredDir, "policies");
+        final File srcSuperMetricsDir = new File(sources, "supermetrics");
+        final File destSuperMetricsDir = new File(filteredDir, "supermetrics");
+        final File srcRecommendationsDir = new File(sources, "recommendations");
+        final File destRecommendationsDir = new File(filteredDir, "recommendations");
+        final File srcMetricConfigsDir = new File(sources, "metricconfigs");
+        final File destMetricConfigsDir = new File(filteredDir, "metricconfigs");
+        final File srcCustomGroupDir = new File(sources, "custom_groups");
+        final File destCustomGroupDir = new File(filteredDir, "custom_groups");
 
         destDashboardsDir.mkdirs();
         destViewsDir.mkdirs();
@@ -124,16 +127,16 @@ public class PackageMojo extends AbstractMojo {
         destMetricConfigsDir.mkdirs();
         destCustomGroupDir.mkdirs();
 
-        List<String> dashboardsToPackage = contentYaml.getDashboard() == null ? Collections.emptyList() : contentYaml.getDashboard();
-        List<String> viewsToPackage = contentYaml.getView() == null ? Collections.emptyList() : contentYaml.getView();
-        List<String> reportsToPackage = contentYaml.getReport() == null ? Collections.emptyList() : contentYaml.getReport();
-        List<String> policiesToPackage = contentYaml.getPolicy() == null ? Collections.emptyList() : contentYaml.getPolicy();
-        List<String> alertDefinitionsToPackage = contentYaml.getAlertDefinition() == null ? Collections.emptyList() : contentYaml.getAlertDefinition();
-        List<String> symptomDefinitionsToPackage = contentYaml.getSymptomDefinition() == null ? Collections.emptyList() : contentYaml.getSymptomDefinition();
-        List<String> recommendationsToPackage = contentYaml.getRecommendation() == null ? Collections.emptyList() : contentYaml.getRecommendation();
-        List<String> superMetricsToPackage = contentYaml.getSuperMetric() == null ? Collections.emptyList() : contentYaml.getSuperMetric();
-        List<String> metricConfigsToPackage = contentYaml.getMetricConfig() == null ? Collections.emptyList() : contentYaml.getMetricConfig();
-        List<String> customGroupsToPackage = contentYaml.getCustomGroup() == null ? Collections.emptyList() : contentYaml.getCustomGroup();
+        final List<String> dashboardsToPackage = contentYaml.getDashboard() == null ? Collections.emptyList() : contentYaml.getDashboard();
+        final List<String> viewsToPackage = contentYaml.getView() == null ? Collections.emptyList() : contentYaml.getView();
+        final List<String> reportsToPackage = contentYaml.getReport() == null ? Collections.emptyList() : contentYaml.getReport();
+        final List<String> policiesToPackage = contentYaml.getPolicy() == null ? Collections.emptyList() : contentYaml.getPolicy();
+        final List<String> alertDefinitionsToPackage = contentYaml.getAlertDefinition() == null ? Collections.emptyList() : contentYaml.getAlertDefinition();
+        final List<String> symptomDefinitionsToPackage = contentYaml.getSymptomDefinition() == null ? Collections.emptyList() : contentYaml.getSymptomDefinition();
+        final List<String> recommendationsToPackage = contentYaml.getRecommendation() == null ? Collections.emptyList() : contentYaml.getRecommendation();
+        final List<String> superMetricsToPackage = contentYaml.getSuperMetric() == null ? Collections.emptyList() : contentYaml.getSuperMetric();
+        final List<String> metricConfigsToPackage = contentYaml.getMetricConfig() == null ? Collections.emptyList() : contentYaml.getMetricConfig();
+        final List<String> customGroupsToPackage = contentYaml.getCustomGroup() == null ? Collections.emptyList() : contentYaml.getCustomGroup();
 
         filterDashboards(srcDashboardsDir, destDashboardsDir, dashboardsToPackage);
         filterViews(srcViewsDir, destViewsDir, viewsToPackage);
@@ -149,7 +152,7 @@ public class PackageMojo extends AbstractMojo {
         return filteredDir;
     }
 
-    private void filterDashboards(File srcDashboardsDir, File destDashboardsDir, List<String> dashboardsToPackage) throws IOException {
+    private void filterDashboards(final File srcDashboardsDir, final File destDashboardsDir, final List<String> dashboardsToPackage) throws IOException {
         if (dashboardsToPackage == null || dashboardsToPackage.isEmpty()) {
             return;
         }
@@ -174,13 +177,19 @@ public class PackageMojo extends AbstractMojo {
             File metadataFile = new File(srcDashboardsDir, DASHBOARD_SHARE_METADATA_FILENAME);
             messages.append(String.format("Unable to copy dashboard sharing metadata file '%s' : '%s'", metadataFile.getName(), e.getMessage()));
         }
+        // copy dashboard activation metadata files for the dashboards (for users and groups)
+        try {
+            this.copyDashboardActivationMetadataFiles(srcDashboardsDir, destDashboardsDir);
+        } catch (IOException e) {
+            messages.append(String.format("Unable to copy dashboard activation metadata files: %s",  e.getMessage()));
+        }
 
         if (messages.length() > 0) {
             throw new IOException(messages.toString());
         }
     }
 
-    private void filterSuperMetrics(File srcSuperMetricsDir, File destSuperMetricsDir, List<String> superMetricsToPackage) throws IOException {
+    private void filterSuperMetrics(final File srcSuperMetricsDir, final File destSuperMetricsDir, final List<String> superMetricsToPackage) throws IOException {
         if (superMetricsToPackage == null || superMetricsToPackage.isEmpty()) {
             return;
         }
@@ -457,5 +466,18 @@ public class PackageMojo extends AbstractMojo {
         if (dashboardSharingMetadataFile.exists()) {
             FileUtils.copyFile(dashboardSharingMetadataFile, new File(destDashboardDir, DASHBOARD_SHARE_METADATA_FILENAME));
         }
+    }
+    
+    private void copyDashboardActivationMetadataFiles(File srcDashboardDir, File destDashboardDir) throws IOException {
+        // users activation metadata file
+    	File dashboardUserActivateFile = new File(srcDashboardDir, DASHBOARD_USER_ACTIVATE_METADATA_FILENAME);
+        if (dashboardUserActivateFile.exists()) {
+            FileUtils.copyFile(dashboardUserActivateFile, new File(destDashboardDir, DASHBOARD_USER_ACTIVATE_METADATA_FILENAME));
+        }
+        // groups activation metadata file
+        File dashboardGroupActivateFile = new File(srcDashboardDir, DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME);
+        if (dashboardGroupActivateFile.exists()) {
+            FileUtils.copyFile(dashboardGroupActivateFile, new File(destDashboardDir, DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME));
+        }        
     }
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

If there is a metadata file for activating / deactivating of vROPs dashboards it will be used for activation / deactivation of the imported dashboards for certain users / groups.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] Dependencies in pom.xml are up-to-date

### Testing

Tested using vROPs 8.8 / 8.10 using user / groups activation metadata files created in the dashboards/metadata directory that describe which dashboards for which groups / users will be activated (metadata/dashboardUserActivationMetadata.vrops.json and metadata/dashboardGroupActivationMetadata.vrops.json)


### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
