### PR TITLE
IAC-751 As a developer I need to be able to use vRBT in offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * [artifact-manager] Exporting vROps dashboards fails if metadata folder is not created
 * [artifact-manager] 108 / Pushing and pulling from/to vRA 8.12 fails with buildtools 2.32.0
 
+### Enhancements
+* [maven] IAC-751 / Created an extra package that contains all the necessary dependencies to work in offline mode.
+
 ## v2.33.0 - 02 Jun 2023
 
 ### Fixes

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -23,6 +23,10 @@
 [//]: # (#### Relevant Documentation:)
 
 
+### Created an extra package that contains all the necessary dependencies to work in offline mode
+The packaging phase now creates a new package which is a zip that contains all dependencies so developers can use the vRBT tool in offline environment. The package is generated under the repository project (``maven/repository/pom.xml``) and the package is generated in the path ``maven\repository\target\iac-maven-repository-full.zip``.
+
+
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
 [//]: # (### *Improvement Name* )

--- a/maven/repository/iac-maven-repository-full.xml
+++ b/maven/repository/iac-maven-repository-full.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+	<id>iac-maven-repository</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target/dependency-full</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/maven/repository/pom.xml
+++ b/maven/repository/pom.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
 	<parent>
 		<artifactId>iac</artifactId>
 		<groupId>com.vmware.pscoe</groupId>
 		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-	
+
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.vmware.pscoe.iac</groupId>
 	<artifactId>repository</artifactId>
@@ -310,7 +311,11 @@
 			<version>${project.version}</version>
 			<type>zip</type>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-archetype-plugin</artifactId>
+			<version>3.2.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -329,6 +334,19 @@
 							<addParentPoms>true</addParentPoms>
 							<copyPom>true</copyPom>
 							<includeGroupIds>com.vmware.pscoe</includeGroupIds>
+						</configuration>
+					</execution>
+					<execution>
+						<id>copy-full</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<useRepositoryLayout>true</useRepositoryLayout>
+							<addParentPoms>true</addParentPoms>
+							<copyPom>true</copyPom>
+							<outputDirectory>target/dependency-full</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -352,6 +370,10 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.6</version>
+				<configuration>
+					<outputDirectory>target</outputDirectory>
+					<appendAssemblyId>false</appendAssemblyId>
+				</configuration>
 				<executions>
 					<execution>
 						<id>iac-maven-repository</id>
@@ -361,11 +383,22 @@
 						</goals>
 						<configuration>
 							<finalName>iac-maven-repository</finalName>
-							<appendAssemblyId>false</appendAssemblyId>
 							<descriptors>
 								<descriptor>iac-maven-repository.xml</descriptor>
 							</descriptors>
-							<outputDirectory>target</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>iac-maven-repository-full</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>iac-maven-repository-full</finalName>
+							<descriptors>
+								<descriptor>iac-maven-repository-full.xml</descriptor>
+							</descriptors>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
 
 	<name>Build Tools for VMware Aria</name>
 	<description>
-		Build Tools for VMware Aria provides development and release management tools for implementing automation solutions
-		based on the VMware Aria Suite and VMware Cloud Director. The solution enables Virtual Infrastructure Administrators and 
-		Automation Developers to use standard DevOps practices for managing and deploying content.
+		Build Tools for VMware Aria provides development and release management tools for implementing automation solutions based on the VMware Aria Suite and VMware Cloud Director. The solution enables Virtual Infrastructure Administrators and Automation Developers to use standard DevOps practices for managing and deploying content.
 	</description>
+
+	
 	<url>https://github.com/vmware/build-tools-for-vmware-aria</url>
 	<developers>
 		<developer>


### PR DESCRIPTION
### Description

This allows the creation of an extra zip package that contains all built packages and their dependencies, to allow experience in an offline environment

### Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have updated CHANGELOG.md with a short summary of the changes introduced
- [X] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [X] Dependencies in pom.xml are up-to-date
- [X] My changes have been rebased and squashed to the minimal number of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Created a VRO and VRA-NG project, with only the packages contained in the zip newly created, along with dependencies needed by mvn archetype:generate. It worked seamlessly as well as the actions had the intended behaviour without looking for packages from maven repository.

### Release Notes

Build Tools for VMware Aria can now be used in offline mode by using iac-maven-repository-full.zip

### Related issues and PRs

This PR solves the JIRA ticket https://jira.pscoe.vmware.com/browse/IAC-751
