### PR TITLE
[102] Enabled Build For PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build Project
 
 on:
+  pull_request:
   push:
     branches:
       - "**" # trigger the workflow on any branch push event

--- a/.github/workflows/codeql-java.yml
+++ b/.github/workflows/codeql-java.yml
@@ -1,6 +1,7 @@
 name: "CodeQL Java"
 
 on:
+  pull_request:
   push:
 
 jobs:

--- a/.github/workflows/codeql-js.yml
+++ b/.github/workflows/codeql-js.yml
@@ -1,6 +1,7 @@
 name: "CodeQL JS"
 
 on:
+  pull_request:
   push:
   # pull_request:
   #   branches: [ "main" ]


### PR DESCRIPTION
### Description

Whenever a PR is submitted from a fork, the github actions are not ran. We need to add the "pull_request" trigger to the actions for this to happen.

See this: https://github.com/cal-itp/benefits/pull/1180 | https://github.com/orgs/community/discussions/25012

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

