### PR TITLE
IAC-775 Create all parent folders when exporting vROps dashboards. Up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ### Fixes
 
+* [artifact-manager] Exporting vROps dashboards fails if metadata folder is not created
 * [vro-types] Fixed definitions of RESTHost, XMLManager and HTTPBasicAuthentication to align with actual Orchestrator behaviour
 
 ## v2.32.0 - 11 May 2023

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
@@ -855,7 +855,9 @@ public class VropsPackageStore extends GenericPackageStore<VropsPackageDescripto
 
             dashboardShareMetadataContent = this.serializeObject(metadata);
             dashboardShareMetadataContent = dashboardShareMetadataContent == null ? "" : dashboardShareMetadataContent;
-            logger.info("Generating dashboard sharing metadata file '{}'", DASHBOARD_SHARE_METADATA_FILENAME);
+			logger.debug("Creating parent folders...");
+			dashboardShareMetadataFile.getParentFile().mkdirs();
+			logger.info("Generating dashboard sharing metadata file '{}'", DASHBOARD_SHARE_METADATA_FILENAME);
             Files.write(dashboardShareMetadataFile.toPath(), dashboardShareMetadataContent.getBytes(), StandardOpenOption.CREATE_NEW);
         } catch (JsonProcessingException e) {
             String message = String.format("Error generating dashboard sharing metadata file '%s' : %s", DASHBOARD_SHARE_METADATA_FILENAME, e.getMessage());
@@ -886,14 +888,16 @@ public class VropsPackageStore extends GenericPackageStore<VropsPackageDescripto
 
             dashboardActivationMetadataContent = this.serializeObject(metadata);
             dashboardActivationMetadataContent = dashboardActivationMetadataContent == null ? "" : dashboardActivationMetadataContent;
-            logger.info("Generating dashboard activation metadata file '{}'", DASHBOARD_SHARE_METADATA_FILENAME);
+			logger.debug("Creating parent folders...");
+			dashboardActivationMetadataFile.getParentFile().mkdirs();
+			logger.info("Generating dashboard activation metadata file '{}'", DASHBOARD_SHARE_METADATA_FILENAME);
             Files.write(dashboardActivationMetadataFile.toPath(), dashboardActivationMetadataContent.getBytes(), StandardOpenOption.CREATE_NEW);
         } catch (JsonProcessingException e) {
             String message = String.format("Error generating dashboard activation metadata file '%s' for resource of type %s: %s", fileName, resourceType, e.getMessage());
-            logger.warn(message);
+            logger.warn(message, e);
         } catch (IOException e) {
             String message = String.format("Error exporting dashboard activation metadata file '%s' for resource of type %s : %s", fileName, resourceType, e.getMessage());
-            logger.warn(message);
+            logger.warn(message, e);
         }
     }
 


### PR DESCRIPTION

### Description

IAC-775 Exporting vROps dashboards fails if metadata folder is not created

### Checklist

- [ x] Lint and unit tests pass locally with my changes
- [x ] I have added relevant error handling and logging messages to help troubleshooting
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1. Generate a sample vRops project from scratch.
2. Define 1 dashboard in content.yaml and pull it.

### Release Notes

Exporting vROps dashboards fails if metadata folder is not created

### Related issues and PRs

IAC-775
