### PR TITLE
IAC 777 build failing missing source map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Fixes
-* [vrotest] IAC-777 / Package Build Failing - vropkg build error due to missing source-map
+* [vrotest] IAC-777 / Package Build Failing - typescript folder build error due to forcing of newer version of the terser devDependency
 
 * [maven-plugins] IAC-706 / Package Build Failing - Typescript transpilation failed since Command line is too long
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixes
+* [vrotest] IAC-777 / Package Build Failing - vropkg build error due to missing source-map
+
 * [maven-plugins] IAC-706 / Package Build Failing - Typescript transpilation failed since Command line is too long
 
 ## v2.32.0 - 11 May 2023

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -10,11 +10,11 @@
 
 #### Previous Behavior
 
-Building the project is not successful due to changed dependency (terser in the vropkg devDependencies).
+Building the project is not successful due to forcing of newer version of the terser devDependency (in the typescript folder).
 
 #### New Behavior
 
-The build is successful due to updated devDependencies in the vropkg.
+The build is successful due to updated devDependencies in the typescript folder.
 
 ### Fix error Command line is too long
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -6,6 +6,16 @@
 
 ## Improvements
 
+### Fix vropkg build error due to missing source-map
+
+#### Previous Behavior
+
+Building the project is not successful due to changed dependency (terser in the vropkg devDependencies).
+
+#### New Behavior
+
+The build is successful due to updated devDependencies in the vropkg.
+
 ### Fix error Command line is too long
 
 #### Previous Behavior

--- a/typescript/vro-scripting-api/package.json
+++ b/typescript/vro-scripting-api/package.json
@@ -32,6 +32,7 @@
     "rollup": "2.67.1",
     "rollup-plugin-terser": "7.0.2",
     "ts-node": "10.5.0",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "source-map": "^0.8.0-beta.0"
   }
 }

--- a/typescript/vropkg/package.json
+++ b/typescript/vropkg/package.json
@@ -50,7 +50,8 @@
 		"rollup-plugin-natives": "^0.7.2",
 		"rollup-plugin-terser": "^5.1.3",
 		"ts-node": "^8.6.2",
-		"typescript": "^3.8.3"
+		"typescript": "^3.8.3",
+		"source-map": "^0.8.0-beta.0"
 	},
 	"dependencies": {
 		"abstract-syntax-tree": "2.17.5",

--- a/typescript/vrotest/package.json
+++ b/typescript/vrotest/package.json
@@ -51,7 +51,8 @@
 		"rollup": "2.67.2",
 		"rollup-plugin-terser": "7.0.2",
 		"ts-node": "10.5.0",
-		"typescript": "4.5.5"
+		"typescript": "4.5.5",
+		"source-map": "^0.8.0-beta.0"
 	},
 	"bundledDependencies": [
 		"iconv-lite",

--- a/typescript/vrotsc/package.json
+++ b/typescript/vrotsc/package.json
@@ -48,7 +48,8 @@
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
     "xmlbuilder": "13.0.2",
-    "xmldoc": "1.1.2"
+    "xmldoc": "1.1.2",
+    "source-map": "^0.8.0-beta.0"
   },
   "scripts": {
     "build": "gulp build",


### PR DESCRIPTION
### Description
Building the project was not successful due to changed dependency (terser in the vropkg devDependencies).
Updating the typescript folder's package.json files by adding "source-map": "^0.8.0-beta.0" solves the issue.

### Checklist
- [X] Lint and unit tests pass locally with my changes
- [X] I have added necessary documentation (if appropriate)
- [X] I have updated CHANGELOG.md with a short summary of the changes introduced
- [X] Dependencies in pom.xml are up-to-date
- [X] My changes have been rebased and squashed to the minimal number of relevant commits
- [X] My changes have a descriptive commit message with a short title

### Testing
Running 'mvn install -DskipTests' in the main folder - builds the project successfully.
