### PR TITLE
111 typescript vcvirtualpcipassthrough backing doesnt support vcvirtualpcipassthroughvmiopbackinginfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## v2.33.0 - 14 Jun 2023
-
 ### Enhancements
 * [vro-types] Declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.33.0 - 14 Jun 2023
+
+### Enhancements
+* [vro-types] Declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 
 ## v2.33.0 - 14 Jun 2023
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.33.0 - 14 Jun 2023
+
+### Enhancements
+* [vro-types] Declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
+
 ## v2.33.0 - 02 Jun 2023
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 ## v2.33.0 - 14 Jun 2023
-
 ### Enhancements
 * [vro-types] Declared new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
-
-## v2.33.0 - 14 Jun 2023
-### Enhancements
 
 ### Fixes
 * [artifact-manager] Exporting vROps dashboards fails if metadata folder is not created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v2.33.0 - 14 Jun 2023
 ### Enhancements
 * [vro-types] Declared new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v2.33.0 - 14 Jun 2023
 
 ### Enhancements
-* [vro-types] Declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
+* [vro-types] Declared new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 
 ## v2.33.0 - 14 Jun 2023
 ### Enhancements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -40,11 +40,12 @@
 [//]: # (#### Relevant Documentation:)
 
 
-## Upgrade procedure:
-[//]: # (Explain in details if something needs to be done)
 
+## Upgrade procedure
+[//]: # (Explain in details if something needs to be done)
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
+
 
 
 ## Improvements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -38,6 +38,7 @@
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
+[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo) 
 
 
 
@@ -45,8 +46,3 @@
 [//]: # (Explain in details if something needs to be done)
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
-
-
-
-## Improvements
-[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo) 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -1,44 +1,11 @@
-[//]: # (VERSION_PLACEHOLDER DO NOT DELETE)
-[//]: # (Used when working on a new release. Placed together with the Version.md)
-[//]: # (Nothing here is optional. If a step must not be performed, it must be said so)
-[//]: # (Do not fill the version, it will be done automatically)
-[//]: # (Quick Intro to what is the focus of this release)
-
 ## Breaking Changes
-[//]: # (### *Breaking Change*)
-[//]: # (Describe the breaking change AND explain how to resolve it)
-[//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
+GitHub issue 
+111 typescript vcvirtualpcipassthrough backing doesnt support vcvirtualpcipassthroughvmiopbackinginfo #124
 
+## Issues Description 
+When trying to create / attache new PCI device (vGPU), the VcVirtualPCIPassthrough class doesn't support for VcVirtualPCIPassthroughVmiopBackingInfo.vgpu. 
 
-## Deprecations
-[//]: # (### *Deprecation*)
-[//]: # (Explain what is deprecated and suggest alternatives)
-
-
-[//]: # (Features -> New Functionality)
-## Features
-[//]: # (### *Feature Name*)
-[//]: # (Describe the feature)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
-
-
-[//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
-[//]: # (### *Improvement Name* )
-[//]: # (Talk ONLY regarding the improvement)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### Previous Behavior)
-[//]: # (Explain how it used to behave, regarding to the change)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### New Behavior)
-[//]: # (Explain how it behaves now, regarding to the change)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
-[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo)
+declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 
-
-## Upgrade procedure
-[//]: # (Explain in details if something needs to be done)
-[//]: # (## Changelog:)
-[//]: # (Pull request links)
+this way the class "VcVirtualPCIPassthrough" supports vgpu

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -2,7 +2,7 @@ GitHub issue
 111 typescript vcvirtualpcipassthrough backing doesnt support vcvirtualpcipassthroughvmiopbackinginfo #124
 
 ## Issues Description
-When trying to create / attache new PCI device (vGPU), the VcVirtualPCIPassthrough class doesn't support for VcVirtualPCIPassthroughVmiopBackingInfo.vgpu. 
+When trying to create / attache new PCI device (vGPU), the VcVirtualPCIPassthrough class doesn't support for VcVirtualPCIPassthroughVmiopBackingInfo.vgpu.
 
 ## Improvements
 declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -38,7 +38,7 @@
 [//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo)
 
 
-## Upgrade procedure:
+## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 [//]: # (## Changelog:)
 [//]: # (Pull request links)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -10,11 +10,9 @@
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
 
 
-
 ## Deprecations
 [//]: # (### *Deprecation*)
 [//]: # (Explain what is deprecated and suggest alternatives)
-
 
 
 [//]: # (Features -> New Functionality)
@@ -23,7 +21,6 @@
 [//]: # (Describe the feature)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
 
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
@@ -38,8 +35,7 @@
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo) 
-
+[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo)
 
 
 ## Upgrade procedure:

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -1,7 +1,7 @@
-GitHub issue 
+GitHub issue
 111 typescript vcvirtualpcipassthrough backing doesnt support vcvirtualpcipassthroughvmiopbackinginfo #124
 
-## Issues Description 
+## Issues Description
 When trying to create / attache new PCI device (vGPU), the VcVirtualPCIPassthrough class doesn't support for VcVirtualPCIPassthroughVmiopBackingInfo.vgpu. 
 
 ## Improvements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -46,3 +46,8 @@
 
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
+
+
+
+## Improvements
+[//]: # (declared a new type cVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo) 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -40,13 +40,11 @@
 [//]: # (#### Relevant Documentation:)
 
 
-
 ## Upgrade procedure:
 [//]: # (Explain in details if something needs to be done)
 
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
-
 
 
 ## Improvements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -42,7 +42,7 @@
 
 
 
-## Upgrade procedure
+## Upgrade procedure:
 [//]: # (Explain in details if something needs to be done)
 [//]: # (## Changelog:)
 [//]: # (Pull request links)


### PR DESCRIPTION
### Description
Fixed issue for use of “vgpu”
### Checklist
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [ ] My changes have been rebased and squashed to the minimal number of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue
### Testing
<!-- Please provide a brief description of how were the changes tested - -->
### Release Notes
declared type VcVirtualPCIPassthroughBackingInfo used in class VcVirtualPCIPassthrough
### Related issues and PRs
Issue Typescript: VcVirtualPCIPassthrough backing doesn’t support VcVirtualPCIPassthroughVmiopBackingInfo #111