### PR TITLE
Added support for vRLI alerts API v1 fallback

### DIFF
--- a/.github/linters/sun_checks.xml
+++ b/.github/linters/sun_checks.xml
@@ -103,6 +103,7 @@ https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
 		<module name="JavadocType" />
 		<module name="JavadocVariable" />
 		<module name="JavadocStyle" />
+        <module name="MissingJavadocMethod" />
 
 		<!-- Checks for Naming Conventions.                  -->
 		<!-- See https://checkstyle.org/config_naming.html -->

--- a/.github/linters/sun_checks.xml
+++ b/.github/linters/sun_checks.xml
@@ -100,11 +100,9 @@ https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
 		<!-- Checks for Javadoc comments.                     -->
 		<!-- See https://checkstyle.org/config_javadoc.html -->
 		<module name="InvalidJavadocPosition" />
-		<module name="JavadocMethod" />
 		<module name="JavadocType" />
 		<module name="JavadocVariable" />
 		<module name="JavadocStyle" />
-		<module name="MissingJavadocMethod" />
 
 		<!-- Checks for Naming Conventions.                  -->
 		<!-- See https://checkstyle.org/config_naming.html -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [artifact-manager] 72 / Fixed domain detection to start from the last `@`, rather than the first.
 
 ### Enhancements
+* [package-installer] IAC-780 / Add support for flag vrli_use_old_alerts_api for importing vROPs enabled vRLI alerts.
 * [package-installer] IAC-728 / Deprecate ```vro_delete_include_dependencies``` flag  
 * [package-installer] IAC-591 / Added backup functionalities for vRO packages that will be imported
 * [maven] 87 / npm installation will now throw in case of a failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Enhancements
 * [vro-types] Declared new type VcVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
+* [package-installer] IAC-780 / Add support for flag vrli_use_old_alerts_api for importing vROPs enabled vRLI alerts.
 
 ### Fixes
 * [vro-scripting-api] 110 / Mocking for configuration elements is incorrect
@@ -19,7 +20,6 @@
 * [artifact-manager] 72 / Fixed domain detection to start from the last `@`, rather than the first.
 
 ### Enhancements
-* [package-installer] IAC-780 / Add support for flag vrli_use_old_alerts_api for importing vROPs enabled vRLI alerts.
 * [package-installer] IAC-728 / Deprecate ```vro_delete_include_dependencies``` flag  
 * [package-installer] IAC-591 / Added backup functionalities for vRO packages that will be imported
 * [maven] 87 / npm installation will now throw in case of a failure

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
@@ -59,6 +59,9 @@ import com.vmware.pscoe.iac.artifact.strategy.Strategy;
 import com.vmware.pscoe.iac.artifact.strategy.StrategySkipOldVersions;
 
 public final class PackageStoreFactory {
+	/**
+	 * Logger instance.
+	 */
 	private static Logger logger = LoggerFactory.getLogger(VraPackageStore.class);
 
 	/**

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
@@ -59,7 +59,7 @@ import com.vmware.pscoe.iac.artifact.strategy.Strategy;
 import com.vmware.pscoe.iac.artifact.strategy.StrategySkipOldVersions;
 
 public final class PackageStoreFactory {
-	private static final Logger logger = LoggerFactory.getLogger(VraPackageStore.class);
+	private static Logger logger = LoggerFactory.getLogger(VraPackageStore.class);
 
 	/**
 	 * Empty constructor.
@@ -71,7 +71,7 @@ public final class PackageStoreFactory {
 	/**
 	 * Returns the package store instance based on the configuration type.
 	 * 
-	 * @param configuration instance of an configuration type.
+	 * @param <T> configuration instance of an configuration type.
 	 * @return packageStore instance based on the configuration.
 	 * @throws RuntimeException if the configuration type is wrong.
 	 */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
@@ -18,16 +18,24 @@ package com.vmware.pscoe.iac.artifact;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vmware.pscoe.iac.artifact.configuration.*;
-import com.vmware.pscoe.iac.artifact.rest.*;
-import com.vmware.pscoe.iac.artifact.rest.client.vrli.RestClientVrliV1;
-import com.vmware.pscoe.iac.artifact.rest.client.vrli.RestClientVrliV2;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vmware.pscoe.iac.artifact.cli.CliManagerFactory;
 import com.vmware.pscoe.iac.artifact.cli.CliManagerVrops;
+import com.vmware.pscoe.iac.artifact.configuration.Configuration;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationAbx;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationCs;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationNg;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationSsh;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVcd;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVra;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVraNg;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVrli;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVro;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVroNg;
+import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVrops;
 import com.vmware.pscoe.iac.artifact.extentions.PackageStoreExtention;
 import com.vmware.pscoe.iac.artifact.extentions.VraCatalogItemPackageStoreExtention;
 import com.vmware.pscoe.iac.artifact.extentions.VraCustomFormPackageStoreExtention;
@@ -38,116 +46,135 @@ import com.vmware.pscoe.iac.artifact.extentions.VraSubscriptionPackageStoreExten
 import com.vmware.pscoe.iac.artifact.model.Version;
 import com.vmware.pscoe.iac.artifact.model.vra.VraPackageDescriptor;
 import com.vmware.pscoe.iac.artifact.model.vro.VroPackageDescriptor;
+import com.vmware.pscoe.iac.artifact.rest.RestClientCs;
+import com.vmware.pscoe.iac.artifact.rest.RestClientFactory;
+import com.vmware.pscoe.iac.artifact.rest.RestClientVcd;
+import com.vmware.pscoe.iac.artifact.rest.RestClientVra;
+import com.vmware.pscoe.iac.artifact.rest.RestClientVraNg;
+import com.vmware.pscoe.iac.artifact.rest.RestClientVro;
+import com.vmware.pscoe.iac.artifact.rest.RestClientVrops;
+import com.vmware.pscoe.iac.artifact.rest.client.vrli.RestClientVrliV1;
+import com.vmware.pscoe.iac.artifact.rest.client.vrli.RestClientVrliV2;
 import com.vmware.pscoe.iac.artifact.strategy.Strategy;
 import com.vmware.pscoe.iac.artifact.strategy.StrategySkipOldVersions;
 
-public class PackageStoreFactory {
+public final class PackageStoreFactory {
+	private static final Logger logger = LoggerFactory.getLogger(VraPackageStore.class);
 
-    private PackageStoreFactory() {}
+	/**
+	 * Empty constructor.
+	 */
+	private PackageStoreFactory() {
 
-    private final static Logger logger = LoggerFactory.getLogger(VraPackageStore.class);
+	}
 
-    public static <T extends Configuration> PackageStore<?> getInstance(T configuration) {
-        List<Strategy> strategies = new ArrayList<>();
-        logger.info("Searching for Package Store for type " + configuration.getPackageType());
+	/**
+	 * Returns the package store instance based on the configuration type.
+	 * 
+	 * @param configuration instance of an configuration type.
+	 * @return packageStore instance based on the configuration.
+	 * @throws RuntimeException if the configuration type is wrong.
+	 */
+	public static <T extends Configuration> PackageStore<?> getInstance(final T configuration) {
+		List<Strategy> strategies = new ArrayList<>();
+		logger.info("Searching for Package Store for type " + configuration.getPackageType());
 
-        String version;
-        if (!configuration.isImportOldVersions()) {
-            strategies.add(new StrategySkipOldVersions());
-        }
+		String version;
+		if (!configuration.isImportOldVersions()) {
+			strategies.add(new StrategySkipOldVersions());
+		}
 
-        if (configuration instanceof ConfigurationVroNg) {
+		if (configuration instanceof ConfigurationVroNg) {
 			logger.info("Detected ConfigurationVroNg");
-            ConfigurationVroNg config = (ConfigurationVroNg) configuration;
-            RestClientVro restClient = RestClientFactory.getClientVroNg(config);
-            version = restClient.getVersion();
-            logger.info("Detecting vRO Server version '{}'.", version);
-            List<PackageStoreExtention<VroPackageDescriptor>> extentions = new ArrayList<>();
-            extentions.addAll(loadVroExtensions(version, config, restClient));
+			ConfigurationVroNg config = (ConfigurationVroNg) configuration;
+			RestClientVro restClient = RestClientFactory.getClientVroNg(config);
+			version = restClient.getVersion();
+			logger.info("Detecting vRO Server version '{}'.", version);
+			List<PackageStoreExtention<VroPackageDescriptor>> extentions = new ArrayList<>();
+			extentions.addAll(loadVroExtensions(version, config, restClient));
 
-            return new VroPackageStore(restClient, strategies, extentions, new Version(version));
-        }
+			return new VroPackageStore(restClient, strategies, extentions, new Version(version));
+		}
 
-        if (configuration instanceof ConfigurationVro) {
+		if (configuration instanceof ConfigurationVro) {
 			logger.info("Detected ConfigurationVro");
-            ConfigurationVro config = (ConfigurationVro) configuration;
-            RestClientVro restClient = RestClientFactory.getClientVro(config);
-            version = restClient.getVersion();
-            logger.info("Detecting vRO Server version '{}'.", version);
-            List<PackageStoreExtention<VroPackageDescriptor>> extentions = new ArrayList<>();
-            extentions.addAll(loadVroExtensions(version, config, restClient));
+			ConfigurationVro config = (ConfigurationVro) configuration;
+			RestClientVro restClient = RestClientFactory.getClientVro(config);
+			version = restClient.getVersion();
+			logger.info("Detecting vRO Server version '{}'.", version);
+			List<PackageStoreExtention<VroPackageDescriptor>> extentions = new ArrayList<>();
+			extentions.addAll(loadVroExtensions(version, config, restClient));
 
-            return new VroPackageStore(restClient, strategies, extentions, new Version(version));
-        }
+			return new VroPackageStore(restClient, strategies, extentions, new Version(version));
+		}
 
-       
-
-        if (configuration instanceof ConfigurationVra) {
+		if (configuration instanceof ConfigurationVra) {
 			logger.info("Detected ConfigurationVra");
-            ConfigurationVra config = (ConfigurationVra) configuration;
-            RestClientVra restClient = RestClientFactory.getClientVra(config);
-            version = restClient.getVersion();
-            logger.info("Detecting vRA Server version '{}'.", version);
-            List<PackageStoreExtention<VraPackageDescriptor>> extentions = new ArrayList<>();
-            extentions.addAll(loadVraExtensions(version, config, restClient));
+			ConfigurationVra config = (ConfigurationVra) configuration;
+			RestClientVra restClient = RestClientFactory.getClientVra(config);
+			version = restClient.getVersion();
+			logger.info("Detecting vRA Server version '{}'.", version);
+			List<PackageStoreExtention<VraPackageDescriptor>> extentions = new ArrayList<>();
+			extentions.addAll(loadVraExtensions(version, config, restClient));
 
-            return new VraPackageStore(restClient, strategies, extentions, new Version(version));
-        }
+			return new VraPackageStore(restClient, strategies, extentions, new Version(version));
+		}
 
-        if (configuration instanceof ConfigurationAbx) {
+		if (configuration instanceof ConfigurationAbx) {
 			logger.info("Detected ConfigurationAbx");
-            logger.info("Creating configuration for ABX");
-            ConfigurationAbx config = (ConfigurationAbx) configuration;
+			logger.info("Creating configuration for ABX");
+			ConfigurationAbx config = (ConfigurationAbx) configuration;
 
-            // ABX service is part of vRA therefore the same REST client is used
-            RestClientVraNg restClient = RestClientFactory.getClientVraNg(config);
+			// ABX service is part of vRA therefore the same REST client is used
+			RestClientVraNg restClient = RestClientFactory.getClientVraNg(config);
 
-            // Specific ABX operations are handled by dedicated ABX package store
-            return new AbxPackageStore(restClient, config);
-        }
-        if (configuration instanceof ConfigurationCs) {
+			// Specific ABX operations are handled by dedicated ABX package store
+			return new AbxPackageStore(restClient, config);
+		}
+
+		if (configuration instanceof ConfigurationCs) {
 			logger.info("Detected ConfigurationCs");
-            ConfigurationCs config = (ConfigurationCs) configuration;
-            RestClientCs restClient = RestClientFactory.getClientCs(config);
-            logger.info("Creating configuration for Code Stream");
-            return new CsPackageStore(restClient, config);
-        }
+			ConfigurationCs config = (ConfigurationCs) configuration;
+			RestClientCs restClient = RestClientFactory.getClientCs(config);
+			logger.info("Creating configuration for Code Stream");
+			return new CsPackageStore(restClient, config);
+		}
 
-        if (configuration instanceof ConfigurationVraNg) {
+		if (configuration instanceof ConfigurationVraNg) {
 			logger.info("Detected ConfigurationVraNg");
-            ConfigurationVraNg config = (ConfigurationVraNg) configuration;
-            RestClientVraNg restClient = RestClientFactory.getClientVraNg(config);
-            logger.info("Creating configuration for VRA NG");
+			ConfigurationVraNg config = (ConfigurationVraNg) configuration;
+			RestClientVraNg restClient = RestClientFactory.getClientVraNg(config);
+			logger.info("Creating configuration for VRA NG");
 
-            return new VraNgPackageStore(restClient, config);
-        }
+			return new VraNgPackageStore(restClient, config);
+		}
 
-        if (configuration instanceof ConfigurationVcd) {
+		if (configuration instanceof ConfigurationVcd) {
 			logger.info("Detected ConfigurationVcd");
-            ConfigurationVcd config = (ConfigurationVcd) configuration;
-            RestClientVcd restClient = RestClientFactory.getClientVcd(config);
-            version = restClient.getVersion();
-            logger.info("Detecting vCD Server version '{}'.", version);
+			ConfigurationVcd config = (ConfigurationVcd) configuration;
+			RestClientVcd restClient = RestClientFactory.getClientVcd(config);
+			version = restClient.getVersion();
+			logger.info("Detecting vCD Server version '{}'.", version);
 
-            return new VcdNgPackageStore(restClient, strategies, new Version(version));
-        }
+			return new VcdNgPackageStore(restClient, strategies, new Version(version));
+		}
 
-        if (configuration instanceof ConfigurationVrops) {
+		if (configuration instanceof ConfigurationVrops) {
 			logger.info("Detected ConfigurationVrops");
-            ConfigurationVrops config = (ConfigurationVrops) configuration;
+			ConfigurationVrops config = (ConfigurationVrops) configuration;
 
-            CliManagerVrops cliManager = CliManagerFactory.getVropsCliManager(config);
-            RestClientVrops restClient = RestClientFactory.getClientVrops(config);
-            version = restClient.getVersion();
-            logger.info("Detecting vROPs Server version '{}'.", version);
+			CliManagerVrops cliManager = CliManagerFactory.getVropsCliManager(config);
+			RestClientVrops restClient = RestClientFactory.getClientVrops(config);
+			version = restClient.getVersion();
+			logger.info("Detecting vROPs Server version '{}'.", version);
 
-            return new VropsPackageStore(cliManager, restClient, new Version(version));
-        }
+			return new VropsPackageStore(cliManager, restClient, new Version(version));
+		}
 
-        if (configuration instanceof ConfigurationVrli) {
+		if (configuration instanceof ConfigurationVrli) {
 			logger.info("Detected ConfigurationVrli");
-            ConfigurationVrli config = (ConfigurationVrli) configuration;
-            RestClientVrliV1 restClientV1 = RestClientFactory.getClientVrliV1(config);
+			ConfigurationVrli config = (ConfigurationVrli) configuration;
+			RestClientVrliV1 restClientV1 = RestClientFactory.getClientVrliV1(config);
 			RestClientVrliV2 restClientV2 = RestClientFactory.getClientVrliV2(config);
 
 			try {
@@ -156,43 +183,63 @@ public class PackageStoreFactory {
 				version = restClientV2.getVersion();
 			}
 			logger.info("Detected vRLI version " + version);
+			// if flag for the old alert API is in effect use API v1 client
+			if (config.isOldAlertsApiUsed()) {
+				logger.info("Usage of old alerts API is in effect.");
+				return new VrliPackageStoreV1(restClientV1);
+			}
 			if (!StringUtils.isEmpty(version) && Version.compareSemanticVersions(version, "8.8") > -1) {
 				logger.info("Instantiate REST Client v2.");
 				return new VrliPackageStoreV2(restClientV2);
 			}
 			logger.info("Instantiate REST Client v1.");
 			return new VrliPackageStoreV1(restClientV1);
-        }
+		}
 
-        if (configuration instanceof ConfigurationSsh) {
+		if (configuration instanceof ConfigurationSsh) {
 			logger.info("Detected ConfigurationSsh");
-            ConfigurationSsh config = (ConfigurationSsh) configuration;
-            return new SshPackageStore(config);
-        }
+			ConfigurationSsh config = (ConfigurationSsh) configuration;
+			return new SshPackageStore(config);
+		}
 
+		throw new RuntimeException("There is no PackageStore defined for Configuration Type " + configuration.getClass().getSimpleName());
+	}
 
+	/**
+	 * Load vRA extensions like subscriptions, icons, catalog items, etc.
+	 * 
+	 * @param vraVersion version of the vRA used.
+	 * @param config     vRA configuration type.
+	 * @param client     vRA REST client to use.
+	 * @return extensions list of loaded extensions.
+	 */
+	private static List<PackageStoreExtention<VraPackageDescriptor>> loadVraExtensions(final String vraVersion, final ConfigurationVra config,
+			final RestClientVra client) {
+		List<PackageStoreExtention<VraPackageDescriptor>> extentions = new ArrayList<>();
 
-        throw new RuntimeException("There is no PackageStore defined for Configuration Type " + configuration.getClass().getSimpleName());
-    }
+		if (new Version(vraVersion).compareTo(new Version("7.4-SNAPSHOT")) >= 0) {
+			extentions.add(new VraCustomFormPackageStoreExtention(client));
+		}
+		extentions.add(new VraSubscriptionPackageStoreExtention(client));
+		extentions.add(new VraGlobalPropertyDefinitionPackageStoreExtention(client));
+		extentions.add(new VraGlobalPropertyGroupPackageStoreExtention(client));
+		extentions.add(new VraIconPackageStoreExtention(client));
+		extentions.add(new VraCatalogItemPackageStoreExtention(client));
 
-    private static List<PackageStoreExtention<VraPackageDescriptor>> loadVraExtensions(String vraVersion, ConfigurationVra config, RestClientVra client) {
-        List<PackageStoreExtention<VraPackageDescriptor>> extentions = new ArrayList<>();
+		return extentions;
+	}
 
-        if (new Version(vraVersion).compareTo(new Version("7.4-SNAPSHOT")) >= 0) {
-            extentions.add(new VraCustomFormPackageStoreExtention(client));
-        }
-        extentions.add(new VraSubscriptionPackageStoreExtention(client));
-        extentions.add(new VraGlobalPropertyDefinitionPackageStoreExtention(client));
-        extentions.add(new VraGlobalPropertyGroupPackageStoreExtention(client));
-        extentions.add(new VraIconPackageStoreExtention(client));
-        extentions.add(new VraCatalogItemPackageStoreExtention(client));
-
-        return extentions;
-    }
-
-    private static List<PackageStoreExtention<VroPackageDescriptor>> loadVroExtensions(String vroVersion, ConfigurationNg config, RestClientVro client) {
-        // No vRO extensions for now
-        return new ArrayList<>();
-    }
-
+	/**
+	 * Load vRO extensions. Currently not supported.
+	 * 
+	 * @param vroVersion version of the vRO used.
+	 * @param config     vRO configuration type.
+	 * @param client     vRO REST client to use.
+	 * @return extensions list of loaded extensions.
+	 */
+	private static List<PackageStoreExtention<VroPackageDescriptor>> loadVroExtensions(final String vroVersion, final ConfigurationNg config,
+			final RestClientVro client) {
+		// No vRO extensions for now
+		return new ArrayList<>();
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVrli.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVrli.java
@@ -22,77 +22,158 @@ import org.springframework.util.StringUtils;
 import com.vmware.pscoe.iac.artifact.model.PackageType;
 
 public class ConfigurationVrli extends Configuration {
-    // Important - when modify properties refer to comments in @Configuration
+	// Important - when modify properties refer to comments in @Configuration.
+	/**
+	 * provider configuration entry.
+	 */
 	public static final String PROVIDER = "provider";
-    public static final String INTEGRATION_VROPS_HOST = "vropsHost";
-    public static final String INTEGRATION_VROPS_PORT = "vropsPort";
-    public static final String INTEGRATION_VROPS_USER = "vropsUser";
-    public static final String INTEGRATION_VROPS_PASS = "vropsPassword";
-    public static final String INTEGRATION_VROPS_AUTH_SOURCE = "vropsAuthSource";
+	/**
+	 * vropsHost configuration entry.
+	 */
+	public static final String INTEGRATION_VROPS_HOST = "vropsHost";
+	/**
+	 * vropsPort configuration entry.
+	 */
+	public static final String INTEGRATION_VROPS_PORT = "vropsPort";
+	/**
+	 * vropsUser configuration entry.
+	 */
+	public static final String INTEGRATION_VROPS_USER = "vropsUser";
+	/**
+	 * vropsPassword configuration entry.
+	 */
+	public static final String INTEGRATION_VROPS_PASS = "vropsPassword";
+	/**
+	 * vropsAuthSource configuration entry.
+	 */
+	public static final String INTEGRATION_VROPS_AUTH_SOURCE = "vropsAuthSource";
+	/**
+	 * useOldAlertsApi configuration entry.
+	 */
+	public static final String VRLI_USE_OLD_ALERTS_API = "useOldAlertsApi";
 
-    /**
-     * VRLI Package Import content conflict resolution mode
-     */
+	/**
+	 * VRLI Package Import content conflict resolution mode.
+	 */
 	public static final String PACKAGE_IMPORT_OVERWRITE_MODE = "packageImportOverwriteMode";
 
-    protected ConfigurationVrli(Properties props) {
-        super(PackageType.VRLI, props);
-    }
+	protected ConfigurationVrli(Properties props) {
+		super(PackageType.VRLI, props);
+	}
 
-    public String getPackageImportOverwriteMode() {
-        return this.properties.getProperty(PACKAGE_IMPORT_OVERWRITE_MODE, "SKIP,OVERWRITE");
-    }
-    
-    public String getProvider() {
-        return this.properties.getProperty(PROVIDER);
-    }
+	/**
+	 * VRLI Package overwrite mode.
+	 * 
+	 * @return value of the packageImportOverwriteMode.
+	 */
+	public String getPackageImportOverwriteMode() {
+		return this.properties.getProperty(PACKAGE_IMPORT_OVERWRITE_MODE, "SKIP,OVERWRITE");
+	}
 
-    public String getIntegrationVropsAuthSource() {
-        return this.properties.getProperty(INTEGRATION_VROPS_AUTH_SOURCE);
-    }
+	/**
+	 * VRLI Package provider name.
+	 * 
+	 * @return value of the provider.
+	 */
+	public String getProvider() {
+		return this.properties.getProperty(PROVIDER);
+	}
 
-    public String getIntegrationVropsAuthHost() {
-        return this.properties.getProperty(INTEGRATION_VROPS_HOST);
-    }
+	/**
+	 * VRLI vROPs integration auth source (used for managing of vROPs enabled vRLI
+	 * alerts).
+	 * 
+	 * @return value of the vropsAuthSource.
+	 */
+	public String getIntegrationVropsAuthSource() {
+		return this.properties.getProperty(INTEGRATION_VROPS_AUTH_SOURCE);
+	}
 
-    public String getIntegrationVropsAuthPort() {
-        return this.properties.getProperty(INTEGRATION_VROPS_PORT);
-    }
+	/**
+	 * VRLI vROPs integration auth host (used for managing of vROPs enabled vRLI
+	 * alerts).
+	 * 
+	 * @return value of the vropsHost.
+	 */
+	public String getIntegrationVropsAuthHost() {
+		return this.properties.getProperty(INTEGRATION_VROPS_HOST);
+	}
 
-    public String getIntegrationVropsAuthUser() {
-        return this.properties.getProperty(INTEGRATION_VROPS_USER);
-    }
+	/**
+	 * VRLI vROPs integration auth port (used for managing of vROPs enabled vRLI
+	 * alerts).
+	 * 
+	 * @return value of the vropsPort.
+	 */
+	public String getIntegrationVropsAuthPort() {
+		return this.properties.getProperty(INTEGRATION_VROPS_PORT);
+	}
 
-    public String getIntegrationVropsAuthPassword() {
-        return this.properties.getProperty(INTEGRATION_VROPS_PASS);
-    }
+	/**
+	 * VRLI vROPs integration auth user (used for managing of vROPs enabled vRLI
+	 * alerts).
+	 * 
+	 * @return value of the vropsUser.
+	 */
+	public String getIntegrationVropsAuthUser() {
+		return this.properties.getProperty(INTEGRATION_VROPS_USER);
+	}
 
-    @Override
-	public void validate(boolean domainOptional) throws ConfigurationException {
-        StringBuilder message = new StringBuilder();
+	/**
+	 * VRLI vROPs integration auth password (used for managing of vROPs enabled vRLI
+	 * alerts).
+	 * 
+	 * @return value of the vropsPassword.
+	 */
+	public String getIntegrationVropsAuthPassword() {
+		return this.properties.getProperty(INTEGRATION_VROPS_PASS);
+	}
 
-        if (StringUtils.isEmpty(getHost())) {
+	/**
+	 * VRLI is old alerts API used (used to workaround bug in vRLI v2 API support of
+	 * vRLI 8.10).
+	 * 
+	 * @return value of the useOldAlertsApi.
+	 */
+	public boolean isOldAlertsApiUsed() {
+		return Boolean.parseBoolean(this.properties.getProperty(VRLI_USE_OLD_ALERTS_API));
+	}
+
+	/**
+	 * Validate configuration settings.
+	 * 
+	 * @param domainOptional flag whether domain is optional parameter.
+	 * @throws ConfigurationException if the configuration is wrong.
+	 */
+	@Override
+	public void validate(final boolean domainOptional) throws ConfigurationException {
+		StringBuilder message = new StringBuilder();
+
+		if (StringUtils.isEmpty(getHost())) {
 			message.append("Hostname ");
-        }
-
-        if (StringUtils.isEmpty(getPort())) {
+		}
+		if (StringUtils.isEmpty(getPort())) {
 			message.append("Port ");
 		}
-
 		if (StringUtils.isEmpty(getProvider())) {
 			message.append("Provider ");
-        }
-
+		}
 		if (message.length() != 0) {
 			throw new ConfigurationException("Configuration validation failed: Empty " + message);
 		}
 	}
 
-    public static ConfigurationVrli fromProperties(Properties props) throws ConfigurationException {
-    	ConfigurationVrli config = new ConfigurationVrli(props);
+	/**
+	 * Read configuration data from properties.
+	 * 
+	 * @param props structure where to read file from.
+	 * @throws ConfigurationException if the configuration is wrong.
+	 */
+	public static ConfigurationVrli fromProperties(final Properties props) throws ConfigurationException {
+		ConfigurationVrli config = new ConfigurationVrli(props);
 
-    	config.validate(false);
+		config.validate(false);
 
-    	return config;
-    }
+		return config;
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVrli.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVrli.java
@@ -57,7 +57,7 @@ public class ConfigurationVrli extends Configuration {
 	 */
 	public static final String PACKAGE_IMPORT_OVERWRITE_MODE = "packageImportOverwriteMode";
 
-	protected ConfigurationVrli(Properties props) {
+	protected ConfigurationVrli(final Properties props) {
 		super(PackageType.VRLI, props);
 	}
 
@@ -167,6 +167,7 @@ public class ConfigurationVrli extends Configuration {
 	 * Read configuration data from properties.
 	 * 
 	 * @param props structure where to read file from.
+	 * @return instance of the ConfigurationVrli object.
 	 * @throws ConfigurationException if the configuration is wrong.
 	 */
 	public static ConfigurationVrli fromProperties(final Properties props) throws ConfigurationException {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Package that represents IAC Artifact configuration.
+ *
+ */
+
+package com.vmware.pscoe.iac.artifact.configuration;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/docs/archive/doc/markdown/use-bundle-installer.md
+++ b/docs/archive/doc/markdown/use-bundle-installer.md
@@ -122,6 +122,7 @@ vrli_vrops_server_port
 vrli_vrops_server_user
 vrli_vrops_server_password
 vrli_vrops_server_auth_source
+vrli_use_old_alerts_api
 
 ### VCD connection properties ###
 vcd_server

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -36,6 +36,17 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### Added vRLI alert API fallback optional
+
+#### Previous Behaviour
+
+When pushing vROPs enabled vRLI alerts to vRLI 8.8 and later it uses always the v2 alerts API, that causes some vROPs enabled vRLI alerts not to be pushed
+despite the pushing would work fine with the v1 alerts API.
+
+#### New Behaviour
+An option flag has been added (useOldAlertsApi / vrli_use_old_alerts_api) so that customer is able to control which alerts API to be used. By default the flag
+is set to false (thus v2 alert API is used by default)
+
 ### Fixed pulling of vROps dashboards as managed content
 
 #### Previous Behaviour

--- a/maven/base-package/pom.xml
+++ b/maven/base-package/pom.xml
@@ -313,6 +313,7 @@
                         <vropsUser>${vrli.vropsUser}</vropsUser>
                         <vropsPassword>${vrli.vropsPassword}</vropsPassword>
                         <vropsAuthSource>${vrli.vropsAuthSource}</vropsAuthSource>
+						<useOldAlertsApi>${vrli.useOldAlertsApi}</useOldAlertsApi>
                         <packageImportOverwriteMode>${vrli.packageImportOverwriteMode}</packageImportOverwriteMode>
                     </vrli>
                     <ignoreSslCertificate>${vrealize.ssl.ignore.certificate}</ignoreSslCertificate>

--- a/maven/base-package/vrli-package/pom.xml
+++ b/maven/base-package/vrli-package/pom.xml
@@ -42,6 +42,7 @@
 						<vropsUser>${vrli.vropsUser}</vropsUser>
 						<vropsPassword>${vrli.vropsPassword}</vropsPassword>
 						<vropsAuthSource>${vrli.vropsAuthSource}</vropsAuthSource>
+						<useOldAlertsApi>${vrli.useOldAlertsApi}</useOldAlertsApi>
 						<packageImportOverwriteMode>${vrli.packageImportOverwriteMode}</packageImportOverwriteMode>
 					</vrli>
 					<ignoreSslCertificate>${vrealize.ssl.ignore.certificate}</ignoreSslCertificate>

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -311,6 +311,12 @@ enum Option {
             "vrli_vrops_server_auth_source",
             ConfigurationVrli.INTEGRATION_VROPS_AUTH_SOURCE),
 	/**
+	 * VRLI use old api flag.
+	 */
+    VRLI_USE_OLD_ALERTS_API(
+            "vrli_use_old_alerts_api",
+            ConfigurationVrli.VRLI_USE_OLD_ALERTS_API),    
+	/**
 	 * VCD server.
 	 */
     VCD_SERVER(
@@ -1416,6 +1422,7 @@ public final class Installer {
         userInput(input, Option.VRLI_VROPS_INTEGRATION_USER, "  vROps integration username");
         passInput(input, Option.VRLI_VROPS_INTEGRATION_PASSWORD, "  vROps integration password");
         userInput(input, Option.VRLI_VROPS_INTEGRATION_AUTH_SOURCE, "  vROps integration auth source", "local");
+        userInput(input, Option.VRLI_USE_OLD_ALERTS_API, "  Use old vRLI Alerts API", Boolean.FALSE);
     }
 
     private static void readSshImportProperties(final Input input) {


### PR DESCRIPTION
Signed-off-by: Alexander Kantchev <akantchev@vmware.com>

### Description

Add support for vRLI alerts API v1 fallback option (useOldAlertsApi / vrli_use_old_alerts_api) in order to workaround implementation bug in vROPs enabled vRLI alerts push on vRLI 8.8 and later

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested with pushing vROPs enabled alerts with vRLI alert API v1 (flag vrli_use_old_alerts_api / useOldAlertsApi is set to true) so that the alerts that fail on vRLI alert API v2 were pushed successfully.

### Release Notes

#### Previous Behaviour

When pushing vROPs enabled vRLI alerts to vRLI 8.8 and later it uses always the v2 alerts API, that causes some vROPs enabled vRLI alerts not to be pushed
despite the pushing would work fine with the v1 alerts API.

#### New Behaviour
An option flag has been added (useOldAlertsApi / vrli_use_old_alerts_api) so that customer is able to control which alerts API to be used. By default the flag
is set to false (thus v2 alert API is used by default)

### Related issues and PRs
IAC-780
