### PR TITLE
[Task IAC-780] Added Pagination Support for fetching vROPs Resources when Pushing vROPs enabled vRLI Alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [vro-types] Declared new type VcVirtualPCIPassthroughBackingInfo = VcVirtualDeviceBackingInfo & VcVirtualPCIPassthroughDeviceBackingInfo
 
 ### Fixes
+* [artifact-manager] IAC-780 / VRLI Alerts Push Fails for vROPs Enabled Alerts on Large Scale Environments
 * [vro-scripting-api] 110 / Mocking for configuration elements is incorrect
 * [actions-package] github issue# 73 is addressed. Solution is to replace line breaks in description by space
 * [artifact-manager] Exporting vROps dashboards fails if metadata folder is not created

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
@@ -148,7 +148,7 @@ public class PackageStoreFactory {
 			logger.info("Detected ConfigurationVrli");
             ConfigurationVrli config = (ConfigurationVrli) configuration;
             RestClientVrliV1 restClientV1 = RestClientFactory.getClientVrliV1(config);
-			RestClientVrliV2 restClientV2 = RestClientFactory.getClientVrliV2(config);
+            RestClientVrliV2 restClientV2 = RestClientFactory.getClientVrliV2(config);
 
 			try {
 				version = restClientV1.getVersion();
@@ -161,6 +161,7 @@ public class PackageStoreFactory {
 				return new VrliPackageStoreV2(restClientV2);
 			}
 			logger.info("Instantiate REST Client v1.");
+
 			return new VrliPackageStoreV1(restClientV1);
         }
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/PackageStoreFactory.java
@@ -148,7 +148,7 @@ public class PackageStoreFactory {
 			logger.info("Detected ConfigurationVrli");
             ConfigurationVrli config = (ConfigurationVrli) configuration;
             RestClientVrliV1 restClientV1 = RestClientFactory.getClientVrliV1(config);
-            RestClientVrliV2 restClientV2 = RestClientFactory.getClientVrliV2(config);
+			RestClientVrliV2 restClientV2 = RestClientFactory.getClientVrliV2(config);
 
 			try {
 				version = restClientV1.getVersion();
@@ -161,7 +161,6 @@ public class PackageStoreFactory {
 				return new VrliPackageStoreV2(restClientV2);
 			}
 			logger.info("Instantiate REST Client v1.");
-
 			return new VrliPackageStoreV1(restClientV1);
         }
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
@@ -77,1523 +77,1682 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrops.ViewDefinitionDTO;
 
 @SuppressWarnings("deprecation")
 public class RestClientVrops extends RestClient {
-    private final Logger logger = LoggerFactory.getLogger(RestClientVrops.class);
+	private final Logger logger = LoggerFactory.getLogger(RestClientVrops.class);
 
-    private static final String PUBLIC_API_PREFIX = "/suite-api/api/";
-    private static final String INTERNAL_API_PREFIX = "/suite-api/internal/";
-    private static final String ALERT_DEFS_API = PUBLIC_API_PREFIX + "alertdefinitions/";
-    private static final String SYMPTOM_DEFS_API = PUBLIC_API_PREFIX + "symptomdefinitions/";
-    private static final String POLICIES_API = INTERNAL_API_PREFIX + "policies/";
-    private static final String RECOMMENDATIONS_API = PUBLIC_API_PREFIX + "recommendations/";
-    private static final String RESOURCES_API = PUBLIC_API_PREFIX + "resources/";
-    private static final String CUSTOM_GROUPS_FETCH_API = RESOURCES_API + "groups";
-    private static final String CUSTOM_GROUPS_UPDATE_API = PUBLIC_API_PREFIX + "resources/groups";
-    private static final String CUSTOM_GROUP_TYPES_API = PUBLIC_API_PREFIX + "resources/groups/types";
-    private static final String RESOURCES_LIST_API = PUBLIC_API_PREFIX + "resources";
-    private static final String ADAPTER_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds";
-    private static final String RESOURCE_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds/%s/resourcekinds";
-    private static final String SUPERMETRICS_LIST_API = PUBLIC_API_PREFIX + "supermetrics";
-    private static final String REPORT_DEFINITIONS_LIST_API = PUBLIC_API_PREFIX + "reportdefinitions";
-    private static final String VIEW_DEFINITIONS_LIST_API = INTERNAL_API_PREFIX + "viewdefinitions";
-    private static final String INTERNAL_API_HEADER_NAME = "X-vRealizeOps-API-use-unsupported";
-    private static final String AUTH_GROUPS_API = PUBLIC_API_PREFIX + "/auth/usergroups";
-    private static final String AUTH_USERS_API = PUBLIC_API_PREFIX + "/auth/users";
-    private static final int DEFAULT_PAGE_SIZE = 10000;
-    private static final int VROPS_MAJOR_VERSION = 8;
-    private static final int VROPS_MINOR_VERSION = 2;
-    private static final String VROPS_KIND_ALL = "ALL";
+	private static final String PUBLIC_API_PREFIX = "/suite-api/api/";
+	private static final String INTERNAL_API_PREFIX = "/suite-api/internal/";
+	private static final String ALERT_DEFS_API = PUBLIC_API_PREFIX + "alertdefinitions/";
+	private static final String SYMPTOM_DEFS_API = PUBLIC_API_PREFIX + "symptomdefinitions/";
+	private static final String POLICIES_API = INTERNAL_API_PREFIX + "policies/";
+	private static final String RECOMMENDATIONS_API = PUBLIC_API_PREFIX + "recommendations/";
+	private static final String RESOURCES_API = PUBLIC_API_PREFIX + "resources/";
+	private static final String CUSTOM_GROUPS_FETCH_API = RESOURCES_API + "groups";
+	private static final String CUSTOM_GROUPS_UPDATE_API = PUBLIC_API_PREFIX + "resources/groups";
+	private static final String CUSTOM_GROUP_TYPES_API = PUBLIC_API_PREFIX + "resources/groups/types";
+	private static final String RESOURCES_LIST_API = PUBLIC_API_PREFIX + "resources";
+	private static final String ADAPTER_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds";
+	private static final String RESOURCE_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds/%s/resourcekinds";
+	private static final String RESOURCES_LIST_PER_ADAPTER_KIND = PUBLIC_API_PREFIX + "adapterkinds/%s/resources";
+	private static final String SUPERMETRICS_LIST_API = PUBLIC_API_PREFIX + "supermetrics";
+	private static final String REPORT_DEFINITIONS_LIST_API = PUBLIC_API_PREFIX + "reportdefinitions";
+	private static final String VIEW_DEFINITIONS_LIST_API = INTERNAL_API_PREFIX + "viewdefinitions";
+	private static final String INTERNAL_API_HEADER_NAME = "X-vRealizeOps-API-use-unsupported";
+	private static final String AUTH_GROUPS_API = PUBLIC_API_PREFIX + "/auth/usergroups";
+	private static final String AUTH_USERS_API = PUBLIC_API_PREFIX + "/auth/users";
+	private static final int DEFAULT_PAGE_SIZE = 10000;
+	private static final int VROPS_MAJOR_VERSION = 8;
+	private static final int VROPS_MINOR_VERSION = 2;
+	private static final String VROPS_KIND_ALL = "ALL";
 
-    private ConfigurationVrops configuration;
-    private RestTemplate restTemplate;
-    private ObjectMapper mapper = new ObjectMapper();
-    private Version productVersion = null;
+	private ConfigurationVrops configuration;
+	private RestTemplate restTemplate;
+	private ObjectMapper mapper = new ObjectMapper();
+	private Version productVersion = null;
 
-    public RestClientVrops(ConfigurationVrops configuration, RestTemplate restTemplate) {
-        this.configuration = configuration;
-        this.restTemplate = restTemplate;
-    }
+	public RestClientVrops(ConfigurationVrops configuration, RestTemplate restTemplate) {
+		this.configuration = configuration;
+		this.restTemplate = restTemplate;
+	}
 
-    public RestTemplate getRestTemplate() {
-        return restTemplate;
-    }
+	public RestTemplate getRestTemplate() {
+		return restTemplate;
+	}
 
-    @Override
-    protected Configuration getConfiguration() {
-        return configuration;
-    }
+	@Override
+	protected Configuration getConfiguration() {
+		return configuration;
+	}
 
-    @Override
-    protected URIBuilder getURIBuilder() {
-        ConfigurationVrops config = (ConfigurationVrops) getConfiguration();
-        return new URIBuilder().setScheme("https").setHost(config.getHost()).setPort(config.getHttpPort());
-    }
+	@Override
+	protected URIBuilder getURIBuilder() {
+		ConfigurationVrops config = (ConfigurationVrops) getConfiguration();
+		return new URIBuilder().setScheme("https").setHost(config.getHost()).setPort(config.getHttpPort());
+	}
 
-    @Override
-    public String getVersion() {
-        URI url = getURI(getURIBuilder().setPath(PUBLIC_API_PREFIX + "versions/current"));
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
+	@Override
+	public String getVersion() {
+		URI url = getURI(getURIBuilder().setPath(PUBLIC_API_PREFIX + "versions/current"));
+		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
 
-        String versionString = JsonPath.parse(response.getBody()).read("$.releaseName");
-        Integer buildNumber = JsonPath.parse(response.getBody()).read("buildNumber");
+		String versionString = JsonPath.parse(response.getBody()).read("$.releaseName");
+		Integer buildNumber = JsonPath.parse(response.getBody()).read("buildNumber");
 
-        Pattern versionNumberRegex = Pattern.compile("([\\d]+)\\.([\\d]+)\\.([\\d]+)");
-        Matcher matcher = versionNumberRegex.matcher(versionString);
+		Pattern versionNumberRegex = Pattern.compile("([\\d]+)\\.([\\d]+)\\.([\\d]+)");
+		Matcher matcher = versionNumberRegex.matcher(versionString);
 
-        StringBuilder retVal = new StringBuilder("");
-        if (matcher.find()) {
-            retVal.append(matcher.group(0));
-            retVal.append("." + buildNumber);
-        }
+		StringBuilder retVal = new StringBuilder("");
+		if (matcher.find()) {
+			retVal.append(matcher.group(0));
+			retVal.append("." + buildNumber);
+		}
 
-        return retVal.toString();
-    }
+		return retVal.toString();
+	}
 
-    /**
-     * Import policies from a zip file
-     * 
-     * @param file             policy zip file as byte[]
-     * @param policyName List of strings that represent the custom groups
-     *                         policy will be assigned to.
-     * @param force      true to overwrite the existing policies, false to
-     *                         skip importing when there is a conflict
+	/**
+	 * Import policies from a zip file
+	 * 
+	 * @param file       policy zip file as byte[]
+	 * @param policyName List of strings that represent the custom groups policy
+	 *                   will be assigned to.
+	 * @param force      true to overwrite the existing policies, false to skip
+	 *                   importing when there is a conflict
 	 * @throws Exception exception
-     */
-    public void importPolicyFromZip(String policyName, File file, Boolean force) throws Exception {
-        URI uri;
-        try {
-            uri = getURI(getURIBuilder().setPath(POLICIES_API + "import"));
-        } catch (RuntimeException e) {
-            throw e;
-        }
+	 */
+	public void importPolicyFromZip(String policyName, File file, Boolean force) throws Exception {
+		URI uri;
+		try {
+			uri = getURI(getURIBuilder().setPath(POLICIES_API + "import"));
+		} catch (RuntimeException e) {
+			throw e;
+		}
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        // Required header for internal API
-        headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+		// Required header for internal API
+		headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
 
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("policy", new FileSystemResource(file));
-        body.add("forceImport", force);
+		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+		body.add("policy", new FileSystemResource(file));
+		body.add("forceImport", force);
 
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-        try {
-            restTemplate.postForEntity(uri, requestEntity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("The policy '%s' could not be imported : %s.", policyName, e.getMessage()), e);
-        }
-    }
+		HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+		try {
+			restTemplate.postForEntity(uri, requestEntity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("The policy '%s' could not be imported : %s.", policyName, e.getMessage()), e);
+		}
+	}
 
-    /**
-     * Export a zip file per policies, filtered by name
-     * 
-     * @param policyEntries Names of the policies to be exported
-     * @return a list of policies containing a zip file as byte[], name and id of
-     *         the policy
-     */
-    public List<PolicyDTO.Policy> exportPoliciesFromVrops(List<String> policyEntries) {
-        List<PolicyDTO.Policy> policies = filterPoliciesByName(policyEntries);
-        restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
-        for (PolicyDTO.Policy policy : policies) {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
-            uriBuilder.queryParam("id", policy.getId());
+	/**
+	 * Export a zip file per policies, filtered by name
+	 * 
+	 * @param policyEntries Names of the policies to be exported
+	 * @return a list of policies containing a zip file as byte[], name and id of
+	 *         the policy
+	 */
+	public List<PolicyDTO.Policy> exportPoliciesFromVrops(List<String> policyEntries) {
+		List<PolicyDTO.Policy> policies = filterPoliciesByName(policyEntries);
+		restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
+		for (PolicyDTO.Policy policy : policies) {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
+			uriBuilder.queryParam("id", policy.getId());
 
-            HttpHeaders exportHeader = new HttpHeaders();
-            exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
-            // internal header is needed for vROPs internal API
-            exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
-            HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
-            ResponseEntity<byte[]> exportResponse = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, exportEntity, byte[].class);
+			HttpHeaders exportHeader = new HttpHeaders();
+			exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
+			// internal header is needed for vROPs internal API
+			exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+			HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
+			ResponseEntity<byte[]> exportResponse = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, exportEntity, byte[].class);
 
-            policy.setZipFile(exportResponse.getBody());
-        }
+			policy.setZipFile(exportResponse.getBody());
+		}
 
-        return policies;
-    }
+		return policies;
+	}
 
-    public List<PolicyDTO.Policy> getAllPolicies() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+	public List<PolicyDTO.Policy> getAllPolicies() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 
-        // Required header for internal API
-        headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(POLICIES_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return new ArrayList<>();
-            }
-            throw new RuntimeException(String.format("Error ocurred trying to fetching policies. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error building REST URI to fetch policies. Message: %s", e.getMessage()));
-        }
-        PolicyDTO policyDto = deserializePolicies(response.getBody());
+		// Required header for internal API
+		headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(POLICIES_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ArrayList<>();
+			}
+			throw new RuntimeException(String.format("Error ocurred trying to fetching policies. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error building REST URI to fetch policies. Message: %s", e.getMessage()));
+		}
+		PolicyDTO policyDto = deserializePolicies(response.getBody());
 
-        return policyDto == null ? Collections.emptyList() : policyDto.getPolicies();
-    }
+		return policyDto == null ? Collections.emptyList() : policyDto.getPolicies();
+	}
 
-    public PolicyDTO.Policy getPolicyContent(PolicyDTO.Policy policy) {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
-        uriBuilder.queryParam("id", policy.getId());
+	public PolicyDTO.Policy getPolicyContent(PolicyDTO.Policy policy) {
+		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
+		uriBuilder.queryParam("id", policy.getId());
 
-        HttpHeaders exportHeader = new HttpHeaders();
-        if (isVrops82OrLater()) {
-            // The API vROPs 8.2 or later expects accept to be MediaType.ALL
-            exportHeader.setAccept(Arrays.asList(MediaType.ALL));
-        } else {
-            exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
-        }
-        // internal header is needed for the internal API of vROPs
-        exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		HttpHeaders exportHeader = new HttpHeaders();
+		if (isVrops82OrLater()) {
+			// The API vROPs 8.2 or later expects accept to be MediaType.ALL
+			exportHeader.setAccept(Arrays.asList(MediaType.ALL));
+		} else {
+			exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
+		}
+		// internal header is needed for the internal API of vROPs
+		exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
 
-        HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
-        ResponseEntity<byte[]> response;
-        try {
-            response = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, exportEntity, byte[].class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error exporting all policy %s from vROPS : %s", policy.getName(), e.getMessage()), e);
-        }
+		HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
+		ResponseEntity<byte[]> response;
+		try {
+			response = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, exportEntity, byte[].class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error exporting all policy %s from vROPS : %s", policy.getName(), e.getMessage()), e);
+		}
 
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(
-                    String.format("Error exporting all policy %s from vROPS : remote REST service returned: %s", policy.getName(), response.getStatusCode()));
-        }
-        policy.setZipFile(response.getBody());
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(
+					String.format("Error exporting all policy %s from vROPS : remote REST service returned: %s", policy.getName(), response.getStatusCode()));
+		}
+		policy.setZipFile(response.getBody());
 
-        return policy;
-    }
+		return policy;
+	}
 
-    /**
-     * Export custom groups filtered by list of custom group names.
-     * 
-     * @param customGroupNames Names of the custom groups to be exported
-     * @return a list of custom groups
-     */
-    public List<CustomGroupDTO.Group> exportCustomGroupsFromVrops(List<String> customGroupNames) {
-        return findCustomGroupsByNames(customGroupNames);
-    }
+	/**
+	 * Export custom groups filtered by list of custom group names.
+	 * 
+	 * @param customGroupNames Names of the custom groups to be exported
+	 * @return a list of custom groups
+	 */
+	public List<CustomGroupDTO.Group> exportCustomGroupsFromVrops(List<String> customGroupNames) {
+		return findCustomGroupsByNames(customGroupNames);
+	}
 
-    /**
-     * Export all available custom groups from vROPs.
-     * 
-     * @return a list of custom groups
-     */
-    public List<CustomGroupDTO.Group> getAllCustomGroups() {
-        return findCustomGroupsByNames(null);
-    }
+	/**
+	 * Export all available custom groups from vROPs.
+	 * 
+	 * @return a list of custom groups
+	 */
+	public List<CustomGroupDTO.Group> getAllCustomGroups() {
+		return findCustomGroupsByNames(null);
+	}
 
-    /**
-     * Export definition of given type from vROPS server and return it as string.
-     * 
-     * @param definitionName - the name of the definition that has to be exported.
-     * @param definitionType - the VropsPackageMemberType type of the definition
-     *                       (currently ALERT_DEFINITION, SYMPTOM_DEFINITION and
-     *                       RECOMMENDATION are supported only).
-     * @return JSON String containing the definition data.
-     */
-    public String exportDefinitionFromVrops(String definitionName, VropsPackageMemberType definitionType) {
-        String definitionId = getDefinitionIdByName(definitionName, definitionType);
-        if (StringUtils.isEmpty(definitionId)) {
-            throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS , unable to find definition", definitionName, definitionType));
-        }
-        URI restUri = getDefinitionUri(definitionType, definitionId);
+	/**
+	 * Export definition of given type from vROPS server and return it as string.
+	 * 
+	 * @param definitionName - the name of the definition that has to be exported.
+	 * @param definitionType - the VropsPackageMemberType type of the definition
+	 *                       (currently ALERT_DEFINITION, SYMPTOM_DEFINITION and
+	 *                       RECOMMENDATION are supported only).
+	 * @return JSON String containing the definition data.
+	 */
+	public String exportDefinitionFromVrops(String definitionName, VropsPackageMemberType definitionType) {
+		String definitionId = getDefinitionIdByName(definitionName, definitionType);
+		if (StringUtils.isEmpty(definitionId)) {
+			throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS , unable to find definition", definitionName, definitionType));
+		}
+		URI restUri = getDefinitionUri(definitionType, definitionId);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response;
-        try {
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS : %s", definitionId, definitionType, e.getMessage()), e);
-        }
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS : %s", definitionId, definitionType, e.getMessage()), e);
+		}
 
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS : remote REST service returned: %s", definitionType,
-                    definitionId, response.getStatusCode()));
-        }
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(String.format("Error exporting %s of type %s from vROPS : remote REST service returned: %s", definitionType,
+					definitionId, response.getStatusCode()));
+		}
 
-        return response.getBody();
-    }
+		return response.getBody();
+	}
 
-    /**
-     * Export all definitions of given type from vROPs.
-     * 
-     * @param definitionType - the VropsPackageMemberType type of the definition
-     *                       (currently ALERT_DEFINITION, SYMPTOM_DEFINITION and
-     *                       RECOMMENDATION are supported only).
-     * @return Object - the object that is instance of AlertDefinitionDTO or
-     *         SymptomDefinitionsDTO or RecommendationsDTO.
-     */
-    public Object exportDefinitionsFromVrops(VropsPackageMemberType definitionType) {
-        URI restUri = getDefinitionUri(definitionType);
+	/**
+	 * Export all definitions of given type from vROPs.
+	 * 
+	 * @param definitionType - the VropsPackageMemberType type of the definition
+	 *                       (currently ALERT_DEFINITION, SYMPTOM_DEFINITION and
+	 *                       RECOMMENDATION are supported only).
+	 * @return Object - the object that is instance of AlertDefinitionDTO or
+	 *         SymptomDefinitionsDTO or RecommendationsDTO.
+	 */
+	public Object exportDefinitionsFromVrops(VropsPackageMemberType definitionType) {
+		URI restUri = getDefinitionUri(definitionType);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response;
-        try {
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error exporting all definitions of type %s from vROPS : %s", definitionType, e.getMessage()), e);
-        }
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error exporting all definitions of type %s from vROPS : %s", definitionType, e.getMessage()), e);
+		}
 
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(String.format("Error exporting all definitions of type %s from vROPS : remote REST service returned: %s", definitionType,
-                    response.getStatusCode()));
-        }
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(String.format("Error exporting all definitions of type %s from vROPS : remote REST service returned: %s", definitionType,
+					response.getStatusCode()));
+		}
 
-        return deserializeDefinitions(definitionType, response.getBody());
-    }
+		return deserializeDefinitions(definitionType, response.getBody());
+	}
 
-    /**
-     * Import definitions to the vROPS based on their type.
-     * 
-     * @param definitionType - the VropsPackageMemberType type of the definition
-     *                       (currently ALERT_DEFINITION, SYMPTOM_DEFINITION and
-     *                       RECOMMENDATION are supported only).
-	 * @param definitions - definitions
+	/**
+	 * Import definitions to the vROPS based on their type.
+	 * 
+	 * @param definitionType          - the VropsPackageMemberType type of the
+	 *                                definition (currently ALERT_DEFINITION,
+	 *                                SYMPTOM_DEFINITION and RECOMMENDATION are
+	 *                                supported only).
+	 * @param definitions             - definitions
 	 * @param dependentDefinitionsMap - dependentDefinitionsMap
-     */
-    public void importDefinitionsInVrops(Map<String, Object> definitions, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitionsMap) {
-        if (definitions.isEmpty()) {
-            return;
-        }
-
-        for (Map.Entry<String, Object> definitionEntry : definitions.entrySet()) {
-            if (definitionEntry.getValue() == null) {
-                continue;
-            }
-            String definitionName = getDefinitionName(definitionEntry.getValue(), definitionType);
-            logger.info("Importing {} '{}' to vROPs", definitionType, definitionName);
-            importDefinitionToVrops(definitionEntry.getValue(), definitionType, dependentDefinitionsMap);
-        }
-    }
-
-    /**
-     * Import custom group in vROPs.
-     * 
-     * @param customGroupName    - the custom group name.
-     * @param customGroupPayload - the payload of the custom group as json.
-	 * @param policyIdMap - the policy mappings.
-     */
-    public void importCustomGroupInVrops(String customGroupName, String customGroupPayload, Map<String, String> policyIdMap) {
-        if (StringUtils.isEmpty(customGroupPayload)) {
-            return;
-        }
-
-        HttpHeaders headers = new HttpHeaders();
-        HttpMethod method = customGroupExists(customGroupPayload) ? HttpMethod.PUT : HttpMethod.POST;
-        CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
-
-        // vROPs requires the group type to exists prior to creating
-        createMissingGroupTypes(customGroup);
-
-        // vROPs requires the group id to be set to null prior creating it
-        if (HttpMethod.POST.equals(method)) {
-            customGroupPayload = setCustomGroupIdToNull(customGroupPayload);
-        } else {
-            customGroupPayload = updateCustomGroupId(serializeCustomGroup(customGroupPayload), customGroupPayload);
-        }
-
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(customGroupPayload, headers);
-        ResponseEntity<String> responseEntity;
-        try {
-            URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUPS_UPDATE_API).toString());
-            responseEntity = restTemplate.exchange(restUri, method, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Unable to import custom group %s to vROPS : %s", customGroupName, e.getMessage()), e);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Unable to determine vROPs REST endpoint for custom group %s : %s", customGroupName, e.getMessage()), e);
-        }
-
-        HttpStatus status = responseEntity.getStatusCode();
-        if (HttpMethod.POST.equals(method)) {
-            if (HttpStatus.BAD_REQUEST.equals(status)) {
-                throw new RuntimeException(String.format("Error creating custom group %s: Validation error in the group data", customGroupName));
-            }
-            if (!HttpStatus.CREATED.equals(status)) {
-                throw new RuntimeException(
-                        String.format("Error creating custom group %s: Remote REST service returned status code %s", customGroupName, status));
-            }
-        }
-        if (HttpMethod.PUT.equals(method)) {
-            if (HttpStatus.BAD_REQUEST.equals(status)) {
-                throw new RuntimeException(String.format("Error updating custom group %s: Validation error in the group data", customGroupName));
-            }
-            if (!HttpStatus.OK.equals(status)) {
-                throw new RuntimeException(
-                        String.format("Error creating custom group %s: Remote REST service returned status code %s", customGroupName, status));
-            }
-        }
-
-        // Update policy for the custom group (if any)
-        // Note: due to bug in the API of vROPs the updating for the policy of
-        // a custom group should be done via separate call to the vROPs public API
-        updateCustomGroupPolicy(customGroupPayload, policyIdMap);
-    }
-
-    public void createMissingGroupTypes(CustomGroupDTO.Group customGroup) {
-        String customGroupResourceKind = customGroup.getResourceKey().getResourceKindKey();
-        if (!this.resourceKindExists(customGroupResourceKind, customGroup.getResourceKey().getAdapterKindKey())) {
-            this.createCustomGroupType(customGroupResourceKind);
-        }
-
-        customGroup.getMembershipDefinition().getRules().forEach(rule -> {
-            String resourceKindKey = rule.getResourceKindKey().getResourceKind();
-            String adapterKindKey = rule.getResourceKindKey().getAdapterKind();
-            if (!resourceKindExists(resourceKindKey, adapterKindKey)) {
-                this.createCustomGroupType(resourceKindKey);
-            }
-        });
-    }
-
-    public void createCustomGroupType(String customGroupType) {
-        logger.info(String.format("Custom group type doesn't exist. Creating custom group type '%s'", customGroupType));
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        CustomGroupTypeDTO customGroupTypeDto = new CustomGroupTypeDTO();
-        customGroupTypeDto.setName(customGroupType);
-        String customGroupTypePayload = deserializeCustomGroupType(customGroupTypeDto);
-        HttpEntity<String> entity = new HttpEntity<>(customGroupTypePayload, headers);
-        ResponseEntity<String> responseEntity;
-        try {
-            URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUP_TYPES_API).toString());
-            responseEntity = restTemplate.exchange(restUri, HttpMethod.POST, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Unable to create custom group type %s to vROPS : %s", customGroupType, e.getMessage()), e);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Unable to determine vROPs REST endpoint for custom group type %s : %s", customGroupType, e.getMessage()), e);
-        }
-
-        HttpStatus status = responseEntity.getStatusCode();
-        if (HttpStatus.BAD_REQUEST.equals(status)) {
-            throw new RuntimeException(String.format("Error creating custom group type %s: Validation error in the group data", customGroupType));
-        }
-        if (!HttpStatus.CREATED.equals(status)) {
-            throw new RuntimeException(
-                    String.format("Error creating custom group type %s: Remote REST service returned status code %s", customGroupType, status));
-        }
-    }
-
-    public ResourcesDTO getResources() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(RESOURCES_LIST_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return new ResourcesDTO();
-            }
-            throw new RuntimeException(String.format("Error occurred when trying to fetch resources. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch resources. Message: %s", e.getMessage()));
-        }
-        try {
-            return mapper.readValue(response.getBody(), ResourcesDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the resources response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error while parsing the resources response. Message: %s", e.getMessage()));
-        }
-    }
-
-    public SupermetricDTO getAllSupermetrics() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        SupermetricDTO retVal = new SupermetricDTO();
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(SUPERMETRICS_LIST_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return retVal;
-            }
-            throw new RuntimeException(String.format("Error occurred when trying to fetch supermetrics list. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch supermetrics. Message: %s", e.getMessage()));
-        }
-        try {
-            retVal = mapper.readValue(response.getBody(), SupermetricDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the supermetrics list response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(
-                    String.format("JSON processing error while parsing the supermetrics list resources response. Message: %s", e.getMessage()));
-        }
-        // Unescape special html characters in the names (returned by rest service)
-        retVal.getSuperMetrics().forEach(supermetric -> supermetric.setName(StringEscapeUtils.unescapeHtml4(supermetric.getName())));
-
-        return retVal;
-    }
-
-    public ViewDefinitionDTO getAllViewDefinitions() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        // Required header for internal API
-        headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        ViewDefinitionDTO retVal = new ViewDefinitionDTO();
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(VIEW_DEFINITIONS_LIST_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return retVal;
-            }
-            throw new RuntimeException(String.format("Error ocurred trying to fetching view definitions. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error building REST URI to fetch view definitions. Message: %s", e.getMessage()));
-        }
-        try {
-            retVal = mapper.readValue(response.getBody(), ViewDefinitionDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the view definitions response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error while parsing the view definitions response. Message: %s", e.getMessage()));
-        }
-        // Unescape special html characters in the names (returned by rest service)
-        retVal.getViewDefinitions().forEach(view -> view.setName(StringEscapeUtils.unescapeHtml4(view.getName())));
-
-        return retVal;
-    }
-
-    public ReportDefinitionDTO getAllReportDefinitions() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        ReportDefinitionDTO retVal = new ReportDefinitionDTO();
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(REPORT_DEFINITIONS_LIST_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return retVal;
-            }
-            throw new RuntimeException(String.format("Error occurred when trying to fetch report definitions. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch report definitions. Message: %s", e.getMessage()));
-        }
-        try {
-            retVal = mapper.readValue(response.getBody(), ReportDefinitionDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the report definitions response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(
-                    String.format("JSON processing error while parsing the supermetrics list report definitions response. Message: %s", e.getMessage()));
-        }
-        // Unescape special html characters in the names (returned by rest service)
-        retVal.getReportDefinitions().forEach(report -> report.setName(StringEscapeUtils.unescapeHtml4(report.getName())));
-
-        return retVal;
-    }
-
-    public List<AuthGroupDTO> findAllAuthGroups() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        List<AuthGroupDTO> retVal = new ArrayList<>();
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(AUTH_GROUPS_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return retVal;
-            }
-            throw new RuntimeException(String.format("Error occurred when trying to fetch auth groups. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error occurred when trying to build REST URI to auth groups. Message: %s", e.getMessage()));
-        }
-        try {
-            AuthGroupsDTO authGroupDto = mapper.readValue(response.getBody(), AuthGroupsDTO.class);
-            return authGroupDto == null ? retVal : authGroupDto.getUserGroups();
-
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the auth groups response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error while parsing the auth groups response. Message: %s", e.getMessage()));
-        }
-    }
-
-    public List<AuthUserDTO> findAllAuthUsers() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        List<AuthUserDTO> retVal = new ArrayList<>();
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(AUTH_USERS_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return retVal;
-            }
-            throw new RuntimeException(String.format("Error occurred when trying to fetch auth users. Message: %s", e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error occurred when trying to build REST URI to auth users. Message: %s", e.getMessage()));
-        }
-        try {
-        	AuthUsersDTO authUsersDto = mapper.readValue(response.getBody(), AuthUsersDTO.class);
-            return authUsersDto == null ? retVal : authUsersDto.getUsers();
-
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing the auth users response. Message: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error while parsing the auth users response. Message: %s", e.getMessage()));
-        }
-    }
-    
-    public AuthUserDTO findAllAuthUserByName(String name) {
-        List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
-
-        return allAuthUsers.stream().filter(item -> name.equals(item.getUsername())).findAny().orElse(null);
-    }
-    
-    public AuthGroupDTO findAuthGroupByName(String name) {
-        List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
-
-        return allAuthGroups.stream().filter(item -> name.equals(item.getDisplayName())).findAny().orElse(null);
-    }
-
-    public List<AuthGroupDTO> findAuthGroupsByNames(List<String> names) {
-        List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
-
-        return allAuthGroups.stream().filter(item -> names.contains(item.getDisplayName())).collect(Collectors.toList());
-    }
-    
-    public List<AuthUserDTO> findAuthUsersByNames(List<String> names) {
-    	List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
-
-        return allAuthUsers.stream().filter(item -> names.contains(item.getUsername())).collect(Collectors.toList());
-    }    
-
-    private Version getProductVersion() {
-        if (this.productVersion == null) {
-            this.productVersion = new Version(getVersion());
-        }
-
-        return this.productVersion;
-    }
-
-    private boolean isVrops82OrLater() {
-        Integer major = this.getProductVersion().getMajorVersion();
-        Integer minor = this.getProductVersion().getMinorVersion();
-
-        return (major != null && major >= VROPS_MAJOR_VERSION) && (minor != null && minor >= VROPS_MINOR_VERSION);
-    }
-
-    private PolicyDTO.Policy findPolicyByName(String policyName) {
-        // get all available policies in the target system
-        List<PolicyDTO.Policy> policies = getAllPolicies();
-
-        if (policies == null || policies.isEmpty()) {
-            throw new RuntimeException("Unable to retrieve policies from the target system");
-        }
-        Optional<PolicyDTO.Policy> foundPolicy = policies.stream().filter(item -> item.getName().equalsIgnoreCase(policyName)).findFirst();
-        if (!foundPolicy.isPresent()) {
-            throw new RuntimeException(String.format("Policy '%s' could not be found on the target system", policyName));
-        }
-
-        return foundPolicy.get();
-    }
-
-    private List<PolicyDTO.Policy> filterPoliciesByName(List<String> policyEntries) {
-        List<PolicyDTO.Policy> policies = getAllPolicies();
-        if (policies == null || policies.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return policies.stream().filter(policy -> policyEntries.stream().anyMatch(entry -> entry.equalsIgnoreCase(policy.getName())))
-                .collect(Collectors.toList());
-    }
-
-    private void updateCustomGroupPolicy(String customGroupPayload, Map<String, String> policyIdMap) {
-        CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
-        if (customGroup == null) {
-            return;
-        }
-
-        String policyId = customGroup.getPolicy();
-        if (StringUtils.isEmpty(policyId)) {
-            return;
-        }
-
-        String customGroupName = customGroup.getResourceKey().getName();
-        // throw an exception if the custom group has a policy but it cannot be found in
-        // the mapping data
-        if (!policyIdMap.containsKey(policyId)) {
-            throw new RuntimeException(String.format("The policy for custom group '%s' could not be found in the policy metadata file", customGroupName));
-        }
-
-        // find the custom group in the target system
-        customGroup = findCustomGroupByName(customGroupName);
-        if (customGroup == null) {
-            throw new RuntimeException(String.format("Custom group '%s' cannot be found on the target system", customGroupName));
-        }
-
-        // find policy in the target system
-        String policyName = policyIdMap.get(policyId);
-        PolicyDTO.Policy policy = findPolicyByName(policyName);
-        customGroup.setPolicy(policy.getId());
-
-        // prepare rest call payload
-        customGroupPayload = deserializeCustomGroup(customGroup);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(customGroupPayload, headers);
-        ResponseEntity<String> responseEntity;
-        logger.info("Setting policy for custom group '{}' to '{}'", customGroupName, policyName);
-        try {
-            URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUPS_UPDATE_API).toString());
-            responseEntity = restTemplate.exchange(restUri, HttpMethod.PUT, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Unable to update policy for custom group '%s' : %s", customGroupName, e.getMessage()), e);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(
-                    String.format("Unable to determine REST endpoint for updating policy for custom group '%s' : %s", customGroupName, e.getMessage()), e);
-        }
-
-        if (!HttpStatus.OK.equals(responseEntity.getStatusCode())) {
-            throw new RuntimeException(String.format("Error updating policy for custom group '%s': Remote REST service returned status code %s",
-                    customGroupName, responseEntity.getStatusCode()));
-        }
-    }
-
-    private String setCustomGroupIdToNull(final String customGroupPayload) {
-        CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
-        if (customGroup == null) {
-            return customGroupPayload;
-        }
-        customGroup.setId(null);
-        customGroup.setIdentifier(null);
-
-        return deserializeCustomGroup(customGroup);
-    }
-
-    private String updateCustomGroupId(CustomGroupDTO.Group customGroup, String customGroupPayload) {
-        CustomGroupDTO.Group serializedCustomGroup = serializeCustomGroup(customGroupPayload);
-        if (customGroup == null || serializedCustomGroup == null) {
-            return customGroupPayload;
-        }
-        CustomGroupDTO.Group existingCustomGroup = findCustomGroupByName(customGroup.getResourceKey().getName());
-        if (existingCustomGroup != null) {
-            // vROPs complains if in the membership rules' stat condition rules both
-            // stringValue and doubleValue are set in this case set the doubleValue to null
-            // and leave the stringValue set only
-            // (used for bacward compatibility with older versions of Build Tools for VMware Aria)
-            if (serializedCustomGroup.getMembershipDefinition() != null) {
-                serializedCustomGroup.getMembershipDefinition().getRules().stream().forEach(rule -> {
-                    rule.getStatConditionRules().forEach(statCondition -> {
-                        if (statCondition.getDoubleValue() != null && !StringUtils.isEmpty(statCondition.getStringValue())) {
-                            statCondition.setDoubleValue(null);
-                        }
-                    });
-                });
-            }
-
-            serializedCustomGroup.setId(existingCustomGroup.getId());
-            serializedCustomGroup.setIdentifier(existingCustomGroup.getId());
-        }
-
-        return deserializeCustomGroup(serializedCustomGroup);
-    }
-
-    private CustomGroupDTO.Group serializeCustomGroup(String customGroupPayload) {
-        try {
-            return mapper.readValue(customGroupPayload, CustomGroupDTO.Group.class);
-        } catch (JsonMappingException e) {
-            logger.warn("Failed to serialize custom group, mapping error: {}", e.getMessage());
-            return null;
-        } catch (JsonProcessingException e) {
-            logger.warn("Failed to serialize custom group, JSON processing error: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private String deserializeCustomGroup(CustomGroupDTO.Group customGroup) {
-        try {
-            return mapper.writeValueAsString(customGroup);
-        } catch (JsonMappingException e) {
-            logger.warn("Failed to de-serialize custom group, JSON mapping error: {}", e.getMessage());
-            return null;
-        } catch (JsonProcessingException e) {
-            logger.warn("Failed to de-serialize custom group, JSON processing error: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private String deserializeCustomGroupType(CustomGroupTypeDTO customGroupType) {
-        try {
-            return mapper.writeValueAsString(customGroupType);
-        } catch (JsonMappingException e) {
-            logger.warn("Failed to de-serialize custom group type, JSON mapping error: {}", e.getMessage());
-            return null;
-        } catch (JsonProcessingException e) {
-            logger.warn("Failed to de-serialize custom group type, JSON processing error: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private boolean customGroupExists(String customGroupPayload) {
-        CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
-        if (customGroup == null) {
-            return false;
-        }
-
-        return findCustomGroupByName(customGroup.getResourceKey().getName()) != null;
-    }
-
-    /**
-     * Find vROPS custom group by name.
-     * 
-     * @param List<String> - names of the custom groups.
-     * @return List<CustomGroupDTO.CustomGroup> - list of the found custom groups.
-     */
-    private List<CustomGroupDTO.Group> findCustomGroupsByNames(List<String> customGroupNames) {
-        List<CustomGroupDTO.Group> retVal = new ArrayList<>();
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = new ResponseEntity<>(HttpStatus.OK);
-        String groupInfo = customGroupNames != null && !customGroupNames.isEmpty() ? customGroupNames.stream().collect(Collectors.joining(",")) : "";
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(CUSTOM_GROUPS_FETCH_API).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            uriBuilder.queryParam("includePolicy", Boolean.TRUE.toString());
-            URI restUri = uriBuilder.build().toUri();
-            response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
-        } catch (HttpClientErrorException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
-                return new ArrayList<>();
-            }
-            throw new RuntimeException(String.format("Error ocurred trying to find custom groups %s. Message: %s", groupInfo, e.getMessage()));
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Error building REST URI to find custom groups %s. Message: %s", groupInfo, e.getMessage()));
-        }
-        CustomGroupDTO customGroup = new CustomGroupDTO();
-        try {
-            customGroup = mapper.readValue(response.getBody(), CustomGroupDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error while parsing custom group response: %s", e.getMessage()), e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error while parsing custom group response: %s", e.getMessage()), e);
-        }
-
-        // if no filtering groups are specified return all
-        if (customGroupNames == null || customGroupNames.isEmpty()) {
-            return customGroup.getGroups();
-        }
-
-        for (String name : customGroupNames) {
-            List<CustomGroupDTO.Group> foundGroups = customGroup.getGroups().stream().filter(item -> name.equalsIgnoreCase(item.getResourceKey().getName()))
-                    .collect(Collectors.toList());
-            if (foundGroups.isEmpty()) {
-                continue;
-            }
-            retVal.addAll(foundGroups);
-        }
-
-        return retVal;
-    }
-
-    private CustomGroupDTO.Group findCustomGroupByName(String customGroupName) {
-        if (StringUtils.isEmpty(customGroupName)) {
-            return null;
-        }
-        List<CustomGroupDTO.Group> foundGroups = findCustomGroupsByNames(Arrays.asList(new String[] { customGroupName }));
-
-        return foundGroups.stream().findFirst().isPresent() ? foundGroups.stream().findFirst().get() : null;
-    }
-
-    private void importDefinitionToVrops(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
-        // validate definition sanity
-        if (!validateDefinition(definition, definitionType, dependentDefinitions)) {
-            logger.warn("Invalid definition of type {}, import will be skipped", definitionType);
-            return;
-        }
-
-        URI restUri = getDefinitionUri(definitionType, "");
-
-        // get definition Id on the target system
-        String definitionId = getDefinitionId(definition, definitionType);
-        HttpMethod method = HttpMethod.POST;
-        if (!StringUtils.isEmpty(definitionId)) {
-            updateDefinitionId(definition, definitionType, definitionId);
-            method = HttpMethod.PUT;
-        }
-
-        // update dependent definitions if any
-        updateDependentDefinitions(definition, definitionType, dependentDefinitions);
-
-        // If HTTP method is POST the id has to be removed from the pay load (limitation
-        // of the vROps REST API)
-        if (method.equals(HttpMethod.POST)) {
-            removeIdFromDefinitionPayload(definition, definitionType);
-        }
-
-        // If the resourceKindKey is missing definition cannot be created.
-        // In case of custom resourceKindKey it must be created as a new custom group type
-        String adapterKindKey = getDefinitionAdapterKindKey(definition, definitionType);
-        String resourceKindKey = getDefinitionResourceKindKey(definition, definitionType);
-        if (adapterKindKey != null && resourceKindKey != null && !resourceKindExists(resourceKindKey, adapterKindKey)) {
-            createCustomGroupType(resourceKindKey);
-        }
-
-        String definitionPayload;
-        try {
-            definitionPayload = mapper.writeValueAsString(definition);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("Error serializing definition type %s JSON mapping error : %s", definitionType, e.getMessage()), e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("Error serializing definition type %s JSON processing error: %s", definitionType, e.getMessage()), e);
-        }
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(definitionPayload, headers);
-        ResponseEntity<String> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-        String definitionName = getDefinitionName(definition, definitionType);
-
-        try {
-            responseEntity = restTemplate.exchange(restUri, method, entity, String.class);
-        } catch (RestClientException e) {
-            if (e.getMessage().contains(HttpStatus.NOT_FOUND.toString())) {
-                throw new RuntimeException(String.format("Error importing %s of type %s to vROPS, the REST service could not validate definition data : %s",
-                        definitionName, definitionType, e.getMessage()), e);
-
-            }
-            throw new RuntimeException(String.format("Error importing %s of type %s to vROPS : %s", definitionName, definitionType, e.getMessage()), e);
-        }
-
-        if (HttpMethod.POST.equals(method) && !HttpStatus.CREATED.equals(responseEntity.getStatusCode())) {
-            throw new RuntimeException(String.format("Error creating %s %s: remote REST service returned status code %s", definitionType, definitionName,
-                    responseEntity.getStatusCode()));
-        }
-        if (HttpMethod.PUT.equals(method) && !HttpStatus.OK.equals(responseEntity.getStatusCode())) {
-            throw new RuntimeException(String.format("Error updating %s %s: remote REST service returned status code %s", definitionType, definitionName,
-                    responseEntity.getStatusCode()));
-        }
-    }
-
-    private String getDefinitionAdapterKindKey(Object definition, VropsPackageMemberType definitionType) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                return ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey();
-            }
-            case SYMPTOM_DEFINITION: {
-                return ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey();
-            }
-            case RECOMMENDATION: {
-                return null;
-            }
-            default: {
-                logger.warn("Invalid definition type {}", definitionType);
-            }
-        }
-
-        return null;
-    }
-
-    private String getDefinitionResourceKindKey(Object definition, VropsPackageMemberType definitionType) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                return ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey();
-            }
-            case SYMPTOM_DEFINITION: {
-                return ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey();
-            }
-            case RECOMMENDATION: {
-                return null;
-            }
-            default: {
-                logger.warn("Invalid definition type {}", definitionType);
-            }
-        }
-
-        return null;
-    }
-
-    private String getDefinitionName(Object definition, VropsPackageMemberType definitionType) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                return ((AlertDefinitionDTO.AlertDefinition) definition).getName();
-            }
-            case SYMPTOM_DEFINITION: {
-                return ((SymptomDefinitionDTO.SymptomDefinition) definition).getName();
-            }
-            case RECOMMENDATION: {
-                return ((RecommendationDTO.Recommendation) definition).getDescription();
-            }
-            default: {
-                logger.warn("Invalid definition type {}", definitionType);
-            }
-        }
-
-        return null;
-    }
-
-    private boolean validateDefinition(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
-        if (VropsPackageMemberType.SYMPTOM_DEFINITION.equals(definitionType)) {
-            return validateSymptomDefinition(definition);
-        }
-        if (VropsPackageMemberType.ALERT_DEFINITION.equals(definitionType)) {
-            return validateAlertDefinition(definition, dependentDefinitions);
-        }
-
-        return true;
-    }
-
-    private boolean validateSymptomDefinition(Object definition) {
-        if (!(definition instanceof SymptomDefinitionDTO.SymptomDefinition)) {
-            return false;
-        }
-        String adapterKind = ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey() != null
-                ? ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey().trim()
-                : null;
-        String resourceKind = ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey() != null
-                ? ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey().trim()
-                : null;
-
-        // check whether adapter kind is present
-        if (adapterKind == null) {
-            logger.error("Invalid Symptom definition: adapterKindKeyNode field is required and must be a string value. Symptom definition: '{}'",
-                    ((SymptomDefinitionDTO.SymptomDefinition) definition).getName());
-            return false;
-        }
-
-        // adapterKindKeyNode equals to all is not supported by the vROps Rest API
-        // (version 8.0.0.14857692), it responds with httpStatusCode: 404, "message":"No
-        // such Adapter Kind - All."
-        if ("all".equalsIgnoreCase(adapterKind)) {
-            logger.error("Symptoms definitions for all the adapter types are not supported. Symptom definition: '{}'",
-                    ((SymptomDefinitionDTO.SymptomDefinition) definition).getName());
-            return false;
-        }
-
-        // check whether the adapter kind exists on the target system
-        if (!adapterKindKeyExists(adapterKind)) {
-            logger.error(
-                    "Adapter kind key '{}' for symptom definition '{}' is not present on the target system, please check whether content pack containing adapter kind '{}' is installed there",
-                    adapterKind, ((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), adapterKind);
-            return false;
-        }
-
-        // check whether the resource kind exists on the target system
-        if (!resourceKindExists(resourceKind, adapterKind)) {
-            logger.warn(
-                    "Resource kind key '{}' for symptom definition '{}' with adapter kind '{}' is not present on the target system, please check whether content pack containing resource kind '{}' is installed there",
-                    resourceKind, ((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), adapterKind, resourceKind);
-        }
-
-        return true;
-    }
-
-    private boolean validateAlertDefinition(Object definition, Map<String, Object> dependentDefinitions) {
-        if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
-            return false;
-        }
-        String resourceKind = ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey() != null
-                ? ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey().trim()
-                : null;
-        String adapterKind = ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey() != null
-                ? ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey().trim()
-                : null;
-
-        // check whether the adapter kind exists on the target system
-        if (!adapterKindKeyExists(adapterKind)) {
-            logger.error(
-                    "Adapter kind key '{}' for alert definition '{}' is not present on the target system, please check whether content pack containing adapter kind '{}' is installed there",
-                    adapterKind, ((AlertDefinitionDTO.AlertDefinition) definition).getName(), adapterKind);
-            return false;
-        }
-
-                // check whether the resource kind exists on the target system
-        if (!resourceKindExists(resourceKind, adapterKind)) {
-            logger.warn(
-                    "Resource kind key '{}' for alert definition '{}' with adapter kind '{}' is not present on the target system, please check whether content pack containing resource kind '{}' is installed there",
-                    resourceKind, ((AlertDefinitionDTO.AlertDefinition) definition).getName(), adapterKind, resourceKind);
-        }
-
-        return validateDependentDefinitions(definition, dependentDefinitions);
-    }
-
-    private boolean validateDependentDefinitions(Object definition, Map<String, Object> dependentDefinitions) {
-        if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
-            return false;
-        }
-        if (dependentDefinitions == null || dependentDefinitions.isEmpty()) {
-            return true;
-        }
-        String alertDefName = ((AlertDefinitionDTO.AlertDefinition) definition).getName();
-        for (State state : ((AlertDefinitionDTO.AlertDefinition) definition).getStates()) {
-            if (state.getBaseSymptomSet() == null) {
-                continue;
-            }
-            // check base symptom set's symptom definition ids
-            for (String symptomDefinitionId : state.getBaseSymptomSet().getSymptomDefinitionIds()) {
-                if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
-                    continue;
-                }
-                Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
-                if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
-                    continue;
-                }
-                String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
-                String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
-                if (StringUtils.isEmpty(dependentSymptomDefId)) {
-                    logger.error("Dependent base symptom definition '{}' for alert definition '{}' is missing on the target system", dependentSymptomDefName,
-                            alertDefName);
-                    return false;
-                }
-            }
-
-            // check symptom set's symptom definition ids
-            for (SymptomSet symptomSet : state.getBaseSymptomSet().getSymptomSets()) {
-                for (String symptomDefinitionId : symptomSet.getSymptomDefinitionIds()) {
-                    if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
-                        continue;
-                    }
-                    Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
-                    if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
-                        continue;
-                    }
-                    String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
-                    String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
-                    if (StringUtils.isEmpty(dependentSymptomDefId)) {
-                        logger.error("Dependent symptom definition '{}' for alert definition '{}' is missing on the target system", dependentSymptomDefName,
-                                alertDefName);
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private boolean adapterKindKeyExists(String adapterKindKey) {
-        // get all adapter kinds on the target system
-        AdapterKindDTO adapterKindOject = getAllAdapterKindData();
-        if (adapterKindOject == null) {
-            return false;
-        }
-        if (StringUtils.isEmpty(adapterKindKey)) {
-            return false;
-        }
-
-        return adapterKindOject.getAdapterKind().stream().anyMatch(item -> adapterKindKey.equalsIgnoreCase(item.getKey()));
-    }
-
-    private AdapterKindDTO getAllAdapterKindData() {
-        URI uri;
-        try {
-            uri = new URI(getURIBuilder().setPath(ADAPTER_KINDS_API).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response;
-        try {
-            response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error fetching adapter kinds from target vROPs: %s", e.getMessage()), e);
-        }
-
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(
-                    String.format("Error locating adapter kinds from target vROPs, remote REST service returned: %s", response.getStatusCode()));
-        }
-        try {
-            return mapper.readValue(response.getBody(), AdapterKindDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error during parsing of adapter kind data: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error during parsing of adapter kind data: %s", e.getMessage()));
-        }
-    }
-
-    private boolean resourceKindExists(String resourceKindKey, String adapterKindKey) {
-        if (resourceKindKey.equals(VROPS_KIND_ALL) && adapterKindKey.equals(VROPS_KIND_ALL)) {
-            return true;
-        }
-
-        if (StringUtils.isEmpty(adapterKindKey)) {
-            return false;
-        }
-
-        // get all resource kinds on the target system
-        ResourceKindDTO resourceKindObject = getAllResourceKinds(adapterKindKey);
-        if (resourceKindObject == null) {
-            return false;
-        }
-
-        return resourceKindObject.getResourceKind().stream().anyMatch(item -> resourceKindKey.equalsIgnoreCase(item.getKey()));
-    }
-
-    private ResourceKindDTO getAllResourceKinds(String adapterKindKey) {
-        if (StringUtils.isEmpty(adapterKindKey)) {
-            return new ResourceKindDTO();
-        }
-
-        String endpointName = String.format(RESOURCE_KINDS_API, adapterKindKey);
-        URI uri;
-        try {
-            uri = new URI(getURIBuilder().setPath(endpointName).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response;
-        try {
-            response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error fetching resource kinds for adapter kind %s from target vROPs: %s", adapterKindKey, e.getMessage()),
-                    e);
-        }
-
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(String.format("Error locating resource kinds for adapter kind %s from target vROPs, remote REST service returned: %s",
-                    adapterKindKey, response.getStatusCode()));
-        }
-        try {
-            return mapper.readValue(response.getBody(), ResourceKindDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error during parsing of data for adapter kind %s : %s", adapterKindKey, e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error during parsing of data for adapter kind %s : %s", adapterKindKey, e.getMessage()));
-        }
-    }
-
-    private void updateDependentDefinitions(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
-        // Only for alert definitions need to update dependencies
-        if (!VropsPackageMemberType.ALERT_DEFINITION.equals(definitionType)) {
-            return;
-        }
-        if (definition == null) {
-            return;
-        }
-        if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
-            return;
-        }
-
-        if (dependentDefinitions == null || dependentDefinitions.isEmpty()) {
-            return;
-        }
-
-        for (State state : ((AlertDefinitionDTO.AlertDefinition) definition).getStates()) {
-            if (state.getBaseSymptomSet() == null) {
-                continue;
-            }
-            // update base symptom set's symptom definition ids
-            List<String> symptomDefIds = new ArrayList<>();
-            for (String symptomDefinitionId : state.getBaseSymptomSet().getSymptomDefinitionIds()) {
-                if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
-                    continue;
-                }
-                Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
-                if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
-                    continue;
-                }
-                String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
-                String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
-                symptomDefIds.add(dependentSymptomDefId);
-            }
-            if (!symptomDefIds.isEmpty()) {
-                state.getBaseSymptomSet().setSymptomDefinitionIds(symptomDefIds);
-            }
-
-            // update symptom set's symptom definition ids
-            List<SymptomSet> targetSymptomSets = new ArrayList<>();
-            for (SymptomSet symptomSet : state.getBaseSymptomSet().getSymptomSets()) {
-                symptomDefIds = new ArrayList<>();
-                for (String symptomDefinitionId : symptomSet.getSymptomDefinitionIds()) {
-                    if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
-                        continue;
-                    }
-                    Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
-                    if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
-                        continue;
-                    }
-                    String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
-                    String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
-                    symptomDefIds.add(dependentSymptomDefId);
-                }
-                if (!symptomDefIds.isEmpty()) {
-                    symptomSet.setSymptomDefinitionIds(symptomDefIds);
-                }
-                targetSymptomSets.add(symptomSet);
-            }
-            if (!targetSymptomSets.isEmpty()) {
-                state.getBaseSymptomSet().setSymptomSets(targetSymptomSets);
-            }
-        }
-    }
-
-    private void removeIdFromDefinitionPayload(Object definition, VropsPackageMemberType definitionType) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                ((AlertDefinitionDTO.AlertDefinition) definition).setId(null);
-                break;
-            }
-            case SYMPTOM_DEFINITION: {
-                ((SymptomDefinitionDTO.SymptomDefinition) definition).setId(null);
-                break;
-            }
-            case RECOMMENDATION: {
-                ((RecommendationDTO.Recommendation) definition).setId(null);
-                break;
-            }
-            default: {
-                logger.warn("Invalid definition type {}", definitionType);
-            }
-        }
-    }
-
-    private String getDefinitionId(Object definition, VropsPackageMemberType definitionType) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                return getDefinitionIdByName(((AlertDefinitionDTO.AlertDefinition) definition).getName(), definitionType);
-            }
-            case SYMPTOM_DEFINITION: {
-                return getDefinitionIdByName(((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), definitionType);
-            }
-            case RECOMMENDATION: {
-                return getDefinitionIdByName(((RecommendationDTO.Recommendation) definition).getDescription(), definitionType);
-            }
-            default: {
-                return null;
-            }
-        }
-    }
-
-    private void updateDefinitionId(Object definition, VropsPackageMemberType definitionType, String definitionId) {
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                ((AlertDefinitionDTO.AlertDefinition) definition).setId(definitionId);
-                break;
-            }
-            case SYMPTOM_DEFINITION: {
-                ((SymptomDefinitionDTO.SymptomDefinition) definition).setId(definitionId);
-                break;
-            }
-            case RECOMMENDATION: {
-                ((RecommendationDTO.Recommendation) definition).setId(definitionId);
-                break;
-            }
-            default: {
-                logger.warn("Unknown definition type {}", definitionType);
-            }
-        }
-    }
-
-    private String getDefinitionIdByName(String definitionName, VropsPackageMemberType definitionType) {
-        String restUri;
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                restUri = ALERT_DEFS_API;
-                break;
-            }
-            case SYMPTOM_DEFINITION: {
-                restUri = SYMPTOM_DEFS_API;
-                break;
-            }
-            case RECOMMENDATION: {
-                restUri = RECOMMENDATIONS_API;
-                break;
-            }
-            default: {
-                throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
-            }
-        }
-        URI uri;
-        try {
-            UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(restUri).toString()));
-            uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
-            uri = uriBuilder.build().toUri();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response;
-        try {
-            response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Error finding %s of %s: %s", definitionName, definitionType, e.getMessage()), e);
-        }
-
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(
-                    String.format("Error finding %s of type %s: remote REST service returned %s", definitionType, definitionName, response.getStatusCode()));
-        }
-
-        try {
-            switch (definitionType) {
-                case ALERT_DEFINITION: {
-                    AlertDefinitionDTO alertDefinitions = mapper.readValue(response.getBody(), AlertDefinitionDTO.class);
-                    List<AlertDefinitionDTO.AlertDefinition> filtered = alertDefinitions.getAlertDefinitions().stream()
-                            .filter(item -> definitionName.equalsIgnoreCase(item.getName())).collect(Collectors.toList());
-                    Optional<AlertDefinitionDTO.AlertDefinition> value = filtered.stream().findFirst();
-
-                    return value.isPresent() ? value.get().getId() : null;
-                }
-                case SYMPTOM_DEFINITION: {
-                    SymptomDefinitionDTO symptomDefinitions = mapper.readValue(response.getBody(), SymptomDefinitionDTO.class);
-                    List<SymptomDefinitionDTO.SymptomDefinition> filtered = symptomDefinitions.getSymptomDefinitions().stream()
-                            .filter(item -> definitionName.equalsIgnoreCase(item.getName())).collect(Collectors.toList());
-                    Optional<SymptomDefinitionDTO.SymptomDefinition> value = filtered.stream().findFirst();
-
-                    return value.isPresent() ? value.get().getId() : null;
-                }
-                case RECOMMENDATION: {
-                    RecommendationDTO recommendations = mapper.readValue(response.getBody(), RecommendationDTO.class);
-                    List<RecommendationDTO.Recommendation> filtered = recommendations.getRecommendations().stream()
-                            .filter(item -> definitionName.equalsIgnoreCase(item.getDescription())).collect(Collectors.toList());
-                    Optional<RecommendationDTO.Recommendation> value = filtered.stream().findFirst();
-
-                    return value.isPresent() ? value.get().getId() : null;
-                }
-                default: {
-                    throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
-                }
-            }
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("JSON mapping error during mapping of definitions data: %s", e.getMessage()), e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("JSON processing error during processing of definitions data: %s", e.getMessage()), e);
-        }
-    }
-
-    private URI getDefinitionUri(VropsPackageMemberType definitionType, String id) {
-        String restUri;
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                restUri = ALERT_DEFS_API;
-                break;
-            }
-            case SYMPTOM_DEFINITION: {
-                restUri = SYMPTOM_DEFS_API;
-                break;
-            }
-            case RECOMMENDATION: {
-                restUri = RECOMMENDATIONS_API;
-                break;
-            }
-            default: {
-                throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
-            }
-        }
-        restUri = restUri + id;
-        try {
-            return new URI(getURIBuilder().setPath(restUri).toString());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private URI getDefinitionUri(VropsPackageMemberType definitionType) {
-        String restUri;
-        switch (definitionType) {
-            case ALERT_DEFINITION: {
-                restUri = ALERT_DEFS_API;
-                break;
-            }
-            case SYMPTOM_DEFINITION: {
-                restUri = SYMPTOM_DEFS_API;
-                break;
-            }
-            case RECOMMENDATION: {
-                restUri = RECOMMENDATIONS_API;
-                break;
-            }
-            default: {
-                throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
-            }
-        }
-        try {
-            return new URI(getURIBuilder().setPath(restUri).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-
-    }
-
-    private PolicyDTO deserializePolicies(String policiesJson) {
-        if (StringUtils.isEmpty(policiesJson)) {
-            return null;
-        }
-
-        try {
-            return mapper.readValue(policiesJson, PolicyDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("Unable to deserialize policies from JSON string, JSON mapping error: %s", e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("Unable to deserialize policies from JSON string, JSON processing error: %s", e.getMessage()));
-        }
-    }
-
-    private Object deserializeDefinitions(VropsPackageMemberType definitionType, String definitionJson) {
-        if (StringUtils.isEmpty(definitionJson)) {
-            return null;
-        }
-        try {
-            switch (definitionType) {
-                case ALERT_DEFINITION: {
-                    return mapper.readValue(definitionJson, AlertDefinitionDTO.class);
-                }
-                case SYMPTOM_DEFINITION: {
-                    return mapper.readValue(definitionJson, SymptomDefinitionDTO.class);
-                }
-                case RECOMMENDATION: {
-                    return mapper.readValue(definitionJson, RecommendationDTO.class);
-                }
-                default: {
-                    throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
-                }
-            }
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(String.format("Unable to deserialize definition of type %s from JSON string, JSON mapping error: %s",
-                    definitionType.name(), e.getMessage()));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("Unable to deserialize definition of type %s from JSON string, JSON processing error: %s",
-                    definitionType.name(), e.getMessage()));
-        }
-    }
+	 */
+	public void importDefinitionsInVrops(Map<String, Object> definitions, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitionsMap) {
+		if (definitions.isEmpty()) {
+			return;
+		}
+
+		for (Map.Entry<String, Object> definitionEntry : definitions.entrySet()) {
+			if (definitionEntry.getValue() == null) {
+				continue;
+			}
+			String definitionName = getDefinitionName(definitionEntry.getValue(), definitionType);
+			logger.info("Importing {} '{}' to vROPs", definitionType, definitionName);
+			importDefinitionToVrops(definitionEntry.getValue(), definitionType, dependentDefinitionsMap);
+		}
+	}
+
+	/**
+	 * Import custom group in vROPs.
+	 * 
+	 * @param customGroupName    - the custom group name.
+	 * @param customGroupPayload - the payload of the custom group as json.
+	 * @param policyIdMap        - the policy mappings.
+	 */
+	public void importCustomGroupInVrops(String customGroupName, String customGroupPayload, Map<String, String> policyIdMap) {
+		if (StringUtils.isEmpty(customGroupPayload)) {
+			return;
+		}
+
+		HttpHeaders headers = new HttpHeaders();
+		HttpMethod method = customGroupExists(customGroupPayload) ? HttpMethod.PUT : HttpMethod.POST;
+		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
+
+		// vROPs requires the group type to exists prior to creating
+		createMissingGroupTypes(customGroup);
+
+		// vROPs requires the group id to be set to null prior creating it
+		if (HttpMethod.POST.equals(method)) {
+			customGroupPayload = setCustomGroupIdToNull(customGroupPayload);
+		} else {
+			customGroupPayload = updateCustomGroupId(serializeCustomGroup(customGroupPayload), customGroupPayload);
+		}
+
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(customGroupPayload, headers);
+		ResponseEntity<String> responseEntity;
+		try {
+			URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUPS_UPDATE_API).toString());
+			responseEntity = restTemplate.exchange(restUri, method, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Unable to import custom group %s to vROPS : %s", customGroupName, e.getMessage()), e);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Unable to determine vROPs REST endpoint for custom group %s : %s", customGroupName, e.getMessage()), e);
+		}
+
+		HttpStatus status = responseEntity.getStatusCode();
+		if (HttpMethod.POST.equals(method)) {
+			if (HttpStatus.BAD_REQUEST.equals(status)) {
+				throw new RuntimeException(String.format("Error creating custom group %s: Validation error in the group data", customGroupName));
+			}
+			if (!HttpStatus.CREATED.equals(status)) {
+				throw new RuntimeException(
+						String.format("Error creating custom group %s: Remote REST service returned status code %s", customGroupName, status));
+			}
+		}
+		if (HttpMethod.PUT.equals(method)) {
+			if (HttpStatus.BAD_REQUEST.equals(status)) {
+				throw new RuntimeException(String.format("Error updating custom group %s: Validation error in the group data", customGroupName));
+			}
+			if (!HttpStatus.OK.equals(status)) {
+				throw new RuntimeException(
+						String.format("Error creating custom group %s: Remote REST service returned status code %s", customGroupName, status));
+			}
+		}
+
+		// Update policy for the custom group (if any)
+		// Note: due to bug in the API of vROPs the updating for the policy of
+		// a custom group should be done via separate call to the vROPs public API
+		updateCustomGroupPolicy(customGroupPayload, policyIdMap);
+	}
+
+	public void createMissingGroupTypes(CustomGroupDTO.Group customGroup) {
+		String customGroupResourceKind = customGroup.getResourceKey().getResourceKindKey();
+		if (!this.resourceKindExists(customGroupResourceKind, customGroup.getResourceKey().getAdapterKindKey())) {
+			this.createCustomGroupType(customGroupResourceKind);
+		}
+
+		customGroup.getMembershipDefinition().getRules().forEach(rule -> {
+			String resourceKindKey = rule.getResourceKindKey().getResourceKind();
+			String adapterKindKey = rule.getResourceKindKey().getAdapterKind();
+			if (!resourceKindExists(resourceKindKey, adapterKindKey)) {
+				this.createCustomGroupType(resourceKindKey);
+			}
+		});
+	}
+
+	public void createCustomGroupType(String customGroupType) {
+		logger.info(String.format("Custom group type doesn't exist. Creating custom group type '%s'", customGroupType));
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		CustomGroupTypeDTO customGroupTypeDto = new CustomGroupTypeDTO();
+		customGroupTypeDto.setName(customGroupType);
+		String customGroupTypePayload = deserializeCustomGroupType(customGroupTypeDto);
+		HttpEntity<String> entity = new HttpEntity<>(customGroupTypePayload, headers);
+		ResponseEntity<String> responseEntity;
+		try {
+			URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUP_TYPES_API).toString());
+			responseEntity = restTemplate.exchange(restUri, HttpMethod.POST, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Unable to create custom group type %s to vROPS : %s", customGroupType, e.getMessage()), e);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Unable to determine vROPs REST endpoint for custom group type %s : %s", customGroupType, e.getMessage()),
+					e);
+		}
+
+		HttpStatus status = responseEntity.getStatusCode();
+		if (HttpStatus.BAD_REQUEST.equals(status)) {
+			throw new RuntimeException(String.format("Error creating custom group type %s: Validation error in the group data", customGroupType));
+		}
+		if (!HttpStatus.CREATED.equals(status)) {
+			throw new RuntimeException(
+					String.format("Error creating custom group type %s: Remote REST service returned status code %s", customGroupType, status));
+		}
+	}
+
+	public ResourcesDTO getResourcesPerAdapterType(String adapterType) {
+		ResourcesDTO.PageInfo pageInfo = this.getResourcePerAdapterKindPageInfo(adapterType);
+
+		ResourcesDTO resource = new ResourcesDTO();
+		long totalRecordsCount = pageInfo.getTotalCount() == null ? 0 : pageInfo.getTotalCount();
+		long pageSize = pageInfo.getPageSize() == null ? 0 : pageInfo.getPageSize();
+		if (pageSize == 0) {
+			throw new RuntimeException(String.format("Invalid page size '0' received from vROPs for adapter type '%s'", adapterType));
+		}
+
+		long totalPages = Math.floorDiv(totalRecordsCount, pageSize);
+		// total pages should be 1 if the page size is exceeding the total records count
+		// (all results on 1 page)
+		totalPages = totalPages == 0 ? 1 : totalPages;
+		for (long currentPage = 0; currentPage < totalPages; currentPage++) {
+			ResourcesDTO currentResource = this.getResourcesPerAdapterType(adapterType, currentPage);
+			if (!currentResource.getResourceList().isEmpty()) {
+				resource.getResourceList().addAll(currentResource.getResourceList());
+			}
+		}
+
+		return resource;
+	}
+
+	public ResourcesDTO getResourcesPerAdapterType(String adapterKind, Long page) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		String endpointName = String.format(RESOURCES_LIST_PER_ADAPTER_KIND, adapterKind);
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(endpointName).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			if (page != null) {
+				uriBuilder.queryParam("page", page);
+			}
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ResourcesDTO();
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch resources for page %s. Message: %s", page, e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(
+					String.format("Error occurred when trying to build REST URI to fetch resources for page %s. Message: %s", page, e.getMessage()));
+		}
+		try {
+			return mapper.readValue(response.getBody(), ResourcesDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(
+					String.format("JSON mapping error while parsing the resources response for resource page %s. Message: %s", page, e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(
+					String.format("JSON processing error while parsing the resources response for resource page %s. Message: %s", page, e.getMessage()));
+		}
+	}
+
+	public ResourcesDTO getResources() {
+		ResourcesDTO.PageInfo pageInfo = this.getResourcePageInfo();
+
+		long totalRecordsCount = pageInfo.getTotalCount() == null ? 0 : pageInfo.getTotalCount();
+		long pageSize = pageInfo.getPageSize() == null ? 0 : pageInfo.getPageSize();
+		if (pageSize == 0) {
+			throw new RuntimeException("Invalid page size '0' received from vROPs");
+		}
+		ResourcesDTO resource = new ResourcesDTO();
+		long totalPages = Math.floorDiv(totalRecordsCount, pageSize);
+		// total pages should be 1 if the page size is exceeding the total records count
+		// (all results on 1 page)
+		totalPages = totalPages == 0 ? 1 : totalPages;
+		for (long currentPage = 0; currentPage < totalPages; currentPage++) {
+			ResourcesDTO currentResource = this.getResources(currentPage);
+			if (!currentResource.getResourceList().isEmpty()) {
+				resource.getResourceList().addAll(currentResource.getResourceList());
+			}
+		}
+
+		return resource;
+	}
+
+	public ResourcesDTO getResources(Long page) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(RESOURCES_LIST_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			if (page != null) {
+				uriBuilder.queryParam("page", page);
+			}
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ResourcesDTO();
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch resources. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch resources. Message: %s", e.getMessage()));
+		}
+		try {
+			return mapper.readValue(response.getBody(), ResourcesDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the resources response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the resources response. Message: %s", e.getMessage()));
+		}
+	}
+
+	public SupermetricDTO getAllSupermetrics() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		SupermetricDTO retVal = new SupermetricDTO();
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(SUPERMETRICS_LIST_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return retVal;
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch supermetrics list. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch supermetrics. Message: %s", e.getMessage()));
+		}
+		try {
+			retVal = mapper.readValue(response.getBody(), SupermetricDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the supermetrics list response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(
+					String.format("JSON processing error while parsing the supermetrics list resources response. Message: %s", e.getMessage()));
+		}
+		// Unescape special html characters in the names (returned by rest service)
+		retVal.getSuperMetrics().forEach(supermetric -> supermetric.setName(StringEscapeUtils.unescapeHtml4(supermetric.getName())));
+
+		return retVal;
+	}
+
+	public ViewDefinitionDTO getAllViewDefinitions() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		// Required header for internal API
+		headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		ViewDefinitionDTO retVal = new ViewDefinitionDTO();
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(VIEW_DEFINITIONS_LIST_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return retVal;
+			}
+			throw new RuntimeException(String.format("Error ocurred trying to fetching view definitions. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error building REST URI to fetch view definitions. Message: %s", e.getMessage()));
+		}
+		try {
+			retVal = mapper.readValue(response.getBody(), ViewDefinitionDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the view definitions response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the view definitions response. Message: %s", e.getMessage()));
+		}
+		// Unescape special html characters in the names (returned by rest service)
+		retVal.getViewDefinitions().forEach(view -> view.setName(StringEscapeUtils.unescapeHtml4(view.getName())));
+
+		return retVal;
+	}
+
+	public ReportDefinitionDTO getAllReportDefinitions() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		ReportDefinitionDTO retVal = new ReportDefinitionDTO();
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(REPORT_DEFINITIONS_LIST_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return retVal;
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch report definitions. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch report definitions. Message: %s", e.getMessage()));
+		}
+		try {
+			retVal = mapper.readValue(response.getBody(), ReportDefinitionDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the report definitions response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(
+					String.format("JSON processing error while parsing the supermetrics list report definitions response. Message: %s", e.getMessage()));
+		}
+		// Unescape special html characters in the names (returned by rest service)
+		retVal.getReportDefinitions().forEach(report -> report.setName(StringEscapeUtils.unescapeHtml4(report.getName())));
+
+		return retVal;
+	}
+
+	public List<AuthGroupDTO> findAllAuthGroups() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		List<AuthGroupDTO> retVal = new ArrayList<>();
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(AUTH_GROUPS_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return retVal;
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch auth groups. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to auth groups. Message: %s", e.getMessage()));
+		}
+		try {
+			AuthGroupsDTO authGroupDto = mapper.readValue(response.getBody(), AuthGroupsDTO.class);
+			return authGroupDto == null ? retVal : authGroupDto.getUserGroups();
+
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the auth groups response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the auth groups response. Message: %s", e.getMessage()));
+		}
+	}
+
+	public List<AuthUserDTO> findAllAuthUsers() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		List<AuthUserDTO> retVal = new ArrayList<>();
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(AUTH_USERS_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return retVal;
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch auth users. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to auth users. Message: %s", e.getMessage()));
+		}
+		try {
+			AuthUsersDTO authUsersDto = mapper.readValue(response.getBody(), AuthUsersDTO.class);
+			return authUsersDto == null ? retVal : authUsersDto.getUsers();
+
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the auth users response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the auth users response. Message: %s", e.getMessage()));
+		}
+	}
+
+	public AuthUserDTO findAllAuthUserByName(String name) {
+		List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
+
+		return allAuthUsers.stream().filter(item -> name.equals(item.getUsername())).findAny().orElse(null);
+	}
+
+	public AuthGroupDTO findAuthGroupByName(String name) {
+		List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
+
+		return allAuthGroups.stream().filter(item -> name.equals(item.getDisplayName())).findAny().orElse(null);
+	}
+
+	public List<AuthGroupDTO> findAuthGroupsByNames(List<String> names) {
+		List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
+
+		return allAuthGroups.stream().filter(item -> names.contains(item.getDisplayName())).collect(Collectors.toList());
+	}
+
+	public List<AuthUserDTO> findAuthUsersByNames(List<String> names) {
+		List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
+
+		return allAuthUsers.stream().filter(item -> names.contains(item.getUsername())).collect(Collectors.toList());
+	}
+
+	private Version getProductVersion() {
+		if (this.productVersion == null) {
+			this.productVersion = new Version(getVersion());
+		}
+
+		return this.productVersion;
+	}
+
+	private boolean isVrops82OrLater() {
+		Integer major = this.getProductVersion().getMajorVersion();
+		Integer minor = this.getProductVersion().getMinorVersion();
+
+		return (major != null && major >= VROPS_MAJOR_VERSION) && (minor != null && minor >= VROPS_MINOR_VERSION);
+	}
+
+	private PolicyDTO.Policy findPolicyByName(String policyName) {
+		// get all available policies in the target system
+		List<PolicyDTO.Policy> policies = getAllPolicies();
+
+		if (policies == null || policies.isEmpty()) {
+			throw new RuntimeException("Unable to retrieve policies from the target system");
+		}
+		Optional<PolicyDTO.Policy> foundPolicy = policies.stream().filter(item -> item.getName().equalsIgnoreCase(policyName)).findFirst();
+		if (!foundPolicy.isPresent()) {
+			throw new RuntimeException(String.format("Policy '%s' could not be found on the target system", policyName));
+		}
+
+		return foundPolicy.get();
+	}
+
+	private List<PolicyDTO.Policy> filterPoliciesByName(List<String> policyEntries) {
+		List<PolicyDTO.Policy> policies = getAllPolicies();
+		if (policies == null || policies.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		return policies.stream().filter(policy -> policyEntries.stream().anyMatch(entry -> entry.equalsIgnoreCase(policy.getName())))
+				.collect(Collectors.toList());
+	}
+
+	private void updateCustomGroupPolicy(String customGroupPayload, Map<String, String> policyIdMap) {
+		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
+		if (customGroup == null) {
+			return;
+		}
+
+		String policyId = customGroup.getPolicy();
+		if (StringUtils.isEmpty(policyId)) {
+			return;
+		}
+
+		String customGroupName = customGroup.getResourceKey().getName();
+		// throw an exception if the custom group has a policy but it cannot be found in
+		// the mapping data
+		if (!policyIdMap.containsKey(policyId)) {
+			throw new RuntimeException(String.format("The policy for custom group '%s' could not be found in the policy metadata file", customGroupName));
+		}
+
+		// find the custom group in the target system
+		customGroup = findCustomGroupByName(customGroupName);
+		if (customGroup == null) {
+			throw new RuntimeException(String.format("Custom group '%s' cannot be found on the target system", customGroupName));
+		}
+
+		// find policy in the target system
+		String policyName = policyIdMap.get(policyId);
+		PolicyDTO.Policy policy = findPolicyByName(policyName);
+		customGroup.setPolicy(policy.getId());
+
+		// prepare rest call payload
+		customGroupPayload = deserializeCustomGroup(customGroup);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(customGroupPayload, headers);
+		ResponseEntity<String> responseEntity;
+		logger.info("Setting policy for custom group '{}' to '{}'", customGroupName, policyName);
+		try {
+			URI restUri = new URI(getURIBuilder().setPath(CUSTOM_GROUPS_UPDATE_API).toString());
+			responseEntity = restTemplate.exchange(restUri, HttpMethod.PUT, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Unable to update policy for custom group '%s' : %s", customGroupName, e.getMessage()), e);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(
+					String.format("Unable to determine REST endpoint for updating policy for custom group '%s' : %s", customGroupName, e.getMessage()), e);
+		}
+
+		if (!HttpStatus.OK.equals(responseEntity.getStatusCode())) {
+			throw new RuntimeException(String.format("Error updating policy for custom group '%s': Remote REST service returned status code %s",
+					customGroupName, responseEntity.getStatusCode()));
+		}
+	}
+
+	private String setCustomGroupIdToNull(final String customGroupPayload) {
+		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
+		if (customGroup == null) {
+			return customGroupPayload;
+		}
+		customGroup.setId(null);
+		customGroup.setIdentifier(null);
+
+		return deserializeCustomGroup(customGroup);
+	}
+
+	private String updateCustomGroupId(CustomGroupDTO.Group customGroup, String customGroupPayload) {
+		CustomGroupDTO.Group serializedCustomGroup = serializeCustomGroup(customGroupPayload);
+		if (customGroup == null || serializedCustomGroup == null) {
+			return customGroupPayload;
+		}
+		CustomGroupDTO.Group existingCustomGroup = findCustomGroupByName(customGroup.getResourceKey().getName());
+		if (existingCustomGroup != null) {
+			// vROPs complains if in the membership rules' stat condition rules both
+			// stringValue and doubleValue are set in this case set the doubleValue to null
+			// and leave the stringValue set only
+			// (used for bacward compatibility with older versions of Build Tools for VMware
+			// Aria)
+			if (serializedCustomGroup.getMembershipDefinition() != null) {
+				serializedCustomGroup.getMembershipDefinition().getRules().stream().forEach(rule -> {
+					rule.getStatConditionRules().forEach(statCondition -> {
+						if (statCondition.getDoubleValue() != null && !StringUtils.isEmpty(statCondition.getStringValue())) {
+							statCondition.setDoubleValue(null);
+						}
+					});
+				});
+			}
+
+			serializedCustomGroup.setId(existingCustomGroup.getId());
+			serializedCustomGroup.setIdentifier(existingCustomGroup.getId());
+		}
+
+		return deserializeCustomGroup(serializedCustomGroup);
+	}
+
+	private CustomGroupDTO.Group serializeCustomGroup(String customGroupPayload) {
+		try {
+			return mapper.readValue(customGroupPayload, CustomGroupDTO.Group.class);
+		} catch (JsonMappingException e) {
+			logger.warn("Failed to serialize custom group, mapping error: {}", e.getMessage());
+			return null;
+		} catch (JsonProcessingException e) {
+			logger.warn("Failed to serialize custom group, JSON processing error: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	private String deserializeCustomGroup(CustomGroupDTO.Group customGroup) {
+		try {
+			return mapper.writeValueAsString(customGroup);
+		} catch (JsonMappingException e) {
+			logger.warn("Failed to de-serialize custom group, JSON mapping error: {}", e.getMessage());
+			return null;
+		} catch (JsonProcessingException e) {
+			logger.warn("Failed to de-serialize custom group, JSON processing error: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	private String deserializeCustomGroupType(CustomGroupTypeDTO customGroupType) {
+		try {
+			return mapper.writeValueAsString(customGroupType);
+		} catch (JsonMappingException e) {
+			logger.warn("Failed to de-serialize custom group type, JSON mapping error: {}", e.getMessage());
+			return null;
+		} catch (JsonProcessingException e) {
+			logger.warn("Failed to de-serialize custom group type, JSON processing error: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	private boolean customGroupExists(String customGroupPayload) {
+		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
+		if (customGroup == null) {
+			return false;
+		}
+
+		return findCustomGroupByName(customGroup.getResourceKey().getName()) != null;
+	}
+
+	/**
+	 * Find vROPS custom group by name.
+	 * 
+	 * @param List<String> - names of the custom groups.
+	 * @return List<CustomGroupDTO.CustomGroup> - list of the found custom groups.
+	 */
+	private List<CustomGroupDTO.Group> findCustomGroupsByNames(List<String> customGroupNames) {
+		List<CustomGroupDTO.Group> retVal = new ArrayList<>();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response = new ResponseEntity<>(HttpStatus.OK);
+		String groupInfo = customGroupNames != null && !customGroupNames.isEmpty() ? customGroupNames.stream().collect(Collectors.joining(",")) : "";
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(CUSTOM_GROUPS_FETCH_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			uriBuilder.queryParam("includePolicy", Boolean.TRUE.toString());
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ArrayList<>();
+			}
+			throw new RuntimeException(String.format("Error ocurred trying to find custom groups %s. Message: %s", groupInfo, e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error building REST URI to find custom groups %s. Message: %s", groupInfo, e.getMessage()));
+		}
+		CustomGroupDTO customGroup = new CustomGroupDTO();
+		try {
+			customGroup = mapper.readValue(response.getBody(), CustomGroupDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing custom group response: %s", e.getMessage()), e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing custom group response: %s", e.getMessage()), e);
+		}
+
+		// if no filtering groups are specified return all
+		if (customGroupNames == null || customGroupNames.isEmpty()) {
+			return customGroup.getGroups();
+		}
+
+		for (String name : customGroupNames) {
+			List<CustomGroupDTO.Group> foundGroups = customGroup.getGroups().stream().filter(item -> name.equalsIgnoreCase(item.getResourceKey().getName()))
+					.collect(Collectors.toList());
+			if (foundGroups.isEmpty()) {
+				continue;
+			}
+			retVal.addAll(foundGroups);
+		}
+
+		return retVal;
+	}
+
+	private CustomGroupDTO.Group findCustomGroupByName(String customGroupName) {
+		if (StringUtils.isEmpty(customGroupName)) {
+			return null;
+		}
+		List<CustomGroupDTO.Group> foundGroups = findCustomGroupsByNames(Arrays.asList(new String[] { customGroupName }));
+
+		return foundGroups.stream().findFirst().isPresent() ? foundGroups.stream().findFirst().get() : null;
+	}
+
+	private void importDefinitionToVrops(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
+		// validate definition sanity
+		if (!validateDefinition(definition, definitionType, dependentDefinitions)) {
+			logger.warn("Invalid definition of type {}, import will be skipped", definitionType);
+			return;
+		}
+
+		URI restUri = getDefinitionUri(definitionType, "");
+
+		// get definition Id on the target system
+		String definitionId = getDefinitionId(definition, definitionType);
+		HttpMethod method = HttpMethod.POST;
+		if (!StringUtils.isEmpty(definitionId)) {
+			updateDefinitionId(definition, definitionType, definitionId);
+			method = HttpMethod.PUT;
+		}
+
+		// update dependent definitions if any
+		updateDependentDefinitions(definition, definitionType, dependentDefinitions);
+
+		// If HTTP method is POST the id has to be removed from the pay load (limitation
+		// of the vROps REST API)
+		if (method.equals(HttpMethod.POST)) {
+			removeIdFromDefinitionPayload(definition, definitionType);
+		}
+
+		// If the resourceKindKey is missing definition cannot be created.
+		// In case of custom resourceKindKey it must be created as a new custom group
+		// type
+		String adapterKindKey = getDefinitionAdapterKindKey(definition, definitionType);
+		String resourceKindKey = getDefinitionResourceKindKey(definition, definitionType);
+		if (adapterKindKey != null && resourceKindKey != null && !resourceKindExists(resourceKindKey, adapterKindKey)) {
+			createCustomGroupType(resourceKindKey);
+		}
+
+		String definitionPayload;
+		try {
+			definitionPayload = mapper.writeValueAsString(definition);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("Error serializing definition type %s JSON mapping error : %s", definitionType, e.getMessage()), e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("Error serializing definition type %s JSON processing error: %s", definitionType, e.getMessage()), e);
+		}
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(definitionPayload, headers);
+		ResponseEntity<String> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+		String definitionName = getDefinitionName(definition, definitionType);
+
+		try {
+			responseEntity = restTemplate.exchange(restUri, method, entity, String.class);
+		} catch (RestClientException e) {
+			if (e.getMessage().contains(HttpStatus.NOT_FOUND.toString())) {
+				throw new RuntimeException(String.format("Error importing %s of type %s to vROPS, the REST service could not validate definition data : %s",
+						definitionName, definitionType, e.getMessage()), e);
+
+			}
+			throw new RuntimeException(String.format("Error importing %s of type %s to vROPS : %s", definitionName, definitionType, e.getMessage()), e);
+		}
+
+		if (HttpMethod.POST.equals(method) && !HttpStatus.CREATED.equals(responseEntity.getStatusCode())) {
+			throw new RuntimeException(String.format("Error creating %s %s: remote REST service returned status code %s", definitionType, definitionName,
+					responseEntity.getStatusCode()));
+		}
+		if (HttpMethod.PUT.equals(method) && !HttpStatus.OK.equals(responseEntity.getStatusCode())) {
+			throw new RuntimeException(String.format("Error updating %s %s: remote REST service returned status code %s", definitionType, definitionName,
+					responseEntity.getStatusCode()));
+		}
+	}
+
+	private String getDefinitionAdapterKindKey(Object definition, VropsPackageMemberType definitionType) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				return ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey();
+			}
+			case SYMPTOM_DEFINITION: {
+				return ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey();
+			}
+			case RECOMMENDATION: {
+				return null;
+			}
+			default: {
+				logger.warn("Invalid definition type {}", definitionType);
+			}
+		}
+
+		return null;
+	}
+
+	private String getDefinitionResourceKindKey(Object definition, VropsPackageMemberType definitionType) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				return ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey();
+			}
+			case SYMPTOM_DEFINITION: {
+				return ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey();
+			}
+			case RECOMMENDATION: {
+				return null;
+			}
+			default: {
+				logger.warn("Invalid definition type {}", definitionType);
+			}
+		}
+
+		return null;
+	}
+
+	private String getDefinitionName(Object definition, VropsPackageMemberType definitionType) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				return ((AlertDefinitionDTO.AlertDefinition) definition).getName();
+			}
+			case SYMPTOM_DEFINITION: {
+				return ((SymptomDefinitionDTO.SymptomDefinition) definition).getName();
+			}
+			case RECOMMENDATION: {
+				return ((RecommendationDTO.Recommendation) definition).getDescription();
+			}
+			default: {
+				logger.warn("Invalid definition type {}", definitionType);
+			}
+		}
+
+		return null;
+	}
+
+	private boolean validateDefinition(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
+		if (VropsPackageMemberType.SYMPTOM_DEFINITION.equals(definitionType)) {
+			return validateSymptomDefinition(definition);
+		}
+		if (VropsPackageMemberType.ALERT_DEFINITION.equals(definitionType)) {
+			return validateAlertDefinition(definition, dependentDefinitions);
+		}
+
+		return true;
+	}
+
+	private boolean validateSymptomDefinition(Object definition) {
+		if (!(definition instanceof SymptomDefinitionDTO.SymptomDefinition)) {
+			return false;
+		}
+		String adapterKind = ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey() != null
+				? ((SymptomDefinitionDTO.SymptomDefinition) definition).getAdapterKindKey().trim()
+				: null;
+		String resourceKind = ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey() != null
+				? ((SymptomDefinitionDTO.SymptomDefinition) definition).getResourceKindKey().trim()
+				: null;
+
+		// check whether adapter kind is present
+		if (adapterKind == null) {
+			logger.error("Invalid Symptom definition: adapterKindKeyNode field is required and must be a string value. Symptom definition: '{}'",
+					((SymptomDefinitionDTO.SymptomDefinition) definition).getName());
+			return false;
+		}
+
+		// adapterKindKeyNode equals to all is not supported by the vROps Rest API
+		// (version 8.0.0.14857692), it responds with httpStatusCode: 404, "message":"No
+		// such Adapter Kind - All."
+		if ("all".equalsIgnoreCase(adapterKind)) {
+			logger.error("Symptoms definitions for all the adapter types are not supported. Symptom definition: '{}'",
+					((SymptomDefinitionDTO.SymptomDefinition) definition).getName());
+			return false;
+		}
+
+		// check whether the adapter kind exists on the target system
+		if (!adapterKindKeyExists(adapterKind)) {
+			logger.error(
+					"Adapter kind key '{}' for symptom definition '{}' is not present on the target system, please check whether content pack containing adapter kind '{}' is installed there",
+					adapterKind, ((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), adapterKind);
+			return false;
+		}
+
+		// check whether the resource kind exists on the target system
+		if (!resourceKindExists(resourceKind, adapterKind)) {
+			logger.warn(
+					"Resource kind key '{}' for symptom definition '{}' with adapter kind '{}' is not present on the target system, please check whether content pack containing resource kind '{}' is installed there",
+					resourceKind, ((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), adapterKind, resourceKind);
+		}
+
+		return true;
+	}
+
+	private boolean validateAlertDefinition(Object definition, Map<String, Object> dependentDefinitions) {
+		if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
+			return false;
+		}
+		String resourceKind = ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey() != null
+				? ((AlertDefinitionDTO.AlertDefinition) definition).getResourceKindKey().trim()
+				: null;
+		String adapterKind = ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey() != null
+				? ((AlertDefinitionDTO.AlertDefinition) definition).getAdapterKindKey().trim()
+				: null;
+
+		// check whether the adapter kind exists on the target system
+		if (!adapterKindKeyExists(adapterKind)) {
+			logger.error(
+					"Adapter kind key '{}' for alert definition '{}' is not present on the target system, please check whether content pack containing adapter kind '{}' is installed there",
+					adapterKind, ((AlertDefinitionDTO.AlertDefinition) definition).getName(), adapterKind);
+			return false;
+		}
+
+		// check whether the resource kind exists on the target system
+		if (!resourceKindExists(resourceKind, adapterKind)) {
+			logger.warn(
+					"Resource kind key '{}' for alert definition '{}' with adapter kind '{}' is not present on the target system, please check whether content pack containing resource kind '{}' is installed there",
+					resourceKind, ((AlertDefinitionDTO.AlertDefinition) definition).getName(), adapterKind, resourceKind);
+		}
+
+		return validateDependentDefinitions(definition, dependentDefinitions);
+	}
+
+	private boolean validateDependentDefinitions(Object definition, Map<String, Object> dependentDefinitions) {
+		if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
+			return false;
+		}
+		if (dependentDefinitions == null || dependentDefinitions.isEmpty()) {
+			return true;
+		}
+		String alertDefName = ((AlertDefinitionDTO.AlertDefinition) definition).getName();
+		for (State state : ((AlertDefinitionDTO.AlertDefinition) definition).getStates()) {
+			if (state.getBaseSymptomSet() == null) {
+				continue;
+			}
+			// check base symptom set's symptom definition ids
+			for (String symptomDefinitionId : state.getBaseSymptomSet().getSymptomDefinitionIds()) {
+				if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
+					continue;
+				}
+				Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
+				if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
+					continue;
+				}
+				String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
+				String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
+				if (StringUtils.isEmpty(dependentSymptomDefId)) {
+					logger.error("Dependent base symptom definition '{}' for alert definition '{}' is missing on the target system", dependentSymptomDefName,
+							alertDefName);
+					return false;
+				}
+			}
+
+			// check symptom set's symptom definition ids
+			for (SymptomSet symptomSet : state.getBaseSymptomSet().getSymptomSets()) {
+				for (String symptomDefinitionId : symptomSet.getSymptomDefinitionIds()) {
+					if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
+						continue;
+					}
+					Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
+					if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
+						continue;
+					}
+					String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
+					String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
+					if (StringUtils.isEmpty(dependentSymptomDefId)) {
+						logger.error("Dependent symptom definition '{}' for alert definition '{}' is missing on the target system", dependentSymptomDefName,
+								alertDefName);
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+
+	private boolean adapterKindKeyExists(String adapterKindKey) {
+		// get all adapter kinds on the target system
+		AdapterKindDTO adapterKindOject = getAllAdapterKindData();
+		if (adapterKindOject == null) {
+			return false;
+		}
+		if (StringUtils.isEmpty(adapterKindKey)) {
+			return false;
+		}
+
+		return adapterKindOject.getAdapterKind().stream().anyMatch(item -> adapterKindKey.equalsIgnoreCase(item.getKey()));
+	}
+
+	private AdapterKindDTO getAllAdapterKindData() {
+		URI uri;
+		try {
+			uri = new URI(getURIBuilder().setPath(ADAPTER_KINDS_API).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error fetching adapter kinds from target vROPs: %s", e.getMessage()), e);
+		}
+
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(
+					String.format("Error locating adapter kinds from target vROPs, remote REST service returned: %s", response.getStatusCode()));
+		}
+		try {
+			return mapper.readValue(response.getBody(), AdapterKindDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error during parsing of adapter kind data: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error during parsing of adapter kind data: %s", e.getMessage()));
+		}
+	}
+
+	private ResourcesDTO.PageInfo getResourcePerAdapterKindPageInfo(String adapterKind) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		String endpointName = String.format(RESOURCES_LIST_PER_ADAPTER_KIND, adapterKind);
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(endpointName).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ResourcesDTO.PageInfo();
+			}
+			throw new RuntimeException(
+					String.format("Error occurred when trying to fetch resources page info for adapter kind '%s'. Message: %s", adapterKind, e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(
+					String.format("Error occurred when trying to build REST URI to fetch resources page info for adapter kind '%s'. Message: %s", adapterKind,
+							e.getMessage()));
+		}
+		try {
+			ResourcesDTO resource = mapper.readValue(response.getBody(), ResourcesDTO.class);
+			if (resource == null) {
+				return new ResourcesDTO.PageInfo();
+			}
+
+			return resource.getPageInfo();
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the resources page info response for adapter kind '%s'. Message: %s",
+					adapterKind, e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the resources page info response for adapter kind '%s'. Message: %s",
+					adapterKind, e.getMessage()));
+		}
+	}
+
+	private ResourcesDTO.PageInfo getResourcePageInfo() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(RESOURCES_LIST_API).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			URI restUri = uriBuilder.build().toUri();
+			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				return new ResourcesDTO.PageInfo();
+			}
+			throw new RuntimeException(String.format("Error occurred when trying to fetch resources page info. Message: %s", e.getMessage()));
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Error occurred when trying to build REST URI to fetch resources page info. Message: %s", e.getMessage()));
+		}
+		try {
+			ResourcesDTO resource = mapper.readValue(response.getBody(), ResourcesDTO.class);
+			if (resource == null) {
+				return new ResourcesDTO.PageInfo();
+			}
+
+			return resource.getPageInfo();
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error while parsing the resources page info response. Message: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error while parsing the resources page info response. Message: %s", e.getMessage()));
+		}
+	}
+
+	private boolean resourceKindExists(String resourceKindKey, String adapterKindKey) {
+		if (resourceKindKey.equals(VROPS_KIND_ALL) && adapterKindKey.equals(VROPS_KIND_ALL)) {
+			return true;
+		}
+
+		if (StringUtils.isEmpty(adapterKindKey)) {
+			return false;
+		}
+
+		// get all resource kinds on the target system
+		ResourceKindDTO resourceKindObject = getAllResourceKinds(adapterKindKey);
+		if (resourceKindObject == null) {
+			return false;
+		}
+
+		return resourceKindObject.getResourceKind().stream().anyMatch(item -> resourceKindKey.equalsIgnoreCase(item.getKey()));
+	}
+
+	private ResourceKindDTO getAllResourceKinds(String adapterKindKey) {
+		if (StringUtils.isEmpty(adapterKindKey)) {
+			return new ResourceKindDTO();
+		}
+
+		String endpointName = String.format(RESOURCE_KINDS_API, adapterKindKey);
+		URI uri;
+		try {
+			uri = new URI(getURIBuilder().setPath(endpointName).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error fetching resource kinds for adapter kind %s from target vROPs: %s", adapterKindKey, e.getMessage()),
+					e);
+		}
+
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(String.format("Error locating resource kinds for adapter kind %s from target vROPs, remote REST service returned: %s",
+					adapterKindKey, response.getStatusCode()));
+		}
+		try {
+			return mapper.readValue(response.getBody(), ResourceKindDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error during parsing of data for adapter kind %s : %s", adapterKindKey, e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error during parsing of data for adapter kind %s : %s", adapterKindKey, e.getMessage()));
+		}
+	}
+
+	private void updateDependentDefinitions(Object definition, VropsPackageMemberType definitionType, Map<String, Object> dependentDefinitions) {
+		// Only for alert definitions need to update dependencies
+		if (!VropsPackageMemberType.ALERT_DEFINITION.equals(definitionType)) {
+			return;
+		}
+		if (definition == null) {
+			return;
+		}
+		if (!(definition instanceof AlertDefinitionDTO.AlertDefinition)) {
+			return;
+		}
+
+		if (dependentDefinitions == null || dependentDefinitions.isEmpty()) {
+			return;
+		}
+
+		for (State state : ((AlertDefinitionDTO.AlertDefinition) definition).getStates()) {
+			if (state.getBaseSymptomSet() == null) {
+				continue;
+			}
+			// update base symptom set's symptom definition ids
+			List<String> symptomDefIds = new ArrayList<>();
+			for (String symptomDefinitionId : state.getBaseSymptomSet().getSymptomDefinitionIds()) {
+				if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
+					continue;
+				}
+				Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
+				if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
+					continue;
+				}
+				String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
+				String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
+				symptomDefIds.add(dependentSymptomDefId);
+			}
+			if (!symptomDefIds.isEmpty()) {
+				state.getBaseSymptomSet().setSymptomDefinitionIds(symptomDefIds);
+			}
+
+			// update symptom set's symptom definition ids
+			List<SymptomSet> targetSymptomSets = new ArrayList<>();
+			for (SymptomSet symptomSet : state.getBaseSymptomSet().getSymptomSets()) {
+				symptomDefIds = new ArrayList<>();
+				for (String symptomDefinitionId : symptomSet.getSymptomDefinitionIds()) {
+					if (!dependentDefinitions.containsKey(symptomDefinitionId)) {
+						continue;
+					}
+					Object dependentSymptomDef = dependentDefinitions.get(symptomDefinitionId);
+					if (!(dependentSymptomDef instanceof SymptomDefinitionDTO.SymptomDefinition)) {
+						continue;
+					}
+					String dependentSymptomDefName = ((SymptomDefinitionDTO.SymptomDefinition) dependentSymptomDef).getName();
+					String dependentSymptomDefId = getDefinitionIdByName(dependentSymptomDefName, VropsPackageMemberType.SYMPTOM_DEFINITION);
+					symptomDefIds.add(dependentSymptomDefId);
+				}
+				if (!symptomDefIds.isEmpty()) {
+					symptomSet.setSymptomDefinitionIds(symptomDefIds);
+				}
+				targetSymptomSets.add(symptomSet);
+			}
+			if (!targetSymptomSets.isEmpty()) {
+				state.getBaseSymptomSet().setSymptomSets(targetSymptomSets);
+			}
+		}
+	}
+
+	private void removeIdFromDefinitionPayload(Object definition, VropsPackageMemberType definitionType) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				((AlertDefinitionDTO.AlertDefinition) definition).setId(null);
+				break;
+			}
+			case SYMPTOM_DEFINITION: {
+				((SymptomDefinitionDTO.SymptomDefinition) definition).setId(null);
+				break;
+			}
+			case RECOMMENDATION: {
+				((RecommendationDTO.Recommendation) definition).setId(null);
+				break;
+			}
+			default: {
+				logger.warn("Invalid definition type {}", definitionType);
+			}
+		}
+	}
+
+	private String getDefinitionId(Object definition, VropsPackageMemberType definitionType) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				return getDefinitionIdByName(((AlertDefinitionDTO.AlertDefinition) definition).getName(), definitionType);
+			}
+			case SYMPTOM_DEFINITION: {
+				return getDefinitionIdByName(((SymptomDefinitionDTO.SymptomDefinition) definition).getName(), definitionType);
+			}
+			case RECOMMENDATION: {
+				return getDefinitionIdByName(((RecommendationDTO.Recommendation) definition).getDescription(), definitionType);
+			}
+			default: {
+				return null;
+			}
+		}
+	}
+
+	private void updateDefinitionId(Object definition, VropsPackageMemberType definitionType, String definitionId) {
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				((AlertDefinitionDTO.AlertDefinition) definition).setId(definitionId);
+				break;
+			}
+			case SYMPTOM_DEFINITION: {
+				((SymptomDefinitionDTO.SymptomDefinition) definition).setId(definitionId);
+				break;
+			}
+			case RECOMMENDATION: {
+				((RecommendationDTO.Recommendation) definition).setId(definitionId);
+				break;
+			}
+			default: {
+				logger.warn("Unknown definition type {}", definitionType);
+			}
+		}
+	}
+
+	private String getDefinitionIdByName(String definitionName, VropsPackageMemberType definitionType) {
+		String restUri;
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				restUri = ALERT_DEFS_API;
+				break;
+			}
+			case SYMPTOM_DEFINITION: {
+				restUri = SYMPTOM_DEFS_API;
+				break;
+			}
+			case RECOMMENDATION: {
+				restUri = RECOMMENDATIONS_API;
+				break;
+			}
+			default: {
+				throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
+			}
+		}
+		URI uri;
+		try {
+			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(restUri).toString()));
+			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
+			uri = uriBuilder.build().toUri();
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		ResponseEntity<String> response;
+		try {
+			response = restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error finding %s of %s: %s", definitionName, definitionType, e.getMessage()), e);
+		}
+
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(
+					String.format("Error finding %s of type %s: remote REST service returned %s", definitionType, definitionName, response.getStatusCode()));
+		}
+
+		try {
+			switch (definitionType) {
+				case ALERT_DEFINITION: {
+					AlertDefinitionDTO alertDefinitions = mapper.readValue(response.getBody(), AlertDefinitionDTO.class);
+					List<AlertDefinitionDTO.AlertDefinition> filtered = alertDefinitions.getAlertDefinitions().stream()
+							.filter(item -> definitionName.equalsIgnoreCase(item.getName())).collect(Collectors.toList());
+					Optional<AlertDefinitionDTO.AlertDefinition> value = filtered.stream().findFirst();
+
+					return value.isPresent() ? value.get().getId() : null;
+				}
+				case SYMPTOM_DEFINITION: {
+					SymptomDefinitionDTO symptomDefinitions = mapper.readValue(response.getBody(), SymptomDefinitionDTO.class);
+					List<SymptomDefinitionDTO.SymptomDefinition> filtered = symptomDefinitions.getSymptomDefinitions().stream()
+							.filter(item -> definitionName.equalsIgnoreCase(item.getName())).collect(Collectors.toList());
+					Optional<SymptomDefinitionDTO.SymptomDefinition> value = filtered.stream().findFirst();
+
+					return value.isPresent() ? value.get().getId() : null;
+				}
+				case RECOMMENDATION: {
+					RecommendationDTO recommendations = mapper.readValue(response.getBody(), RecommendationDTO.class);
+					List<RecommendationDTO.Recommendation> filtered = recommendations.getRecommendations().stream()
+							.filter(item -> definitionName.equalsIgnoreCase(item.getDescription())).collect(Collectors.toList());
+					Optional<RecommendationDTO.Recommendation> value = filtered.stream().findFirst();
+
+					return value.isPresent() ? value.get().getId() : null;
+				}
+				default: {
+					throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
+				}
+			}
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("JSON mapping error during mapping of definitions data: %s", e.getMessage()), e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("JSON processing error during processing of definitions data: %s", e.getMessage()), e);
+		}
+	}
+
+	private URI getDefinitionUri(VropsPackageMemberType definitionType, String id) {
+		String restUri;
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				restUri = ALERT_DEFS_API;
+				break;
+			}
+			case SYMPTOM_DEFINITION: {
+				restUri = SYMPTOM_DEFS_API;
+				break;
+			}
+			case RECOMMENDATION: {
+				restUri = RECOMMENDATIONS_API;
+				break;
+			}
+			default: {
+				throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
+			}
+		}
+		restUri = restUri + id;
+		try {
+			return new URI(getURIBuilder().setPath(restUri).toString());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private URI getDefinitionUri(VropsPackageMemberType definitionType) {
+		String restUri;
+		switch (definitionType) {
+			case ALERT_DEFINITION: {
+				restUri = ALERT_DEFS_API;
+				break;
+			}
+			case SYMPTOM_DEFINITION: {
+				restUri = SYMPTOM_DEFS_API;
+				break;
+			}
+			case RECOMMENDATION: {
+				restUri = RECOMMENDATIONS_API;
+				break;
+			}
+			default: {
+				throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
+			}
+		}
+		try {
+			return new URI(getURIBuilder().setPath(restUri).addParameter("pageSize", String.valueOf(DEFAULT_PAGE_SIZE)).toString());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	private PolicyDTO deserializePolicies(String policiesJson) {
+		if (StringUtils.isEmpty(policiesJson)) {
+			return null;
+		}
+
+		try {
+			return mapper.readValue(policiesJson, PolicyDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("Unable to deserialize policies from JSON string, JSON mapping error: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("Unable to deserialize policies from JSON string, JSON processing error: %s", e.getMessage()));
+		}
+	}
+
+	private Object deserializeDefinitions(VropsPackageMemberType definitionType, String definitionJson) {
+		if (StringUtils.isEmpty(definitionJson)) {
+			return null;
+		}
+		try {
+			switch (definitionType) {
+				case ALERT_DEFINITION: {
+					return mapper.readValue(definitionJson, AlertDefinitionDTO.class);
+				}
+				case SYMPTOM_DEFINITION: {
+					return mapper.readValue(definitionJson, SymptomDefinitionDTO.class);
+				}
+				case RECOMMENDATION: {
+					return mapper.readValue(definitionJson, RecommendationDTO.class);
+				}
+				default: {
+					throw new RuntimeException(String.format("Unsupported definition type %s", definitionType.name()));
+				}
+			}
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("Unable to deserialize definition of type %s from JSON string, JSON mapping error: %s",
+					definitionType.name(), e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("Unable to deserialize definition of type %s from JSON string, JSON processing error: %s",
+					definitionType.name(), e.getMessage()));
+		}
+	}
 
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
@@ -77,58 +77,196 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrops.ViewDefinitionDTO;
 
 @SuppressWarnings("deprecation")
 public class RestClientVrops extends RestClient {
+	/**
+	 * logger.
+	 */
 	private final Logger logger = LoggerFactory.getLogger(RestClientVrops.class);
 
+	/**
+	 * PUBLIC_API_PREFIX.
+	 */
 	private static final String PUBLIC_API_PREFIX = "/suite-api/api/";
+
+	/**
+	 * INTERNAL_API_PREFIX.
+	 */
 	private static final String INTERNAL_API_PREFIX = "/suite-api/internal/";
+
+	/**
+	 * ALERT_DEFS_API.
+	 */
 	private static final String ALERT_DEFS_API = PUBLIC_API_PREFIX + "alertdefinitions/";
+
+	/**
+	 * SYMPTOM_DEFS_API.
+	 */
 	private static final String SYMPTOM_DEFS_API = PUBLIC_API_PREFIX + "symptomdefinitions/";
+
+	/**
+	 * POLICIES_API.
+	 */
 	private static final String POLICIES_API = INTERNAL_API_PREFIX + "policies/";
+
+	/**
+	 * RECOMMENDATIONS_API.
+	 */
 	private static final String RECOMMENDATIONS_API = PUBLIC_API_PREFIX + "recommendations/";
+
+	/**
+	 * RESOURCES_API.
+	 */
 	private static final String RESOURCES_API = PUBLIC_API_PREFIX + "resources/";
+
+	/**
+	 * CUSTOM_GROUPS_FETCH_API.
+	 */
 	private static final String CUSTOM_GROUPS_FETCH_API = RESOURCES_API + "groups";
+
+	/**
+	 * CUSTOM_GROUPS_UPDATE_API.
+	 */
 	private static final String CUSTOM_GROUPS_UPDATE_API = PUBLIC_API_PREFIX + "resources/groups";
+
+	/**
+	 * CUSTOM_GROUP_TYPES_API.
+	 */
 	private static final String CUSTOM_GROUP_TYPES_API = PUBLIC_API_PREFIX + "resources/groups/types";
+
+	/**
+	 * RESOURCES_LIST_API.
+	 */
 	private static final String RESOURCES_LIST_API = PUBLIC_API_PREFIX + "resources";
+
+	/**
+	 * ADAPTER_KINDS_API.
+	 */
 	private static final String ADAPTER_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds";
+
+	/**
+	 * RESOURCE_KINDS_API.
+	 */
 	private static final String RESOURCE_KINDS_API = PUBLIC_API_PREFIX + "adapterkinds/%s/resourcekinds";
+
+	/**
+	 * RESOURCES_LIST_PER_ADAPTER_KIND.
+	 */
 	private static final String RESOURCES_LIST_PER_ADAPTER_KIND = PUBLIC_API_PREFIX + "adapterkinds/%s/resources";
+
+	/**
+	 * SUPERMETRICS_LIST_API.
+	 */
 	private static final String SUPERMETRICS_LIST_API = PUBLIC_API_PREFIX + "supermetrics";
+
+	/**
+	 * REPORT_DEFINITIONS_LIST_API.
+	 */
 	private static final String REPORT_DEFINITIONS_LIST_API = PUBLIC_API_PREFIX + "reportdefinitions";
+
+	/**
+	 * VIEW_DEFINITIONS_LIST_API.
+	 */
 	private static final String VIEW_DEFINITIONS_LIST_API = INTERNAL_API_PREFIX + "viewdefinitions";
+
+	/**
+	 * INTERNAL_API_HEADER_NAME.
+	 */
 	private static final String INTERNAL_API_HEADER_NAME = "X-vRealizeOps-API-use-unsupported";
+
+	/**
+	 * AUTH_GROUPS_API.
+	 */
 	private static final String AUTH_GROUPS_API = PUBLIC_API_PREFIX + "/auth/usergroups";
+
+	/**
+	 * AUTH_USERS_API.
+	 */
 	private static final String AUTH_USERS_API = PUBLIC_API_PREFIX + "/auth/users";
+
+	/**
+	 * DEFAULT_PAGE_SIZE.
+	 */
 	private static final int DEFAULT_PAGE_SIZE = 10000;
+
+	/**
+	 * VROPS_MAJOR_VERSION.
+	 */
 	private static final int VROPS_MAJOR_VERSION = 8;
+
+	/**
+	 * VROPS_MINOR_VERSION.
+	 */
 	private static final int VROPS_MINOR_VERSION = 2;
+
+	/**
+	 * VROPS_KIND_ALL.
+	 */
 	private static final String VROPS_KIND_ALL = "ALL";
 
+	/**
+	 * configuration.
+	 */
 	private ConfigurationVrops configuration;
+
+	/**
+	 * restTemplate.
+	 */
 	private RestTemplate restTemplate;
+	
+	/**
+	 * mapper.
+	 */
 	private ObjectMapper mapper = new ObjectMapper();
+	
+	/**
+	 * productVersion.
+	 */
 	private Version productVersion = null;
 
+	/**
+	 * RestClientVrops.
+	 * @param configuration
+	 * @param restTemplate
+	 */	
 	public RestClientVrops(ConfigurationVrops configuration, RestTemplate restTemplate) {
 		this.configuration = configuration;
 		this.restTemplate = restTemplate;
 	}
 
+	/**
+	 * getRestTemplate.
+	 * 
+	 * @return restTemplate
+	 */
 	public RestTemplate getRestTemplate() {
 		return restTemplate;
 	}
 
+	/**
+	 * getConfiguration.
+	 * 
+	 * @return configuration
+	 */
 	@Override
 	protected Configuration getConfiguration() {
 		return configuration;
 	}
 
+	/**
+	 * getURIBuilder.
+	 * 
+	 * @return URIBuilder
+	 */
 	@Override
 	protected URIBuilder getURIBuilder() {
 		ConfigurationVrops config = (ConfigurationVrops) getConfiguration();
 		return new URIBuilder().setScheme("https").setHost(config.getHost()).setPort(config.getHttpPort());
 	}
 
+	/**
+	 * getVersion.
+	 * 
+	 * @return version
+	 */
 	@Override
 	public String getVersion() {
 		URI url = getURI(getURIBuilder().setPath(PUBLIC_API_PREFIX + "versions/current"));
@@ -150,7 +288,7 @@ public class RestClientVrops extends RestClient {
 	}
 
 	/**
-	 * Import policies from a zip file
+	 * Import policies from a zip file.
 	 * 
 	 * @param file       policy zip file as byte[]
 	 * @param policyName List of strings that represent the custom groups policy
@@ -185,7 +323,7 @@ public class RestClientVrops extends RestClient {
 	}
 
 	/**
-	 * Export a zip file per policies, filtered by name
+	 * Export a zip file per policies, filtered by name.
 	 * 
 	 * @param policyEntries Names of the policies to be exported
 	 * @return a list of policies containing a zip file as byte[], name and id of
@@ -211,6 +349,11 @@ public class RestClientVrops extends RestClient {
 		return policies;
 	}
 
+	/**
+	 * Returns all policies.
+	 * 
+	 * @return a list of policies
+	 */
 	public List<PolicyDTO.Policy> getAllPolicies() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -237,6 +380,13 @@ public class RestClientVrops extends RestClient {
 		return policyDto == null ? Collections.emptyList() : policyDto.getPolicies();
 	}
 
+	/**
+	 * Returns the content for certain policy.
+	 * 
+	 * @param policy
+	 * 
+	 * @return policy
+	 */
 	public PolicyDTO.Policy getPolicyContent(PolicyDTO.Policy policy) {
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
 		uriBuilder.queryParam("id", policy.getId());
@@ -442,6 +592,11 @@ public class RestClientVrops extends RestClient {
 		updateCustomGroupPolicy(customGroupPayload, policyIdMap);
 	}
 
+	/**
+	 * Create the missing group types in vROPs.
+	 * 
+	 * @param customGroup - custom group DTO
+	 */	
 	public void createMissingGroupTypes(CustomGroupDTO.Group customGroup) {
 		String customGroupResourceKind = customGroup.getResourceKey().getResourceKindKey();
 		if (!this.resourceKindExists(customGroupResourceKind, customGroup.getResourceKey().getAdapterKindKey())) {
@@ -457,6 +612,11 @@ public class RestClientVrops extends RestClient {
 		});
 	}
 
+	/**
+	 * Create the custom group type in vROPs.
+	 * 
+	 * @param customGroupType - custom group type.
+	 */		
 	public void createCustomGroupType(String customGroupType) {
 		logger.info(String.format("Custom group type doesn't exist. Creating custom group type '%s'", customGroupType));
 		HttpHeaders headers = new HttpHeaders();
@@ -486,6 +646,12 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Get resources per vROPs adapter type.
+	 * 
+	 * @param adapterType - adapter type
+	 * @return resource DTO.
+	 */		
 	public ResourcesDTO getResourcesPerAdapterType(final String adapterType) {
 		ResourcesDTO.PageInfo pageInfo = this.getResourcePerAdapterKindPageInfo(adapterType);
 
@@ -510,12 +676,19 @@ public class RestClientVrops extends RestClient {
 		return resource;
 	}
 
-	public ResourcesDTO getResourcesPerAdapterType(final String adapterKind, final Long page) {
+	/**
+	 * Get resources per vROPs adapter type and page.
+	 * 
+	 * @param adapterType - adapter type.
+	 * @param page - page to retrieve from.
+	 * @return resource DTO.
+	 */		
+	public ResourcesDTO getResourcesPerAdapterType(final String adapterType, final Long page) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 		HttpEntity<String> entity = new HttpEntity<>(headers);
 		ResponseEntity<String> response;
-		String endpointName = String.format(RESOURCES_LIST_PER_ADAPTER_KIND, adapterKind);
+		String endpointName = String.format(RESOURCES_LIST_PER_ADAPTER_KIND, adapterType);
 		try {
 			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(endpointName).toString()));
 			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
@@ -544,6 +717,10 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Get all vROPs resources.
+	 * @return resource DTO.
+	 */		
 	public ResourcesDTO getResources() {
 		ResourcesDTO.PageInfo pageInfo = this.getResourcePageInfo();
 
@@ -567,6 +744,12 @@ public class RestClientVrops extends RestClient {
 		return resource;
 	}
 
+	/**
+	 * Get all vROPs resources for page.
+	 * 
+	 * @param page - page to retrieve from.
+	 * @return resource DTO.
+	 */		
 	public ResourcesDTO getResources(final Long page) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -597,6 +780,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Get all vROPs super metrics.
+	 * 
+	 * @return supermetric DTO.
+	 */			
 	public SupermetricDTO getAllSupermetrics() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -630,6 +818,11 @@ public class RestClientVrops extends RestClient {
 		return retVal;
 	}
 
+	/**
+	 * Get all vROPs view definitions.
+	 * 
+	 * @return ViewDefinitionDTO
+	 */			
 	public ViewDefinitionDTO getAllViewDefinitions() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -664,6 +857,11 @@ public class RestClientVrops extends RestClient {
 		return retVal;
 	}
 
+	/**
+	 * Get all vROPs report definitions.
+	 * 
+	 * @return ReportDefinitionDTO
+	 */	
 	public ReportDefinitionDTO getAllReportDefinitions() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -697,6 +895,11 @@ public class RestClientVrops extends RestClient {
 		return retVal;
 	}
 
+	/**
+	 * Get all vROPs auth groups.
+	 * 
+	 * @return list of AuthGroupDTO
+	 */		
 	public List<AuthGroupDTO> findAllAuthGroups() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -727,6 +930,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Get all vROPs auth users.
+	 * 
+	 * @return list of AuthUserDTO
+	 */		
 	public List<AuthUserDTO> findAllAuthUsers() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
@@ -757,30 +965,59 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Get vROPs auth user by name.
+	 * @param name
+	 * 
+	 * @return AuthUserDTO
+	 */			
 	public AuthUserDTO findAllAuthUserByName(String name) {
 		List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
 
 		return allAuthUsers.stream().filter(item -> name.equals(item.getUsername())).findAny().orElse(null);
 	}
 
+	/**
+	 * Get vROPs auth group by name.
+	 * @param name
+	 * 
+	 * @return AuthGroupDTO
+	 */		
 	public AuthGroupDTO findAuthGroupByName(String name) {
 		List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
 
 		return allAuthGroups.stream().filter(item -> name.equals(item.getDisplayName())).findAny().orElse(null);
 	}
 
+	/**
+	 * Get all vROPs auth groups by name.
+	 * @param names
+	 * 
+	 * @return list of AuthGroupDTO
+	 */		
 	public List<AuthGroupDTO> findAuthGroupsByNames(List<String> names) {
 		List<AuthGroupDTO> allAuthGroups = this.findAllAuthGroups();
 
 		return allAuthGroups.stream().filter(item -> names.contains(item.getDisplayName())).collect(Collectors.toList());
 	}
 
+	/**
+	 * Get all vROPs auth users by name.
+	 * @param names
+	 * 
+	 * @return list of AuthUserDTO
+	 */		
 	public List<AuthUserDTO> findAuthUsersByNames(List<String> names) {
 		List<AuthUserDTO> allAuthUsers = this.findAllAuthUsers();
 
 		return allAuthUsers.stream().filter(item -> names.contains(item.getUsername())).collect(Collectors.toList());
 	}
 
+	/**
+	 * Get vROPs product version.
+	 * 
+	 * @return version info
+	 */		
 	private Version getProductVersion() {
 		if (this.productVersion == null) {
 			this.productVersion = new Version(getVersion());
@@ -789,6 +1026,11 @@ public class RestClientVrops extends RestClient {
 		return this.productVersion;
 	}
 
+	/**
+	 * Checks whether the vROPs is version 8.2 or later.
+	 * 
+	 * @return true if vROPs is 8.2 or later otherwise false
+	 */			
 	private boolean isVrops82OrLater() {
 		Integer major = this.getProductVersion().getMajorVersion();
 		Integer minor = this.getProductVersion().getMinorVersion();
@@ -796,6 +1038,12 @@ public class RestClientVrops extends RestClient {
 		return (major != null && major >= VROPS_MAJOR_VERSION) && (minor != null && minor >= VROPS_MINOR_VERSION);
 	}
 
+	/**
+	 * Searches for vROPs policy by name.
+	 * @param policyName
+	 * 
+	 * @return PolicyDTO.Policy object
+	 */			
 	private PolicyDTO.Policy findPolicyByName(String policyName) {
 		// get all available policies in the target system
 		List<PolicyDTO.Policy> policies = getAllPolicies();
@@ -811,6 +1059,12 @@ public class RestClientVrops extends RestClient {
 		return foundPolicy.get();
 	}
 
+	/**
+	 * Filter policies by set of names.
+	 * @param policyEntries
+	 * 
+	 * @return a list of PolicyDTO.Policy object
+	 */			
 	private List<PolicyDTO.Policy> filterPoliciesByName(List<String> policyEntries) {
 		List<PolicyDTO.Policy> policies = getAllPolicies();
 		if (policies == null || policies.isEmpty()) {
@@ -821,6 +1075,11 @@ public class RestClientVrops extends RestClient {
 				.collect(Collectors.toList());
 	}
 
+	/**
+	 * Update policy for custom group.
+	 * @param customGroupPayload
+	 * @param policyIdMap
+	 */	
 	private void updateCustomGroupPolicy(String customGroupPayload, Map<String, String> policyIdMap) {
 		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
 		if (customGroup == null) {
@@ -874,6 +1133,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * Set the customer group id to null (required by vROPs API).
+	 * @param customGroupPayload
+     * @return JSON string of custom group
+	 */		
 	private String setCustomGroupIdToNull(final String customGroupPayload) {
 		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
 		if (customGroup == null) {
@@ -885,6 +1149,12 @@ public class RestClientVrops extends RestClient {
 		return deserializeCustomGroup(customGroup);
 	}
 
+	/**
+	 * Update the customer group id (required by vROPs API).
+	 * @param customGroup
+	 * @param customGroupPayload
+     * @return JSON string of custom group
+	 */		
 	private String updateCustomGroupId(CustomGroupDTO.Group customGroup, String customGroupPayload) {
 		CustomGroupDTO.Group serializedCustomGroup = serializeCustomGroup(customGroupPayload);
 		if (customGroup == null || serializedCustomGroup == null) {
@@ -914,6 +1184,11 @@ public class RestClientVrops extends RestClient {
 		return deserializeCustomGroup(serializedCustomGroup);
 	}
 
+	/**
+	 * serializeCustomGroup.
+	 * @param customGroupPayload
+     * @return JSON string of custom group
+	 */		
 	private CustomGroupDTO.Group serializeCustomGroup(String customGroupPayload) {
 		try {
 			return mapper.readValue(customGroupPayload, CustomGroupDTO.Group.class);
@@ -926,6 +1201,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * deserializeCustomGroup.
+	 * @param customGroup
+     * @return JSON string of custom group
+	 */		
 	private String deserializeCustomGroup(CustomGroupDTO.Group customGroup) {
 		try {
 			return mapper.writeValueAsString(customGroup);
@@ -938,6 +1218,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * deserializeCustomGroupType.
+	 * @param customGroupType
+     * @return JSON string of custom group
+	 */		
 	private String deserializeCustomGroupType(CustomGroupTypeDTO customGroupType) {
 		try {
 			return mapper.writeValueAsString(customGroupType);
@@ -950,6 +1235,11 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	/**
+	 * customGroupExists.
+	 * @param customGroupPayload
+     * @return true if exists
+	 */		
 	private boolean customGroupExists(String customGroupPayload) {
 		CustomGroupDTO.Group customGroup = serializeCustomGroup(customGroupPayload);
 		if (customGroup == null) {
@@ -962,8 +1252,8 @@ public class RestClientVrops extends RestClient {
 	/**
 	 * Find vROPS custom group by name.
 	 * 
-	 * @param List<String> - names of the custom groups.
-	 * @return List<CustomGroupDTO.CustomGroup> - list of the found custom groups.
+	 * @param customGroupNames names of the custom groups
+	 * @return List<CustomGroupDTO.CustomGroup> - list of the found custom groups
 	 */
 	private List<CustomGroupDTO.Group> findCustomGroupsByNames(List<String> customGroupNames) {
 		List<CustomGroupDTO.Group> retVal = new ArrayList<>();

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
@@ -486,7 +486,7 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
-	public ResourcesDTO getResourcesPerAdapterType(String adapterType) {
+	public ResourcesDTO getResourcesPerAdapterType(final String adapterType) {
 		ResourcesDTO.PageInfo pageInfo = this.getResourcePerAdapterKindPageInfo(adapterType);
 
 		ResourcesDTO resource = new ResourcesDTO();
@@ -510,7 +510,7 @@ public class RestClientVrops extends RestClient {
 		return resource;
 	}
 
-	public ResourcesDTO getResourcesPerAdapterType(String adapterKind, Long page) {
+	public ResourcesDTO getResourcesPerAdapterType(final String adapterKind, final Long page) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 		HttpEntity<String> entity = new HttpEntity<>(headers);
@@ -567,7 +567,7 @@ public class RestClientVrops extends RestClient {
 		return resource;
 	}
 
-	public ResourcesDTO getResources(Long page) {
+	public ResourcesDTO getResources(final Long page) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 		HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
@@ -48,8 +48,9 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrops.ResourcesDTO;
 public class RestClientVrliV1 extends AbstractRestClientVrli {
 	private static final String API_PREFIX = "/api/v1";
 	private static final String RESOURCE_KIND_KEY = "resourceKindKey";
-	private static final String RESOURCE_KIND_KEYS_SPLIT_KEY = "&";
-	private static final String RESOURCE_KIND_KEY_SPLIT_KEY = "=";
+	private static final String ADAPTER_KIND_KEY = "adapterKindKey";
+	private static final String KEYS_SPLIT_KEY = "&";
+	private static final String KEY_SPLIT_KEY = "=";
 
 	public RestClientVrliV1(ConfigurationVrli configuration, RestTemplate restTemplate) {
 		super(API_PREFIX, configuration, restTemplate);
@@ -172,44 +173,32 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         }
         if (StringUtils.isEmpty(alert.getVcopsResourceName()) || StringUtils.isEmpty(alert.getVcopsResourceKindKey())) {
             return;
-        }
-
+        }        
+		// fetch the adapter type for alert
+		String alertAdapterType = this.getAdapterTypeForAlert(alert);
+		// fetch the resource type for alert
+		String alertResourceType = this.getResourceTypeForAlert(alert);        
         RestClientVrops restClientVrops = getVropsRestClient();
         ResourcesDTO resourceDto = new ResourcesDTO();
         try {
-            resourceDto = restClientVrops.getResources();
+            resourceDto = restClientVrops.getResourcesPerAdapterType(alertAdapterType);
         } catch (Exception e) {
             throw new RuntimeException(
-                    String.format("Unable to update vCOPs integration for alert '%s', unable to fetch vROPs resources: %s", alert.getName(), e.getMessage()));
+                    String.format("Unable to update vCOPs integration for alert '%s', unable to fetch vROPs resources for adapter type '%s': %s", alert.getName(), alertAdapterType, e.getMessage()));
         }
         if (resourceDto == null) {
             return;
         }
-
-		String targetResourceKindKeys = alert.getVcopsResourceKindKey();
-		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(RESOURCE_KIND_KEYS_SPLIT_KEY));
-		Optional<String> resourceTypes = keysSplit.stream().filter(item -> item.contains(RESOURCE_KIND_KEY)).findFirst();
-
-		if (!resourceTypes.isPresent()) {
-			throw new RuntimeException(String.format("Unable to find resource type '%s' for vROPs enabled alert: '%s' on the target vROPs system", RESOURCE_KIND_KEY, alert.getName()));
-		}
-		List<String> types = Arrays.asList(resourceTypes.get().split(RESOURCE_KIND_KEY_SPLIT_KEY));
-		if (types.isEmpty()) {
-			throw new RuntimeException(String.format("Unable to to extract vROPs resource kind type for alert '%s'", alert.getName()));			
-		}		
-		String targetResourceType = types.get(types.size() - 1);
 		Optional<ResourcesDTO.ResourceList> targetResource = resourceDto.getResourceList().stream()
-				.filter(item -> item.getResourceKey().getResourceKindKey().equalsIgnoreCase(targetResourceType)).findFirst();
+				.filter(item -> item.getResourceKey().getResourceKindKey().equalsIgnoreCase(alertResourceType)).findFirst();
 		if (!targetResource.isPresent()) {
 			throw new RuntimeException(String.format(
 					"Unable to find resource type '%s' on the target vROPs server for alert: '%s', please check VROPS content pack configuration in VRLI or VROPS configuration",
-					targetResourceType, alert.getName()));
+					alertResourceType, alert.getName()));
 		}
-
         String resourceName = targetResource.get().getResourceKey().getName();
         String adapterKindKey = targetResource.get().getResourceKey().getAdapterKindKey();
         String resourceKindKey = targetResource.get().getResourceKey().getResourceKindKey();
-
         List<String> baseResourceKindKeys = new ArrayList<>();
         baseResourceKindKeys.add("resourceName=" + resourceName);
         baseResourceKindKeys.add("adapterKindKey=" + adapterKindKey);
@@ -222,7 +211,6 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 
             return name + "::" + value;
         }).collect(Collectors.toList());
-
         if (!identifiersList.isEmpty()) {
             String identifiers = identifiersList.stream().collect(Collectors.joining("$$"));
             baseResourceKindKeys.add("identifiers=" + identifiers);
@@ -233,6 +221,39 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         alert.setVcopsResourceKindKey(baseResourceKindKeys.stream().collect(Collectors.joining("&")));
     }
 
+	private String getAdapterTypeForAlert(AlertDTO alert) {
+		String targetResourceKindKeys = alert.getVcopsResourceKindKey();		
+		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
+		Optional<String> adapterTypeKeys = keysSplit.stream().filter(item -> item.contains(ADAPTER_KIND_KEY)).findFirst();
+
+		if (!adapterTypeKeys.isPresent()) {
+			throw new RuntimeException(String.format("Unable to find adapter type '%s' for vROPs enabled alert: '%s' on the target vROPs system",
+					ADAPTER_KIND_KEY, alert.getName()));
+		}
+		List<String> adapterTypes = Arrays.asList(adapterTypeKeys.get().split(KEY_SPLIT_KEY));
+		if (adapterTypes.isEmpty()) {
+			throw new RuntimeException(String.format("Unable to to extract vROPs adapter kind type for vROPs enabled alert '%s'", alert.getName()));
+		}
+
+		return adapterTypes.get(adapterTypes.size() - 1);
+	}
+
+	private String getResourceTypeForAlert(AlertDTO alert) {
+		String targetResourceKindKeys = alert.getVcopsResourceKindKey();
+		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
+		Optional<String> resourceTypes = keysSplit.stream().filter(item -> item.contains(RESOURCE_KIND_KEY)).findFirst();
+		if (!resourceTypes.isPresent()) {
+			throw new RuntimeException(String.format("Unable to find resource type '%s' for vROPs enabled alert: '%s' on the target vROPs system",
+					RESOURCE_KIND_KEY, alert.getName()));
+		}
+		List<String> types = Arrays.asList(resourceTypes.get().split(KEY_SPLIT_KEY));
+		if (types.isEmpty()) {
+			throw new RuntimeException(String.format("Unable to to extract vROPs resource kind type for vROPs enabled alert '%s'", alert.getName()));
+		}
+
+		return types.get(types.size() - 1);
+	}
+	
     private AlertDTO findAlertByName(String alertName) {
         List<AlertDTO> alerts = getAllAlerts();
         if (alerts == null || alerts.isEmpty()) {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
@@ -71,7 +71,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         return deserializeContentPacks(response.getBody());
     }
 
-	public void updateAlert(AlertDTO alertToUpdate, String existingAlertId) {
+	public void updateAlert(final AlertDTO alertToUpdate,final String existingAlertId) {
         if (alertToUpdate == null || StringUtils.isEmpty(existingAlertId)) {
             return;
         }
@@ -81,7 +81,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         insertAlert(serializeAlert(alertToUpdate));
     }
 
-	public void importAlert(String alertJson) {
+	public void importAlert(final String alertJson) {
         if (StringUtils.isEmpty(alertJson)) {
             return;
         }
@@ -99,7 +99,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         insertAlert(alertJson);
     }
 
-	public void deleteAlert(String alertId) {
+	public void deleteAlert(final String alertId) {
         if (StringUtils.isEmpty(alertId)) {
             return;
         }
@@ -164,7 +164,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 	 * @param AlertDTO alert DTO object
 	 * @throws Runtime exception
 	 */
-    private void rewriteVcopsIntegrationInfo(AlertDTO alert) {
+    private void rewriteVcopsIntegrationInfo(final AlertDTO alert) {
         if (alert == null) {
             return;
         }
@@ -221,7 +221,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         alert.setVcopsResourceKindKey(baseResourceKindKeys.stream().collect(Collectors.joining("&")));
     }
 
-	private String getAdapterTypeForAlert(AlertDTO alert) {
+	private String getAdapterTypeForAlert(final AlertDTO alert) {
 		String targetResourceKindKeys = alert.getVcopsResourceKindKey();		
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
 		Optional<String> adapterTypeKeys = keysSplit.stream().filter(item -> item.contains(ADAPTER_KIND_KEY)).findFirst();
@@ -238,7 +238,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 		return adapterTypes.get(adapterTypes.size() - 1);
 	}
 
-	private String getResourceTypeForAlert(AlertDTO alert) {
+	private String getResourceTypeForAlert(final AlertDTO alert) {
 		String targetResourceKindKeys = alert.getVcopsResourceKindKey();
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
 		Optional<String> resourceTypes = keysSplit.stream().filter(item -> item.contains(RESOURCE_KIND_KEY)).findFirst();
@@ -254,7 +254,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 		return types.get(types.size() - 1);
 	}
 	
-    private AlertDTO findAlertByName(String alertName) {
+    private AlertDTO findAlertByName(final String alertName) {
         List<AlertDTO> alerts = getAllAlerts();
         if (alerts == null || alerts.isEmpty()) {
             return null;
@@ -271,7 +271,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         return null;
     }
 
-    private AlertDTO deserializeAlert(String alertJson) {
+    private AlertDTO deserializeAlert(final String alertJson) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             return mapper.readValue(alertJson, AlertDTO.class);
@@ -282,7 +282,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         }
     }
 
-    private List<AlertDTO> deserializeAlerts(String alertsJson) {
+    private List<AlertDTO> deserializeAlerts(final String alertsJson) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             return Arrays.asList(mapper.readValue(alertsJson, AlertDTO[].class));
@@ -293,7 +293,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         }
     }
 
-    private List<ContentPackDTO> deserializeContentPacks(String contentPacksJson) {
+    private List<ContentPackDTO> deserializeContentPacks(final String contentPacksJson) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             ContentPackMetadataListDTO contentPackMetadata = mapper.readValue(contentPacksJson, ContentPackMetadataListDTO.class);
@@ -305,7 +305,7 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
         }
     }
 
-    private String serializeAlert(AlertDTO alert) {
+    private String serializeAlert(final AlertDTO alert) {
         ObjectMapper mapper = new ObjectMapper();
         try {
             return mapper.writeValueAsString(alert);

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV1.java
@@ -46,114 +46,166 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrli.v1.ContentPackMetadataListD
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.ResourcesDTO;
 
 public class RestClientVrliV1 extends AbstractRestClientVrli {
+	/**
+	 * API_PREFIX.
+	 */
 	private static final String API_PREFIX = "/api/v1";
+	/**
+	 * RESOURCE_KIND_KEY.
+	 */
 	private static final String RESOURCE_KIND_KEY = "resourceKindKey";
+	/**
+	 * ADAPTER_KIND_KEY.
+	 */
 	private static final String ADAPTER_KIND_KEY = "adapterKindKey";
+	/**
+	 * KEYS_SPLIT_KEY.
+	 */
 	private static final String KEYS_SPLIT_KEY = "&";
+	/**
+	 * KEY_SPLIT_KEY.
+	 */
 	private static final String KEY_SPLIT_KEY = "=";
 
+	/**
+	 * RestClientVrliV1.
+	 * 
+	 * @param configuration
+	 * @param restTemplate
+	 */
 	public RestClientVrliV1(ConfigurationVrli configuration, RestTemplate restTemplate) {
 		super(API_PREFIX, configuration, restTemplate);
 		logger = LoggerFactory.getLogger(RestClientVrliV1.class);
-    }
+	}
 
+	/**
+	 * Returns all alerts in vRLI.
+	 * 
+	 * @return list of AlertDTO
+	 */
 	public List<AlertDTO> getAllAlerts() {
-        URI url = getURI(getURIBuilder().setPath(this.apiPrefix + ALERTS_API));
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
+		URI url = getURI(getURIBuilder().setPath(this.apiPrefix + ALERTS_API));
+		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
 
-        return deserializeAlerts(response.getBody());
-    }
+		return deserializeAlerts(response.getBody());
+	}
 
+	/**
+	 * Returns all content packs in vRLI.
+	 * 
+	 * @return list of ContentPackDTO
+	 */
 	public List<ContentPackDTO> getAllContentPacks() {
-        URI url = getURI(getURIBuilder().setPath(this.apiPrefix + CONTENT_PACKS_LIST_API));
-        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
+		URI url = getURI(getURIBuilder().setPath(this.apiPrefix + CONTENT_PACKS_LIST_API));
+		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getDefaultHttpEntity(), String.class);
 
-        return deserializeContentPacks(response.getBody());
-    }
+		return deserializeContentPacks(response.getBody());
+	}
 
-	public void updateAlert(final AlertDTO alertToUpdate,final String existingAlertId) {
-        if (alertToUpdate == null || StringUtils.isEmpty(existingAlertId)) {
-            return;
-        }
+	/**
+	 * Update vRLI alert.
+	 * 
+	 * @param alertToUpdate
+	 * @param existingAlertId
+	 */
+	public void updateAlert(final AlertDTO alertToUpdate, final String existingAlertId) {
+		if (alertToUpdate == null || StringUtils.isEmpty(existingAlertId)) {
+			return;
+		}
 
-        logger.info("Updating alert '{}'", alertToUpdate.getName());
-        deleteAlert(existingAlertId);
-        insertAlert(serializeAlert(alertToUpdate));
-    }
+		logger.info("Updating alert '{}'", alertToUpdate.getName());
+		deleteAlert(existingAlertId);
+		insertAlert(serializeAlert(alertToUpdate));
+	}
 
+	/**
+	 * Import a vRLI alert.
+	 * 
+	 * @param alertJson
+	 */
 	public void importAlert(final String alertJson) {
-        if (StringUtils.isEmpty(alertJson)) {
-            return;
-        }
+		if (StringUtils.isEmpty(alertJson)) {
+			return;
+		}
 
-        AlertDTO alertToUpdate = deserializeAlert(alertJson);
-        if (alertToUpdate == null) {
-            return;
-        }
-        AlertDTO existingAlert = findAlertByName(alertToUpdate.getName());
-        if (existingAlert != null) {
-            updateAlert(alertToUpdate, existingAlert.getId());
-            return;
-        }
+		AlertDTO alertToUpdate = deserializeAlert(alertJson);
+		if (alertToUpdate == null) {
+			return;
+		}
+		AlertDTO existingAlert = findAlertByName(alertToUpdate.getName());
+		if (existingAlert != null) {
+			updateAlert(alertToUpdate, existingAlert.getId());
+			return;
+		}
 
-        insertAlert(alertJson);
-    }
+		insertAlert(alertJson);
+	}
 
+	/**
+	 * Delete a vRLI alert.
+	 * 
+	 * @param alertId
+	 */
 	public void deleteAlert(final String alertId) {
-        if (StringUtils.isEmpty(alertId)) {
-            return;
-        }
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response;
-        String deleteAlertUri = String.format(this.apiPrefix + ALERTS_API + "/%s", alertId);
-        logger.info("Deleting existing alert {}", alertId);
-        try {
-            URI url = getURIBuilder().setPath(deleteAlertUri).build();
-            response = restTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Unable to delete alert, error: %s", e.getMessage()), e);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Unable to determine REST endpoint for deleting alert, error: %s", e.getMessage()), e);
-        }
-        if (HttpStatus.NOT_FOUND.equals(response.getStatusCode())) {
-            return;
-        }
-        if (!HttpStatus.OK.equals(response.getStatusCode())) {
-            throw new RuntimeException(String.format("Unable to delete alert, Remote REST service returned status code %s, with message %s",
-                    response.getStatusCode(), response.getBody()));
-        }
-    }
+		if (StringUtils.isEmpty(alertId)) {
+			return;
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		ResponseEntity<String> response;
+		String deleteAlertUri = String.format(this.apiPrefix + ALERTS_API + "/%s", alertId);
+		logger.info("Deleting existing alert {}", alertId);
+		try {
+			URI url = getURIBuilder().setPath(deleteAlertUri).build();
+			response = restTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Unable to delete alert, error: %s", e.getMessage()), e);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Unable to determine REST endpoint for deleting alert, error: %s", e.getMessage()), e);
+		}
+		if (HttpStatus.NOT_FOUND.equals(response.getStatusCode())) {
+			return;
+		}
+		if (!HttpStatus.OK.equals(response.getStatusCode())) {
+			throw new RuntimeException(String.format("Unable to delete alert, Remote REST service returned status code %s, with message %s",
+					response.getStatusCode(), response.getBody()));
+		}
+	}
 
+	/**
+	 * Insert a vRLI alert.
+	 * 
+	 * @param alertJson
+	 */
 	public void insertAlert(String alertJson) {
-        if (StringUtils.isEmpty(alertJson)) {
-            return;
-        }
+		if (StringUtils.isEmpty(alertJson)) {
+			return;
+		}
 
-        AlertDTO alert = deserializeAlert(alertJson);
-        // rewrite the vcops integration data if needed
-        rewriteVcopsIntegrationInfo(alert);
-        alertJson = serializeAlert(alert);
+		AlertDTO alert = deserializeAlert(alertJson);
+		// rewrite the vcops integration data if needed
+		rewriteVcopsIntegrationInfo(alert);
+		alertJson = serializeAlert(alert);
 
-        logger.info("Inserting a new alert '{}'", alert.getName());
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
-        HttpEntity<String> entity = new HttpEntity<>(alertJson, headers);
-        ResponseEntity<String> response;
-        try {
-            URI url = getURIBuilder().setPath(this.apiPrefix + ALERTS_API).build();
-            response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
-        } catch (RestClientException e) {
-            throw new RuntimeException(String.format("Unable to insert/update alert, error: %s", e.getMessage()), e);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(String.format("Unable to determine REST endpoint for alert, error: %s", e.getMessage()), e);
-        }
-        if (!HttpStatus.CREATED.equals(response.getStatusCode())) {
-            throw new RuntimeException(String.format("Unable to insert/update alert, Remote REST service returned status code %s, with message %s",
-                    response.getStatusCode(), response.getBody()));
-        }
-    }
+		logger.info("Inserting a new alert '{}'", alert.getName());
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+		HttpEntity<String> entity = new HttpEntity<>(alertJson, headers);
+		ResponseEntity<String> response;
+		try {
+			URI url = getURIBuilder().setPath(this.apiPrefix + ALERTS_API).build();
+			response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Unable to insert/update alert, error: %s", e.getMessage()), e);
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(String.format("Unable to determine REST endpoint for alert, error: %s", e.getMessage()), e);
+		}
+		if (!HttpStatus.CREATED.equals(response.getStatusCode())) {
+			throw new RuntimeException(String.format("Unable to insert/update alert, Remote REST service returned status code %s, with message %s",
+					response.getStatusCode(), response.getBody()));
+		}
+	}
 
 	/**
 	 * Rewrite the vROPs integration data for vROPs enabled vRLI alerts so that the
@@ -161,34 +213,35 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 	 * vROPs integration data is retrieved dynamically from vROPs based on the
 	 * configured vROPs integration in the settings.xml (<vrli.vrops*> settings)
 	 *
-	 * @param AlertDTO alert DTO object
+	 * @param alert DTO object
 	 * @throws Runtime exception
 	 */
-    private void rewriteVcopsIntegrationInfo(final AlertDTO alert) {
-        if (alert == null) {
-            return;
-        }
-        if (!alert.isVcopsEnabled()) {
-            return;
-        }
-        if (StringUtils.isEmpty(alert.getVcopsResourceName()) || StringUtils.isEmpty(alert.getVcopsResourceKindKey())) {
-            return;
-        }        
+	private void rewriteVcopsIntegrationInfo(final AlertDTO alert) {
+		if (alert == null) {
+			return;
+		}
+		if (!alert.isVcopsEnabled()) {
+			return;
+		}
+		if (StringUtils.isEmpty(alert.getVcopsResourceName()) || StringUtils.isEmpty(alert.getVcopsResourceKindKey())) {
+			return;
+		}
 		// fetch the adapter type for alert
 		String alertAdapterType = this.getAdapterTypeForAlert(alert);
 		// fetch the resource type for alert
-		String alertResourceType = this.getResourceTypeForAlert(alert);        
-        RestClientVrops restClientVrops = getVropsRestClient();
-        ResourcesDTO resourceDto = new ResourcesDTO();
-        try {
-            resourceDto = restClientVrops.getResourcesPerAdapterType(alertAdapterType);
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    String.format("Unable to update vCOPs integration for alert '%s', unable to fetch vROPs resources for adapter type '%s': %s", alert.getName(), alertAdapterType, e.getMessage()));
-        }
-        if (resourceDto == null) {
-            return;
-        }
+		String alertResourceType = this.getResourceTypeForAlert(alert);
+		RestClientVrops restClientVrops = getVropsRestClient();
+		ResourcesDTO resourceDto = new ResourcesDTO();
+		try {
+			resourceDto = restClientVrops.getResourcesPerAdapterType(alertAdapterType);
+		} catch (Exception e) {
+			throw new RuntimeException(
+					String.format("Unable to update vCOPs integration for alert '%s', unable to fetch vROPs resources for adapter type '%s': %s",
+							alert.getName(), alertAdapterType, e.getMessage()));
+		}
+		if (resourceDto == null) {
+			return;
+		}
 		Optional<ResourcesDTO.ResourceList> targetResource = resourceDto.getResourceList().stream()
 				.filter(item -> item.getResourceKey().getResourceKindKey().equalsIgnoreCase(alertResourceType)).findFirst();
 		if (!targetResource.isPresent()) {
@@ -196,33 +249,39 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 					"Unable to find resource type '%s' on the target vROPs server for alert: '%s', please check VROPS content pack configuration in VRLI or VROPS configuration",
 					alertResourceType, alert.getName()));
 		}
-        String resourceName = targetResource.get().getResourceKey().getName();
-        String adapterKindKey = targetResource.get().getResourceKey().getAdapterKindKey();
-        String resourceKindKey = targetResource.get().getResourceKey().getResourceKindKey();
-        List<String> baseResourceKindKeys = new ArrayList<>();
-        baseResourceKindKeys.add("resourceName=" + resourceName);
-        baseResourceKindKeys.add("adapterKindKey=" + adapterKindKey);
-        baseResourceKindKeys.add("resourceKindKey=" + resourceKindKey);
+		String resourceName = targetResource.get().getResourceKey().getName();
+		String adapterKindKey = targetResource.get().getResourceKey().getAdapterKindKey();
+		String resourceKindKey = targetResource.get().getResourceKey().getResourceKindKey();
+		List<String> baseResourceKindKeys = new ArrayList<>();
+		baseResourceKindKeys.add("resourceName=" + resourceName);
+		baseResourceKindKeys.add("adapterKindKey=" + adapterKindKey);
+		baseResourceKindKeys.add("resourceKindKey=" + resourceKindKey);
 
-        // create resource identifiers list
-        List<String> identifiersList = targetResource.get().getResourceKey().getResourceIdentifiers().stream().map(identifier -> {
-            String name = identifier.getIdentifierType().getName();
-            String value = identifier.getValue();
+		// create resource identifiers list
+		List<String> identifiersList = targetResource.get().getResourceKey().getResourceIdentifiers().stream().map(identifier -> {
+			String name = identifier.getIdentifierType().getName();
+			String value = identifier.getValue();
 
-            return name + "::" + value;
-        }).collect(Collectors.toList());
-        if (!identifiersList.isEmpty()) {
-            String identifiers = identifiersList.stream().collect(Collectors.joining("$$"));
-            baseResourceKindKeys.add("identifiers=" + identifiers);
-        }
+			return name + "::" + value;
+		}).collect(Collectors.toList());
+		if (!identifiersList.isEmpty()) {
+			String identifiers = identifiersList.stream().collect(Collectors.joining("$$"));
+			baseResourceKindKeys.add("identifiers=" + identifiers);
+		}
 
-        logger.info("Rewriting the vCopsResourceKindKey for alert '{}', using resource name '{}'", alert.getName(), resourceName);
-        alert.setVcopsResourceName(resourceName);
-        alert.setVcopsResourceKindKey(baseResourceKindKeys.stream().collect(Collectors.joining("&")));
-    }
+		logger.info("Rewriting the vCopsResourceKindKey for alert '{}', using resource name '{}'", alert.getName(), resourceName);
+		alert.setVcopsResourceName(resourceName);
+		alert.setVcopsResourceKindKey(baseResourceKindKeys.stream().collect(Collectors.joining("&")));
+	}
 
+	/**
+	 * Return the vROPs adapter type for an alert.
+	 * 
+	 * @param alert
+	 * @return adapterType
+	 */
 	private String getAdapterTypeForAlert(final AlertDTO alert) {
-		String targetResourceKindKeys = alert.getVcopsResourceKindKey();		
+		String targetResourceKindKeys = alert.getVcopsResourceKindKey();
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
 		Optional<String> adapterTypeKeys = keysSplit.stream().filter(item -> item.contains(ADAPTER_KIND_KEY)).findFirst();
 
@@ -238,6 +297,12 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 		return adapterTypes.get(adapterTypes.size() - 1);
 	}
 
+	/**
+	 * Return the vROPs resource type for an alert.
+	 * 
+	 * @param alert
+	 * @return resource type
+	 */
 	private String getResourceTypeForAlert(final AlertDTO alert) {
 		String targetResourceKindKeys = alert.getVcopsResourceKindKey();
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
@@ -253,66 +318,96 @@ public class RestClientVrliV1 extends AbstractRestClientVrli {
 
 		return types.get(types.size() - 1);
 	}
-	
-    private AlertDTO findAlertByName(final String alertName) {
-        List<AlertDTO> alerts = getAllAlerts();
-        if (alerts == null || alerts.isEmpty()) {
-            return null;
-        }
-        List<AlertDTO> foundAlerts = alerts.stream().filter(alert -> alert.getName().equalsIgnoreCase(alertName)).distinct().collect(Collectors.toList());
-        if (foundAlerts == null || foundAlerts.isEmpty()) {
-            return null;
-        }
-        Optional<AlertDTO> foundAlert = foundAlerts.stream().findFirst();
-        if (foundAlert.isPresent()) {
-            return foundAlert.get();
-        }
 
-        return null;
-    }
+	/**
+	 * Finds alert by name.
+	 * 
+	 * @param alertName
+	 * @return AlertDTO
+	 */
+	private AlertDTO findAlertByName(final String alertName) {
+		List<AlertDTO> alerts = getAllAlerts();
+		if (alerts == null || alerts.isEmpty()) {
+			return null;
+		}
+		List<AlertDTO> foundAlerts = alerts.stream().filter(alert -> alert.getName().equalsIgnoreCase(alertName)).distinct().collect(Collectors.toList());
+		if (foundAlerts == null || foundAlerts.isEmpty()) {
+			return null;
+		}
+		Optional<AlertDTO> foundAlert = foundAlerts.stream().findFirst();
+		if (foundAlert.isPresent()) {
+			return foundAlert.get();
+		}
 
-    private AlertDTO deserializeAlert(final String alertJson) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return mapper.readValue(alertJson, AlertDTO.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
-        }
-    }
+		return null;
+	}
 
-    private List<AlertDTO> deserializeAlerts(final String alertsJson) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return Arrays.asList(mapper.readValue(alertsJson, AlertDTO[].class));
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
-        }
-    }
+	/**
+	 * Deserialize alert.
+	 * 
+	 * @param alertJson
+	 * @return AlertDTO
+	 */
+	private AlertDTO deserializeAlert(final String alertJson) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			return mapper.readValue(alertJson, AlertDTO.class);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
+		}
+	}
 
-    private List<ContentPackDTO> deserializeContentPacks(final String contentPacksJson) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            ContentPackMetadataListDTO contentPackMetadata = mapper.readValue(contentPacksJson, ContentPackMetadataListDTO.class);
-            return contentPackMetadata.getContentPackMetadataList();
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(Errors.MAP_CONTENT_PACK_DATA_ERROR, e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(Errors.PROCESS_CONTENT_PACK_DATA_ERROR, e);
-        }
-    }
+	/**
+	 * Deserialize alerts.
+	 * 
+	 * @param alertsJson
+	 * @return list of AlertDTO
+	 */
+	private List<AlertDTO> deserializeAlerts(final String alertsJson) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			return Arrays.asList(mapper.readValue(alertsJson, AlertDTO[].class));
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
+		}
+	}
 
-    private String serializeAlert(final AlertDTO alert) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return mapper.writeValueAsString(alert);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
-        }
-    }
+	/**
+	 * Deserialize content packs.
+	 * 
+	 * @param contentPacksJson
+	 * @return list of ContentPackDTO
+	 */
+	private List<ContentPackDTO> deserializeContentPacks(final String contentPacksJson) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			ContentPackMetadataListDTO contentPackMetadata = mapper.readValue(contentPacksJson, ContentPackMetadataListDTO.class);
+			return contentPackMetadata.getContentPackMetadataList();
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(Errors.MAP_CONTENT_PACK_DATA_ERROR, e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(Errors.PROCESS_CONTENT_PACK_DATA_ERROR, e);
+		}
+	}
+
+	/**
+	 * Serialize alert.
+	 * 
+	 * @param alert
+	 * @return JSON string
+	 */
+	private String serializeAlert(final AlertDTO alert) {
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			return mapper.writeValueAsString(alert);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(Errors.MAP_ALERT_DATA_ERROR, e);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(Errors.PROCESS_ALERT_DATA_ERROR, e);
+		}
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV2.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/RestClientVrliV2.java
@@ -65,7 +65,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		return deserializeContentPacks(response.getBody());
 	}
 
-	public void updateAlert(AlertDTO alertToUpdate, String existingAlertId) {
+	public void updateAlert(final AlertDTO alertToUpdate, final String existingAlertId) {
 		if (alertToUpdate == null || StringUtils.isEmpty(existingAlertId)) {
 			return;
 		}
@@ -75,7 +75,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		insertAlert(serializeAlert(alertToUpdate));
 	}
 
-	public void importAlert(String alertJson) {
+	public void importAlert(final String alertJson) {
 		if (StringUtils.isEmpty(alertJson)) {
 			return;
 		}
@@ -93,7 +93,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		insertAlert(alertJson);
 	}
 
-	public void deleteAlert(String alertId) {
+	public void deleteAlert(final String alertId) {
 		if (StringUtils.isEmpty(alertId)) {
 			return;
 		}
@@ -160,7 +160,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 	 * @param AlertDTO alert DTO object
 	 * @throws Runtime exception
 	 */
-	private void rewriteVcopsIntegrationInfo(AlertDTO alert) {
+	private void rewriteVcopsIntegrationInfo(final AlertDTO alert) {
 		if (alert == null) {
 			return;
 		}
@@ -212,7 +212,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		alert.getRecipients().getVrops().setVcopsResourceKindKey(baseResourceKindKeys.stream().collect(Collectors.joining("&")));
 	}
 
-	private String getAdapterTypeForAlert(AlertDTO alert) {
+	private String getAdapterTypeForAlert(final AlertDTO alert) {
 		String targetResourceKindKeys = alert.getRecipients().getVrops().getVcopsResourceKindKey();
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
 		Optional<String> adapterTypeKeys = keysSplit.stream().filter(item -> item.contains(ADAPTER_KIND_KEY)).findFirst();
@@ -229,7 +229,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		return adapterTypes.get(adapterTypes.size() - 1);
 	}
 
-	private String getResourceTypeForAlert(AlertDTO alert) {
+	private String getResourceTypeForAlert(final AlertDTO alert) {
 		String targetResourceKindKeys = alert.getRecipients().getVrops().getVcopsResourceKindKey();
 		List<String> keysSplit = Arrays.asList(targetResourceKindKeys.split(KEYS_SPLIT_KEY));
 		Optional<String> resourceTypes = keysSplit.stream().filter(item -> item.contains(RESOURCE_KIND_KEY)).findFirst();
@@ -245,7 +245,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		return types.get(types.size() - 1);
 	}
 
-	private AlertDTO findAlertByName(String alertName) {
+	private AlertDTO findAlertByName(final String alertName) {
 		List<AlertDTO> alerts = getAllAlerts();
 		if (alerts == null || alerts.isEmpty()) {
 			return null;
@@ -262,7 +262,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		return null;
 	}
 
-	private AlertDTO deserializeAlert(String alertJson) {
+	private AlertDTO deserializeAlert(final String alertJson) {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			return mapper.readValue(alertJson, AlertDTO.class);
@@ -273,7 +273,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		}
 	}
 
-	private List<AlertDTO> deserializeAlerts(String alertsJson) {
+	private List<AlertDTO> deserializeAlerts(final String alertsJson) {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			return Arrays.asList(mapper.readValue(alertsJson, AlertDTO[].class));
@@ -284,7 +284,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		}
 	}
 
-	private List<ContentPackDTO> deserializeContentPacks(String contentPacksJson) {
+	private List<ContentPackDTO> deserializeContentPacks(final String contentPacksJson) {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			ContentPackMetadataListDTO contentPackMetadata = mapper.readValue(contentPacksJson, ContentPackMetadataListDTO.class);
@@ -296,7 +296,7 @@ public class RestClientVrliV2 extends AbstractRestClientVrli {
 		}
 	}
 
-	private String serializeAlert(AlertDTO alert) {
+	private String serializeAlert(final AlertDTO alert) {
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			return mapper.writeValueAsString(alert);

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/client/vrli/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vRLI rest client.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.rest.client.vrli;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrli/v1/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrli/v1/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vRLI API v1 Rest Model.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.rest.model.vrli.v1;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrli/v2/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrli/v2/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vRLI API v2 Rest Model.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.rest.model.vrli.v2;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
@@ -19,6 +19,7 @@ package com.vmware.pscoe.iac.artifact.rest.model.vrops;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -32,451 +33,587 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "pageInfo", "links", "resourceList" })
-@JsonIgnoreProperties({ "pageInfo", "links" })
 public class ResourcesDTO implements Serializable {
-    private static final long serialVersionUID = -4565701751149713687L;
-
-    @JsonProperty("resourceList")
-    private List<ResourceList> resourceList = new ArrayList<>();
-
-    @JsonIgnore
-    private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-    @JsonProperty("resourceList")
-    public List<ResourceList> getResourceList() {
-        return resourceList;
-    }
-
-    @JsonProperty("resourceList")
-    public void setResourceList(List<ResourceList> resourceList) {
-        this.resourceList = resourceList;
-    }
-
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
-
-    @JsonAnySetter
-    public void setAdditionalProperties(String name, Object value) {
-        this.additionalProperties.put(name, value);
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonPropertyOrder({ "creationTime", "resourceKey", "resourceStatusStates", "resourceHealth", "resourceHealthValue", "dtEnabled", "monitoringInterval",
-            "badges", "relatedResources", "links", "identifier" })
-    @JsonIgnoreProperties({ "links" })
-    public static class ResourceList implements Serializable {
-        private static final long serialVersionUID = -7272621081244854723L;
-
-        @JsonProperty("creationTime")
-        private long creationTime;
-
-        @JsonProperty("credentialInstanceId")
-        private String credentialInstanceId;
-
-        @JsonProperty("description")
-        private String description;
-
-        @JsonProperty("resourceKey")
-        private ResourceKey resourceKey;
-
-        @JsonProperty("resourceStatusStates")
-        private List<ResourceStatusState> resourceStatusStates = new ArrayList<>();
-
-        @JsonProperty("resourceHealth")
-        private String resourceHealth;
-
-        @JsonProperty("resourceHealthValue")
-        private Double resourceHealthValue;
-
-        @JsonProperty("dtEnabled")
-        private Boolean dtEnabled;
-
-        @JsonProperty("monitoringInterval")
-        private Integer monitoringInterval;
-
-        @JsonProperty("badges")
-        private List<Object> badges = new ArrayList<>();
-
-        @JsonProperty("relatedResources")
-        private List<Object> relatedResources = new ArrayList<>();
-
-        @JsonProperty("identifier")
-        private String identifier;
-
-        @JsonIgnore
-        private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-        @JsonProperty("creationTime")
-        public long getCreationTime() {
-            return creationTime;
-        }
-
-        @JsonProperty("creationTime")
-        public void setCreationTime(long creationTime) {
-            this.creationTime = creationTime;
-        }
-
-        public String getCredentialInstanceId() {
-            return credentialInstanceId;
-        }
-
-        public void setCredentialInstanceId(String credentialInstanceId) {
-            this.credentialInstanceId = credentialInstanceId;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public void setDescription(String description) {
-            this.description = description;
-        }
-
-        @JsonProperty("resourceKey")
-        public ResourceKey getResourceKey() {
-            return resourceKey;
-        }
-
-        @JsonProperty("resourceKey")
-        public void setResourceKey(ResourceKey resourceKey) {
-            this.resourceKey = resourceKey;
-        }
-
-        @JsonProperty("resourceStatusStates")
-        public List<ResourceStatusState> getResourceStatusStates() {
-            return resourceStatusStates;
-        }
-
-        @JsonProperty("resourceStatusStates")
-        public void setResourceStatusStates(List<ResourceStatusState> resourceStatusStates) {
-            this.resourceStatusStates = resourceStatusStates;
-        }
-
-        @JsonProperty("resourceHealth")
-        public String getResourceHealth() {
-            return resourceHealth;
-        }
-
-        @JsonProperty("resourceHealth")
-        public void setResourceHealth(String resourceHealth) {
-            this.resourceHealth = resourceHealth;
-        }
-
-        @JsonProperty("resourceHealthValue")
-        public Double getResourceHealthValue() {
-            return resourceHealthValue;
-        }
-
-        @JsonProperty("resourceHealthValue")
-        public void setResourceHealthValue(Double resourceHealthValue) {
-            this.resourceHealthValue = resourceHealthValue;
-        }
-
-        @JsonProperty("dtEnabled")
-        public Boolean isDtEnabled() {
-            return dtEnabled;
-        }
-
-        @JsonProperty("dtEnabled")
-        public void setDtEnabled(Boolean dtEnabled) {
-            this.dtEnabled = dtEnabled;
-        }
-
-        @JsonProperty("monitoringInterval")
-        public Integer getMonitoringInterval() {
-            return monitoringInterval;
-        }
-
-        @JsonProperty("monitoringInterval")
-        public void setMonitoringInterval(Integer monitoringInterval) {
-            this.monitoringInterval = monitoringInterval;
-        }
-
-        @JsonProperty("badges")
-        public List<Object> getBadges() {
-            return badges;
-        }
-
-        @JsonProperty("badges")
-        public void setBadges(List<Object> badges) {
-            this.badges = badges;
-        }
-
-        @JsonProperty("relatedResources")
-        public List<Object> getRelatedResources() {
-            return relatedResources;
-        }
-
-        @JsonProperty("relatedResources")
-        public void setRelatedResources(List<Object> relatedResources) {
-            this.relatedResources = relatedResources;
-        }
-
-        @JsonProperty("identifier")
-        public String getIdentifier() {
-            return identifier;
-        }
-
-        @JsonProperty("identifier")
-        public void setIdentifier(String identifier) {
-            this.identifier = identifier;
-        }
-
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
-
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonPropertyOrder({ "adapterInstanceId", "resourceStatus", "resourceState", "statusMessage" })
-    public static class ResourceStatusState implements Serializable {
-        private static final long serialVersionUID = -787582647822155817L;
-
-        @JsonProperty("adapterInstanceId")
-        private String adapterInstanceId;
-
-        @JsonProperty("resourceStatus")
-        private String resourceStatus;
-
-        @JsonProperty("resourceState")
-        private String resourceState;
-
-        @JsonProperty("statusMessage")
-        private String statusMessage;
-
-        @JsonIgnore
-        private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-        @JsonProperty("adapterInstanceId")
-        public String getAdapterInstanceId() {
-            return adapterInstanceId;
-        }
-
-        @JsonProperty("adapterInstanceId")
-        public void setAdapterInstanceId(String adapterInstanceId) {
-            this.adapterInstanceId = adapterInstanceId;
-        }
-
-        @JsonProperty("resourceStatus")
-        public String getResourceStatus() {
-            return resourceStatus;
-        }
-
-        @JsonProperty("resourceStatus")
-        public void setResourceStatus(String resourceStatus) {
-            this.resourceStatus = resourceStatus;
-        }
-
-        @JsonProperty("resourceState")
-        public String getResourceState() {
-            return resourceState;
-        }
-
-        @JsonProperty("resourceState")
-        public void setResourceState(String resourceState) {
-            this.resourceState = resourceState;
-        }
-
-        @JsonProperty("statusMessage")
-        public String getStatusMessage() {
-            return statusMessage;
-        }
-
-        @JsonProperty("statusMessage")
-        public void setStatusMessage(String statusMessage) {
-            this.statusMessage = statusMessage;
-        }
-
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
-
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonPropertyOrder({ "name", "adapterKindKey", "resourceKindKey", "resourceIdentifiers" })
-    public static class ResourceKey implements Serializable {
-        private static final long serialVersionUID = -7173935404365000209L;
-
-        @JsonProperty("name")
-        private String name;
-
-        @JsonProperty("adapterKindKey")
-        private String adapterKindKey;
-
-        @JsonProperty("resourceKindKey")
-        private String resourceKindKey;
-
-        @JsonProperty("resourceIdentifiers")
-        private List<ResourceIdentifier> resourceIdentifiers = new ArrayList<>();
-
-        @JsonIgnore
-        private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-        @JsonProperty("name")
-        public String getName() {
-            return name;
-        }
-
-        @JsonProperty("name")
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        @JsonProperty("adapterKindKey")
-        public String getAdapterKindKey() {
-            return adapterKindKey;
-        }
-
-        @JsonProperty("adapterKindKey")
-        public void setAdapterKindKey(String adapterKindKey) {
-            this.adapterKindKey = adapterKindKey;
-        }
-
-        @JsonProperty("resourceKindKey")
-        public String getResourceKindKey() {
-            return resourceKindKey;
-        }
-
-        @JsonProperty("resourceKindKey")
-        public void setResourceKindKey(String resourceKindKey) {
-            this.resourceKindKey = resourceKindKey;
-        }
-
-        @JsonProperty("resourceIdentifiers")
-        public List<ResourceIdentifier> getResourceIdentifiers() {
-            return resourceIdentifiers;
-        }
-
-        @JsonProperty("resourceIdentifiers")
-        public void setResourceIdentifiers(List<ResourceIdentifier> resourceIdentifiers) {
-            this.resourceIdentifiers = resourceIdentifiers;
-        }
-
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
-
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonPropertyOrder({ "identifierType", "value" })
-    public static class ResourceIdentifier implements Serializable {
-        private static final long serialVersionUID = -4631445128052519908L;
-
-        @JsonProperty("identifierType")
-        private IdentifierType identifierType;
-
-        @JsonProperty("value")
-        private String value;
-
-        @JsonIgnore
-        private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-        @JsonProperty("identifierType")
-        public IdentifierType getIdentifierType() {
-            return identifierType;
-        }
-
-        @JsonProperty("identifierType")
-        public void setIdentifierType(IdentifierType identifierType) {
-            this.identifierType = identifierType;
-        }
-
-        @JsonProperty("value")
-        public String getValue() {
-            return value;
-        }
-
-        @JsonProperty("value")
-        public void setValue(String value) {
-            this.value = value;
-        }
-
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
-
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonPropertyOrder({ "name", "dataType", "isPartOfUniqueness" })
-    public static class IdentifierType implements Serializable {
-        private static final long serialVersionUID = -1370467208132974903L;
-
-        @JsonProperty("name")
-        private String name;
-
-        @JsonProperty("dataType")
-        private String dataType;
-
-        @JsonProperty("isPartOfUniqueness")
-        private Boolean isPartOfUniqueness;
-
-        @JsonIgnore
-        private transient Map<String, Object> additionalProperties = new HashMap<>();
-
-        @JsonProperty("name")
-        public String getName() {
-            return name;
-        }
-
-        @JsonProperty("name")
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        @JsonProperty("dataType")
-        public String getDataType() {
-            return dataType;
-        }
-
-        @JsonProperty("dataType")
-        public void setDataType(String dataType) {
-            this.dataType = dataType;
-        }
-
-        @JsonProperty("isPartOfUniqueness")
-        public Boolean isIsPartOfUniqueness() {
-            return isPartOfUniqueness;
-        }
-
-        @JsonProperty("isPartOfUniqueness")
-        public void setIsPartOfUniqueness(Boolean isPartOfUniqueness) {
-            this.isPartOfUniqueness = isPartOfUniqueness;
-        }
-
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
-
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
+	private static final long serialVersionUID = -4565701751149713687L;
+
+	@JsonProperty("pageInfo")
+	private PageInfo pageInfo;
+	
+	@JsonProperty("links")
+	private List<Link> links;
+
+	@JsonProperty("resourceList")
+	private List<ResourceList> resourceList = new ArrayList<>();
+
+	@JsonIgnore
+	private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+	@JsonProperty("pageInfo")	
+	public PageInfo getPageInfo() {
+		return pageInfo;
+	}
+
+	@JsonProperty("pageInfo")
+	public void setPageInfo(PageInfo pageInfo) {
+		this.pageInfo = pageInfo;
+	}
+
+	@JsonProperty("links")
+	public List<Link> getLinks() {
+		return links;
+	}
+
+	@JsonProperty("links")
+	public void setLinks(List<Link> links) {
+		this.links = links;
+	}
+
+	@JsonProperty("resourceList")
+	public List<ResourceList> getResourceList() {
+		return resourceList;
+	}
+
+	@JsonProperty("resourceList")
+	public void setResourceList(List<ResourceList> resourceList) {
+		this.resourceList = resourceList;
+	}
+
+	@JsonAnyGetter
+	public Map<String, Object> getAdditionalProperties() {
+		return this.additionalProperties;
+	}
+
+	@JsonAnySetter
+	public void setAdditionalProperties(String name, Object value) {
+		this.additionalProperties.put(name, value);
+	}
+
+	@JsonPropertyOrder({ "totalCount", "page", "pageSize" })
+	public static class PageInfo {
+		@JsonProperty("totalCount")
+		private Long totalCount;
+		
+		@JsonProperty("page")
+		private Long page;
+		
+		@JsonProperty("pageSize")
+		private Long pageSize;
+		
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+		@JsonProperty("totalCount")
+		public Long getTotalCount() {
+			return totalCount;
+		}
+
+		@JsonProperty("totalCount")
+		public void setTotalCount(Long totalCount) {
+			this.totalCount = totalCount;
+		}
+
+		@JsonProperty("page")
+		public Long getPage() {
+			return page;
+		}
+
+		@JsonProperty("page")
+		public void setPage(Long page) {
+			this.page = page;
+		}
+
+		@JsonProperty("pageSize")
+		public Long getPageSize() {
+			return pageSize;
+		}
+
+		@JsonProperty("pageSize")
+		public void setPageSize(Long pageSize) {
+			this.pageSize = pageSize;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperty(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "href", "rel", "name" })
+	public static class Link {		
+		@JsonProperty("href")
+		private String href;
+		
+		@JsonProperty("rel")
+		private String rel;
+		
+		@JsonProperty("name")
+		private String name;
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+		
+		@JsonProperty("href")
+		public String getHref() {
+			return href;
+		}
+
+		@JsonProperty("href")
+		public void setHref(String href) {
+			this.href = href;
+		}
+
+		@JsonProperty("rel")
+		public String getRel() {
+			return rel;
+		}
+
+		@JsonProperty("rel")
+		public void setRel(String rel) {
+			this.rel = rel;
+		}
+
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+
+		@JsonProperty("name")
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperty(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "creationTime", "resourceKey", "resourceStatusStates", "resourceHealth", "resourceHealthValue", "dtEnabled", "monitoringInterval",
+			"badges", "relatedResources", "links", "identifier" })
+	@JsonIgnoreProperties({ "links" })
+	public static class ResourceList implements Serializable {
+		private static final long serialVersionUID = -7272621081244854723L;
+
+		@JsonProperty("creationTime")
+		private long creationTime;
+
+		@JsonProperty("credentialInstanceId")
+		private String credentialInstanceId;
+
+		@JsonProperty("description")
+		private String description;
+
+		@JsonProperty("resourceKey")
+		private ResourceKey resourceKey;
+
+		@JsonProperty("resourceStatusStates")
+		private List<ResourceStatusState> resourceStatusStates = new ArrayList<>();
+
+		@JsonProperty("resourceHealth")
+		private String resourceHealth;
+
+		@JsonProperty("resourceHealthValue")
+		private Double resourceHealthValue;
+
+		@JsonProperty("dtEnabled")
+		private Boolean dtEnabled;
+
+		@JsonProperty("monitoringInterval")
+		private Integer monitoringInterval;
+
+		@JsonProperty("badges")
+		private List<Object> badges = new ArrayList<>();
+
+		@JsonProperty("relatedResources")
+		private List<Object> relatedResources = new ArrayList<>();
+
+		@JsonProperty("identifier")
+		private String identifier;
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+		@JsonProperty("creationTime")
+		public long getCreationTime() {
+			return creationTime;
+		}
+
+		@JsonProperty("creationTime")
+		public void setCreationTime(long creationTime) {
+			this.creationTime = creationTime;
+		}
+
+		public String getCredentialInstanceId() {
+			return credentialInstanceId;
+		}
+
+		public void setCredentialInstanceId(String credentialInstanceId) {
+			this.credentialInstanceId = credentialInstanceId;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		@JsonProperty("resourceKey")
+		public ResourceKey getResourceKey() {
+			return resourceKey;
+		}
+
+		@JsonProperty("resourceKey")
+		public void setResourceKey(ResourceKey resourceKey) {
+			this.resourceKey = resourceKey;
+		}
+
+		@JsonProperty("resourceStatusStates")
+		public List<ResourceStatusState> getResourceStatusStates() {
+			return resourceStatusStates;
+		}
+
+		@JsonProperty("resourceStatusStates")
+		public void setResourceStatusStates(List<ResourceStatusState> resourceStatusStates) {
+			this.resourceStatusStates = resourceStatusStates;
+		}
+
+		@JsonProperty("resourceHealth")
+		public String getResourceHealth() {
+			return resourceHealth;
+		}
+
+		@JsonProperty("resourceHealth")
+		public void setResourceHealth(String resourceHealth) {
+			this.resourceHealth = resourceHealth;
+		}
+
+		@JsonProperty("resourceHealthValue")
+		public Double getResourceHealthValue() {
+			return resourceHealthValue;
+		}
+
+		@JsonProperty("resourceHealthValue")
+		public void setResourceHealthValue(Double resourceHealthValue) {
+			this.resourceHealthValue = resourceHealthValue;
+		}
+
+		@JsonProperty("dtEnabled")
+		public Boolean isDtEnabled() {
+			return dtEnabled;
+		}
+
+		@JsonProperty("dtEnabled")
+		public void setDtEnabled(Boolean dtEnabled) {
+			this.dtEnabled = dtEnabled;
+		}
+
+		@JsonProperty("monitoringInterval")
+		public Integer getMonitoringInterval() {
+			return monitoringInterval;
+		}
+
+		@JsonProperty("monitoringInterval")
+		public void setMonitoringInterval(Integer monitoringInterval) {
+			this.monitoringInterval = monitoringInterval;
+		}
+
+		@JsonProperty("badges")
+		public List<Object> getBadges() {
+			return badges;
+		}
+
+		@JsonProperty("badges")
+		public void setBadges(List<Object> badges) {
+			this.badges = badges;
+		}
+
+		@JsonProperty("relatedResources")
+		public List<Object> getRelatedResources() {
+			return relatedResources;
+		}
+
+		@JsonProperty("relatedResources")
+		public void setRelatedResources(List<Object> relatedResources) {
+			this.relatedResources = relatedResources;
+		}
+
+		@JsonProperty("identifier")
+		public String getIdentifier() {
+			return identifier;
+		}
+
+		@JsonProperty("identifier")
+		public void setIdentifier(String identifier) {
+			this.identifier = identifier;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperties(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "adapterInstanceId", "resourceStatus", "resourceState", "statusMessage" })
+	public static class ResourceStatusState implements Serializable {
+		private static final long serialVersionUID = -787582647822155817L;
+
+		@JsonProperty("adapterInstanceId")
+		private String adapterInstanceId;
+
+		@JsonProperty("resourceStatus")
+		private String resourceStatus;
+
+		@JsonProperty("resourceState")
+		private String resourceState;
+
+		@JsonProperty("statusMessage")
+		private String statusMessage;
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+		@JsonProperty("adapterInstanceId")
+		public String getAdapterInstanceId() {
+			return adapterInstanceId;
+		}
+
+		@JsonProperty("adapterInstanceId")
+		public void setAdapterInstanceId(String adapterInstanceId) {
+			this.adapterInstanceId = adapterInstanceId;
+		}
+
+		@JsonProperty("resourceStatus")
+		public String getResourceStatus() {
+			return resourceStatus;
+		}
+
+		@JsonProperty("resourceStatus")
+		public void setResourceStatus(String resourceStatus) {
+			this.resourceStatus = resourceStatus;
+		}
+
+		@JsonProperty("resourceState")
+		public String getResourceState() {
+			return resourceState;
+		}
+
+		@JsonProperty("resourceState")
+		public void setResourceState(String resourceState) {
+			this.resourceState = resourceState;
+		}
+
+		@JsonProperty("statusMessage")
+		public String getStatusMessage() {
+			return statusMessage;
+		}
+
+		@JsonProperty("statusMessage")
+		public void setStatusMessage(String statusMessage) {
+			this.statusMessage = statusMessage;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperties(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "name", "adapterKindKey", "resourceKindKey", "resourceIdentifiers" })
+	public static class ResourceKey implements Serializable {
+		private static final long serialVersionUID = -7173935404365000209L;
+
+		@JsonProperty("name")
+		private String name;
+
+		@JsonProperty("adapterKindKey")
+		private String adapterKindKey;
+
+		@JsonProperty("resourceKindKey")
+		private String resourceKindKey;
+
+		@JsonProperty("resourceIdentifiers")
+		private List<ResourceIdentifier> resourceIdentifiers = new ArrayList<>();
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+
+		@JsonProperty("name")
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@JsonProperty("adapterKindKey")
+		public String getAdapterKindKey() {
+			return adapterKindKey;
+		}
+
+		@JsonProperty("adapterKindKey")
+		public void setAdapterKindKey(String adapterKindKey) {
+			this.adapterKindKey = adapterKindKey;
+		}
+
+		@JsonProperty("resourceKindKey")
+		public String getResourceKindKey() {
+			return resourceKindKey;
+		}
+
+		@JsonProperty("resourceKindKey")
+		public void setResourceKindKey(String resourceKindKey) {
+			this.resourceKindKey = resourceKindKey;
+		}
+
+		@JsonProperty("resourceIdentifiers")
+		public List<ResourceIdentifier> getResourceIdentifiers() {
+			return resourceIdentifiers;
+		}
+
+		@JsonProperty("resourceIdentifiers")
+		public void setResourceIdentifiers(List<ResourceIdentifier> resourceIdentifiers) {
+			this.resourceIdentifiers = resourceIdentifiers;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperties(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "identifierType", "value" })
+	public static class ResourceIdentifier implements Serializable {
+		private static final long serialVersionUID = -4631445128052519908L;
+
+		@JsonProperty("identifierType")
+		private IdentifierType identifierType;
+
+		@JsonProperty("value")
+		private String value;
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+		@JsonProperty("identifierType")
+		public IdentifierType getIdentifierType() {
+			return identifierType;
+		}
+
+		@JsonProperty("identifierType")
+		public void setIdentifierType(IdentifierType identifierType) {
+			this.identifierType = identifierType;
+		}
+
+		@JsonProperty("value")
+		public String getValue() {
+			return value;
+		}
+
+		@JsonProperty("value")
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperties(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonPropertyOrder({ "name", "dataType", "isPartOfUniqueness" })
+	public static class IdentifierType implements Serializable {
+		private static final long serialVersionUID = -1370467208132974903L;
+
+		@JsonProperty("name")
+		private String name;
+
+		@JsonProperty("dataType")
+		private String dataType;
+
+		@JsonProperty("isPartOfUniqueness")
+		private Boolean isPartOfUniqueness;
+
+		@JsonIgnore
+		private transient Map<String, Object> additionalProperties = new HashMap<>();
+
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+
+		@JsonProperty("name")
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@JsonProperty("dataType")
+		public String getDataType() {
+			return dataType;
+		}
+
+		@JsonProperty("dataType")
+		public void setDataType(String dataType) {
+			this.dataType = dataType;
+		}
+
+		@JsonProperty("isPartOfUniqueness")
+		public Boolean isIsPartOfUniqueness() {
+			return isPartOfUniqueness;
+		}
+
+		@JsonProperty("isPartOfUniqueness")
+		public void setIsPartOfUniqueness(Boolean isPartOfUniqueness) {
+			this.isPartOfUniqueness = isPartOfUniqueness;
+		}
+
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		@JsonAnySetter
+		public void setAdditionalProperties(String name, Object value) {
+			this.additionalProperties.put(name, value);
+		}
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
@@ -84,12 +84,12 @@ public class ResourcesDTO implements Serializable {
 	}
 
 	@JsonAnySetter
-	public void setAdditionalProperties(String name, Object value) {
-		this.additionalProperties.put(name, value);
+	public void setAdditionalProperties(String key, Object value) {
+		this.additionalProperties.put(key, value);
 	}
 
 	@JsonPropertyOrder({ "totalCount", "page", "pageSize" })
-	public static class PageInfo {
+	public static final class PageInfo {
 		@JsonProperty("totalCount")
 		private Long totalCount;
 		
@@ -145,7 +145,7 @@ public class ResourcesDTO implements Serializable {
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "href", "rel", "name" })
-	public static class Link {		
+	public static final class Link {		
 		@JsonProperty("href")
 		private String href;
 		
@@ -203,7 +203,7 @@ public class ResourcesDTO implements Serializable {
 	@JsonPropertyOrder({ "creationTime", "resourceKey", "resourceStatusStates", "resourceHealth", "resourceHealthValue", "dtEnabled", "monitoringInterval",
 			"badges", "relatedResources", "links", "identifier" })
 	@JsonIgnoreProperties({ "links" })
-	public static class ResourceList implements Serializable {
+	public static final class ResourceList implements Serializable {
 		private static final long serialVersionUID = -7272621081244854723L;
 
 		@JsonProperty("creationTime")
@@ -367,14 +367,14 @@ public class ResourcesDTO implements Serializable {
 		}
 
 		@JsonAnySetter
-		public void setAdditionalProperties(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperties(String key, Object value) {
+			this.additionalProperties.put(key, value);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "adapterInstanceId", "resourceStatus", "resourceState", "statusMessage" })
-	public static class ResourceStatusState implements Serializable {
+	public static final class ResourceStatusState implements Serializable {
 		private static final long serialVersionUID = -787582647822155817L;
 
 		@JsonProperty("adapterInstanceId")
@@ -438,14 +438,14 @@ public class ResourcesDTO implements Serializable {
 		}
 
 		@JsonAnySetter
-		public void setAdditionalProperties(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperties(String key, Object value) {
+			this.additionalProperties.put(key, value);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "name", "adapterKindKey", "resourceKindKey", "resourceIdentifiers" })
-	public static class ResourceKey implements Serializable {
+	public static final class ResourceKey implements Serializable {
 		private static final long serialVersionUID = -7173935404365000209L;
 
 		@JsonProperty("name")
@@ -509,14 +509,14 @@ public class ResourcesDTO implements Serializable {
 		}
 
 		@JsonAnySetter
-		public void setAdditionalProperties(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperties(String key, Object value) {
+			this.additionalProperties.put(key, value);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "identifierType", "value" })
-	public static class ResourceIdentifier implements Serializable {
+	public static final class ResourceIdentifier implements Serializable {
 		private static final long serialVersionUID = -4631445128052519908L;
 
 		@JsonProperty("identifierType")
@@ -554,14 +554,14 @@ public class ResourcesDTO implements Serializable {
 		}
 
 		@JsonAnySetter
-		public void setAdditionalProperties(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperties(String key, Object value) {
+			this.additionalProperties.put(key, value);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "name", "dataType", "isPartOfUniqueness" })
-	public static class IdentifierType implements Serializable {
+	public static final class IdentifierType implements Serializable {
 		private static final long serialVersionUID = -1370467208132974903L;
 
 		@JsonProperty("name")
@@ -612,8 +612,8 @@ public class ResourcesDTO implements Serializable {
 		}
 
 		@JsonAnySetter
-		public void setAdditionalProperties(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperties(String key, Object value) {
+			this.additionalProperties.put(key, value);
 		}
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/ResourcesDTO.java
@@ -33,169 +33,328 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "pageInfo", "links", "resourceList" })
-public class ResourcesDTO implements Serializable {
+public final class ResourcesDTO implements Serializable {
 	private static final long serialVersionUID = -4565701751149713687L;
 
+	/**
+	 * pageInfo.
+	 */
 	@JsonProperty("pageInfo")
 	private PageInfo pageInfo;
-	
+
+	/**
+	 * links.
+	 */
 	@JsonProperty("links")
 	private List<Link> links;
 
+	/**
+	 * resourceList.
+	 */
 	@JsonProperty("resourceList")
 	private List<ResourceList> resourceList = new ArrayList<>();
 
+	/**
+	 * additionalProperties.
+	 */
 	@JsonIgnore
 	private transient Map<String, Object> additionalProperties = new HashMap<>();
 
-	@JsonProperty("pageInfo")	
+	/**
+	 * getPageInfo.
+	 * 
+	 * @return pageInfo
+	 */
+	@JsonProperty("pageInfo")
 	public PageInfo getPageInfo() {
 		return pageInfo;
 	}
 
+	/**
+	 * setPageInfo.
+	 * 
+	 * @param pageInfo
+	 */
 	@JsonProperty("pageInfo")
 	public void setPageInfo(PageInfo pageInfo) {
 		this.pageInfo = pageInfo;
 	}
 
+	/**
+	 * getLinks.
+	 * 
+	 * @return links
+	 */
 	@JsonProperty("links")
 	public List<Link> getLinks() {
 		return links;
 	}
 
+	/**
+	 * setLinks.
+	 * 
+	 * @param links
+	 */
 	@JsonProperty("links")
 	public void setLinks(List<Link> links) {
 		this.links = links;
 	}
 
+	/**
+	 * getResourceList.
+	 * 
+	 * @return resourceList
+	 */
 	@JsonProperty("resourceList")
 	public List<ResourceList> getResourceList() {
 		return resourceList;
 	}
 
+	/**
+	 * setResourceList.
+	 * 
+	 * @param resourceList
+	 */
 	@JsonProperty("resourceList")
 	public void setResourceList(List<ResourceList> resourceList) {
 		this.resourceList = resourceList;
 	}
 
+	/**
+	 * getAdditionalProperties.
+	 * 
+	 * @return additionalProperties
+	 */
 	@JsonAnyGetter
 	public Map<String, Object> getAdditionalProperties() {
 		return this.additionalProperties;
 	}
 
+	/**
+	 * setAdditionalProperties.
+	 * 
+	 * @param key
+	 * @param val
+	 */
 	@JsonAnySetter
-	public void setAdditionalProperties(String key, Object value) {
-		this.additionalProperties.put(key, value);
+	public void setAdditionalProperties(String key, Object val) {
+		this.additionalProperties.put(key, val);
 	}
 
 	@JsonPropertyOrder({ "totalCount", "page", "pageSize" })
 	public static final class PageInfo {
+		/**
+		 * totalCount.
+		 */
 		@JsonProperty("totalCount")
 		private Long totalCount;
-		
+
+		/**
+		 * page.
+		 */
 		@JsonProperty("page")
 		private Long page;
-		
+
+		/**
+		 * pageSize.
+		 */
 		@JsonProperty("pageSize")
 		private Long pageSize;
-		
+
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
 
+		/**
+		 * getTotalCount.
+		 * 
+		 * @return totalCount
+		 */
 		@JsonProperty("totalCount")
 		public Long getTotalCount() {
 			return totalCount;
 		}
 
+		/**
+		 * setTotalCount.
+		 * 
+		 * @param totalCount
+		 */
 		@JsonProperty("totalCount")
 		public void setTotalCount(Long totalCount) {
 			this.totalCount = totalCount;
 		}
 
+		/**
+		 * getPage.
+		 * 
+		 * @return page
+		 */
 		@JsonProperty("page")
 		public Long getPage() {
 			return page;
 		}
 
+		/**
+		 * setPage.
+		 * 
+		 * @param page
+		 */
 		@JsonProperty("page")
 		public void setPage(Long page) {
 			this.page = page;
 		}
 
+		/**
+		 * getPageSize.
+		 * 
+		 * @return pageSize
+		 */
 		@JsonProperty("pageSize")
 		public Long getPageSize() {
 			return pageSize;
 		}
 
+		/**
+		 * setPageSize.
+		 * 
+		 * @param pageSize
+		 */
 		@JsonProperty("pageSize")
 		public void setPageSize(Long pageSize) {
 			this.pageSize = pageSize;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperty.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperty(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperty(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonPropertyOrder({ "href", "rel", "name" })
-	public static final class Link {		
+	public static final class Link {
+		/**
+		 * href.
+		 */
 		@JsonProperty("href")
 		private String href;
-		
+
+		/**
+		 * rel.
+		 */
 		@JsonProperty("rel")
 		private String rel;
-		
+
+		/**
+		 * name.
+		 */
 		@JsonProperty("name")
 		private String name;
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
-		
+
+		/**
+		 * getHref.
+		 * 
+		 * @return href
+		 */
 		@JsonProperty("href")
 		public String getHref() {
 			return href;
 		}
 
+		/**
+		 * setHref.
+		 * 
+		 * @param href
+		 */
 		@JsonProperty("href")
 		public void setHref(String href) {
 			this.href = href;
 		}
 
+		/**
+		 * getRel.
+		 * 
+		 * @return getRel
+		 */
 		@JsonProperty("rel")
 		public String getRel() {
 			return rel;
 		}
 
+		/**
+		 * setRel.
+		 * 
+		 * @param rel
+		 */
 		@JsonProperty("rel")
 		public void setRel(String rel) {
 			this.rel = rel;
 		}
 
+		/**
+		 * getName.
+		 * 
+		 * @return name
+		 */
 		@JsonProperty("name")
 		public String getName() {
 			return name;
 		}
 
+		/**
+		 * setName.
+		 * 
+		 * @param name
+		 */
 		@JsonProperty("name")
 		public void setName(String name) {
 			this.name = name;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperty.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperty(String name, Object value) {
-			this.additionalProperties.put(name, value);
+		public void setAdditionalProperty(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
@@ -206,169 +365,339 @@ public class ResourcesDTO implements Serializable {
 	public static final class ResourceList implements Serializable {
 		private static final long serialVersionUID = -7272621081244854723L;
 
+		/**
+		 * creationTime.
+		 */
 		@JsonProperty("creationTime")
 		private long creationTime;
 
+		/**
+		 * credentialInstanceId.
+		 */
 		@JsonProperty("credentialInstanceId")
 		private String credentialInstanceId;
 
+		/**
+		 * description.
+		 */
 		@JsonProperty("description")
 		private String description;
 
+		/**
+		 * resourceKey.
+		 */
 		@JsonProperty("resourceKey")
 		private ResourceKey resourceKey;
 
+		/**
+		 * resourceStatusStates.
+		 */
 		@JsonProperty("resourceStatusStates")
 		private List<ResourceStatusState> resourceStatusStates = new ArrayList<>();
 
+		/**
+		 * resourceHealth.
+		 */
 		@JsonProperty("resourceHealth")
 		private String resourceHealth;
 
+		/**
+		 * resourceHealthValue.
+		 */
 		@JsonProperty("resourceHealthValue")
 		private Double resourceHealthValue;
 
+		/**
+		 * dtEnabled.
+		 */
 		@JsonProperty("dtEnabled")
 		private Boolean dtEnabled;
 
+		/**
+		 * monitoringInterval.
+		 */
 		@JsonProperty("monitoringInterval")
 		private Integer monitoringInterval;
 
+		/**
+		 * badges.
+		 */
 		@JsonProperty("badges")
 		private List<Object> badges = new ArrayList<>();
 
+		/**
+		 * relatedResources.
+		 */
 		@JsonProperty("relatedResources")
 		private List<Object> relatedResources = new ArrayList<>();
 
+		/**
+		 * identifier.
+		 */
 		@JsonProperty("identifier")
 		private String identifier;
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new HashMap<>();
 
+		/**
+		 * getCreationTime.
+		 * 
+		 * @return creationTime
+		 */
 		@JsonProperty("creationTime")
 		public long getCreationTime() {
 			return creationTime;
 		}
 
+		/**
+		 * setCreationTime.
+		 * 
+		 * @param creationTime
+		 */
 		@JsonProperty("creationTime")
 		public void setCreationTime(long creationTime) {
 			this.creationTime = creationTime;
 		}
 
+		/**
+		 * getCredentialInstanceId.
+		 * 
+		 * @return credentialInstanceId
+		 */
 		public String getCredentialInstanceId() {
 			return credentialInstanceId;
 		}
 
+		/**
+		 * setCredentialInstanceId.
+		 * 
+		 * @param credentialInstanceId
+		 */
 		public void setCredentialInstanceId(String credentialInstanceId) {
 			this.credentialInstanceId = credentialInstanceId;
 		}
 
+		/**
+		 * getDescription.
+		 * 
+		 * @return description
+		 */
 		public String getDescription() {
 			return description;
 		}
 
+		/**
+		 * setDescription.
+		 * 
+		 * @param description
+		 */
 		public void setDescription(String description) {
 			this.description = description;
 		}
 
+		/**
+		 * getResourceKey.
+		 * 
+		 * @return resourceKey
+		 */
 		@JsonProperty("resourceKey")
 		public ResourceKey getResourceKey() {
 			return resourceKey;
 		}
 
+		/**
+		 * setResourceKey.
+		 * 
+		 * @param resourceKey
+		 */
 		@JsonProperty("resourceKey")
 		public void setResourceKey(ResourceKey resourceKey) {
 			this.resourceKey = resourceKey;
 		}
 
+		/**
+		 * getResourceStatusStates.
+		 * 
+		 * @return resourceStatusStates
+		 */
 		@JsonProperty("resourceStatusStates")
 		public List<ResourceStatusState> getResourceStatusStates() {
 			return resourceStatusStates;
 		}
 
+		/**
+		 * setResourceStatusStates.
+		 * 
+		 * @param resourceStatusStates
+		 */
 		@JsonProperty("resourceStatusStates")
 		public void setResourceStatusStates(List<ResourceStatusState> resourceStatusStates) {
 			this.resourceStatusStates = resourceStatusStates;
 		}
 
+		/**
+		 * getResourceHealth.
+		 * 
+		 * @return resourceHealth
+		 */
 		@JsonProperty("resourceHealth")
 		public String getResourceHealth() {
 			return resourceHealth;
 		}
 
+		/**
+		 * setResourceHealth.
+		 * 
+		 * @param resourceHealth
+		 */
 		@JsonProperty("resourceHealth")
 		public void setResourceHealth(String resourceHealth) {
 			this.resourceHealth = resourceHealth;
 		}
 
+		/**
+		 * getResourceHealthValue.
+		 * 
+		 * @return resourceHealthValue
+		 */
 		@JsonProperty("resourceHealthValue")
 		public Double getResourceHealthValue() {
 			return resourceHealthValue;
 		}
 
+		/**
+		 * setResourceHealthValue.
+		 * 
+		 * @param resourceHealthValue
+		 */
 		@JsonProperty("resourceHealthValue")
 		public void setResourceHealthValue(Double resourceHealthValue) {
 			this.resourceHealthValue = resourceHealthValue;
 		}
 
+		/**
+		 * isDtEnabled.
+		 * 
+		 * @return dtEnabled
+		 */
 		@JsonProperty("dtEnabled")
 		public Boolean isDtEnabled() {
 			return dtEnabled;
 		}
 
+		/**
+		 * setDtEnabled.
+		 * 
+		 * @param dtEnabled
+		 */
 		@JsonProperty("dtEnabled")
 		public void setDtEnabled(Boolean dtEnabled) {
 			this.dtEnabled = dtEnabled;
 		}
 
+		/**
+		 * getMonitoringInterval.
+		 * 
+		 * @return monitoringInterval
+		 */
 		@JsonProperty("monitoringInterval")
 		public Integer getMonitoringInterval() {
 			return monitoringInterval;
 		}
 
+		/**
+		 * setMonitoringInterval.
+		 * 
+		 * @param monitoringInterval
+		 */
 		@JsonProperty("monitoringInterval")
 		public void setMonitoringInterval(Integer monitoringInterval) {
 			this.monitoringInterval = monitoringInterval;
 		}
 
+		/**
+		 * getBadges.
+		 * 
+		 * @return badges
+		 */
 		@JsonProperty("badges")
 		public List<Object> getBadges() {
 			return badges;
 		}
 
+		/**
+		 * setBadges.
+		 * 
+		 * @param badges
+		 */
 		@JsonProperty("badges")
 		public void setBadges(List<Object> badges) {
 			this.badges = badges;
 		}
 
+		/**
+		 * getRelatedResources.
+		 * 
+		 * @return relatedResources
+		 */
 		@JsonProperty("relatedResources")
 		public List<Object> getRelatedResources() {
 			return relatedResources;
 		}
 
+		/**
+		 * setRelatedResources.
+		 * 
+		 * @param relatedResources
+		 */
 		@JsonProperty("relatedResources")
 		public void setRelatedResources(List<Object> relatedResources) {
 			this.relatedResources = relatedResources;
 		}
 
+		/**
+		 * getIdentifier.
+		 * 
+		 * @return identifier
+		 */
 		@JsonProperty("identifier")
 		public String getIdentifier() {
 			return identifier;
 		}
 
+		/**
+		 * setIdentifier.
+		 * 
+		 * @param identifier
+		 */
 		@JsonProperty("identifier")
 		public void setIdentifier(String identifier) {
 			this.identifier = identifier;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperties.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperties(String key, Object value) {
-			this.additionalProperties.put(key, value);
+		public void setAdditionalProperties(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
@@ -377,69 +706,135 @@ public class ResourcesDTO implements Serializable {
 	public static final class ResourceStatusState implements Serializable {
 		private static final long serialVersionUID = -787582647822155817L;
 
+		/**
+		 * adapterInstanceId.
+		 */
 		@JsonProperty("adapterInstanceId")
 		private String adapterInstanceId;
 
+		/**
+		 * resourceStatus.
+		 */
 		@JsonProperty("resourceStatus")
 		private String resourceStatus;
 
+		/**
+		 * resourceState.
+		 */
 		@JsonProperty("resourceState")
 		private String resourceState;
 
+		/**
+		 * statusMessage.
+		 */
 		@JsonProperty("statusMessage")
 		private String statusMessage;
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new HashMap<>();
 
+		/**
+		 * getAdapterInstanceId.
+		 * 
+		 * @return adapterInstanceId
+		 */
 		@JsonProperty("adapterInstanceId")
 		public String getAdapterInstanceId() {
 			return adapterInstanceId;
 		}
 
+		/**
+		 * setAdapterInstanceId.
+		 * 
+		 * @param adapterInstanceId
+		 */
 		@JsonProperty("adapterInstanceId")
 		public void setAdapterInstanceId(String adapterInstanceId) {
 			this.adapterInstanceId = adapterInstanceId;
 		}
 
+		/**
+		 * getResourceStatus.
+		 * 
+		 * @return adapterInstanceId
+		 */
 		@JsonProperty("resourceStatus")
 		public String getResourceStatus() {
 			return resourceStatus;
 		}
 
+		/**
+		 * setResourceStatus.
+		 * 
+		 * @param resourceStatus
+		 */
 		@JsonProperty("resourceStatus")
 		public void setResourceStatus(String resourceStatus) {
 			this.resourceStatus = resourceStatus;
 		}
 
+		/**
+		 * getResourceState.
+		 * 
+		 * @return resourceState
+		 */
 		@JsonProperty("resourceState")
 		public String getResourceState() {
 			return resourceState;
 		}
 
+		/**
+		 * setResourceState.
+		 * 
+		 * @param resourceState
+		 */
 		@JsonProperty("resourceState")
 		public void setResourceState(String resourceState) {
 			this.resourceState = resourceState;
 		}
 
+		/**
+		 * getStatusMessage.
+		 * 
+		 * @return statusMessage
+		 */
 		@JsonProperty("statusMessage")
 		public String getStatusMessage() {
 			return statusMessage;
 		}
 
+		/**
+		 * statusMessage.
+		 * 
+		 * @param statusMessage
+		 */
 		@JsonProperty("statusMessage")
 		public void setStatusMessage(String statusMessage) {
 			this.statusMessage = statusMessage;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperties.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperties(String key, Object value) {
-			this.additionalProperties.put(key, value);
+		public void setAdditionalProperties(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
@@ -448,69 +843,135 @@ public class ResourcesDTO implements Serializable {
 	public static final class ResourceKey implements Serializable {
 		private static final long serialVersionUID = -7173935404365000209L;
 
+		/**
+		 * name.
+		 */
 		@JsonProperty("name")
 		private String name;
 
+		/**
+		 * adapterKindKey.
+		 */
 		@JsonProperty("adapterKindKey")
 		private String adapterKindKey;
 
+		/**
+		 * resourceKindKey.
+		 */
 		@JsonProperty("resourceKindKey")
 		private String resourceKindKey;
 
+		/**
+		 * resourceIdentifiers.
+		 */
 		@JsonProperty("resourceIdentifiers")
 		private List<ResourceIdentifier> resourceIdentifiers = new ArrayList<>();
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new HashMap<>();
 
+		/**
+		 * getName.
+		 * 
+		 * @return name
+		 */
 		@JsonProperty("name")
 		public String getName() {
 			return name;
 		}
 
+		/**
+		 * setName.
+		 * 
+		 * @param name
+		 */
 		@JsonProperty("name")
 		public void setName(String name) {
 			this.name = name;
 		}
 
+		/**
+		 * getAdapterKindKey.
+		 * 
+		 * @return adapterKindKey
+		 */
 		@JsonProperty("adapterKindKey")
 		public String getAdapterKindKey() {
 			return adapterKindKey;
 		}
 
+		/**
+		 * setAdapterKindKey.
+		 * 
+		 * @param adapterKindKey
+		 */
 		@JsonProperty("adapterKindKey")
 		public void setAdapterKindKey(String adapterKindKey) {
 			this.adapterKindKey = adapterKindKey;
 		}
 
+		/**
+		 * getResourceKindKey.
+		 * 
+		 * @return resourceKindKey
+		 */
 		@JsonProperty("resourceKindKey")
 		public String getResourceKindKey() {
 			return resourceKindKey;
 		}
 
+		/**
+		 * resourceKindKey.
+		 * 
+		 * @param resourceKindKey
+		 */
 		@JsonProperty("resourceKindKey")
 		public void setResourceKindKey(String resourceKindKey) {
 			this.resourceKindKey = resourceKindKey;
 		}
 
+		/**
+		 * getResourceIdentifiers.
+		 * 
+		 * @return resourceIdentifiers
+		 */
 		@JsonProperty("resourceIdentifiers")
 		public List<ResourceIdentifier> getResourceIdentifiers() {
 			return resourceIdentifiers;
 		}
 
+		/**
+		 * setResourceIdentifiers.
+		 * 
+		 * @param resourceIdentifiers
+		 */
 		@JsonProperty("resourceIdentifiers")
 		public void setResourceIdentifiers(List<ResourceIdentifier> resourceIdentifiers) {
 			this.resourceIdentifiers = resourceIdentifiers;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperties.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperties(String key, Object value) {
-			this.additionalProperties.put(key, value);
+		public void setAdditionalProperties(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
@@ -519,43 +980,83 @@ public class ResourcesDTO implements Serializable {
 	public static final class ResourceIdentifier implements Serializable {
 		private static final long serialVersionUID = -4631445128052519908L;
 
+		/**
+		 * identifierType.
+		 */
 		@JsonProperty("identifierType")
 		private IdentifierType identifierType;
 
+		/**
+		 * value.
+		 */
 		@JsonProperty("value")
 		private String value;
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new HashMap<>();
 
+		/**
+		 * getIdentifierType.
+		 * 
+		 * @return identifierType
+		 */
 		@JsonProperty("identifierType")
 		public IdentifierType getIdentifierType() {
 			return identifierType;
 		}
 
+		/**
+		 * setIdentifierType.
+		 * 
+		 * @param identifierType
+		 */
 		@JsonProperty("identifierType")
 		public void setIdentifierType(IdentifierType identifierType) {
 			this.identifierType = identifierType;
 		}
 
+		/**
+		 * getValue.
+		 * 
+		 * @return value
+		 */
 		@JsonProperty("value")
 		public String getValue() {
 			return value;
 		}
 
+		/**
+		 * setValue.
+		 * 
+		 * @param value
+		 */
 		@JsonProperty("value")
 		public void setValue(String value) {
 			this.value = value;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperties.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperties(String key, Object value) {
-			this.additionalProperties.put(key, value);
+		public void setAdditionalProperties(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 
@@ -564,56 +1065,109 @@ public class ResourcesDTO implements Serializable {
 	public static final class IdentifierType implements Serializable {
 		private static final long serialVersionUID = -1370467208132974903L;
 
+		/**
+		 * name.
+		 */
 		@JsonProperty("name")
 		private String name;
 
+		/**
+		 * dataType.
+		 */
 		@JsonProperty("dataType")
 		private String dataType;
 
+		/**
+		 * isPartOfUniqueness.
+		 */
 		@JsonProperty("isPartOfUniqueness")
 		private Boolean isPartOfUniqueness;
 
+		/**
+		 * additionalProperties.
+		 */
 		@JsonIgnore
 		private transient Map<String, Object> additionalProperties = new HashMap<>();
 
+		/**
+		 * getName.
+		 * 
+		 * @return name
+		 */
 		@JsonProperty("name")
 		public String getName() {
 			return name;
 		}
 
+		/**
+		 * setName.
+		 * 
+		 * @param name
+		 */
 		@JsonProperty("name")
 		public void setName(String name) {
 			this.name = name;
 		}
 
+		/**
+		 * getDataType.
+		 * 
+		 * @return dataType
+		 */
 		@JsonProperty("dataType")
 		public String getDataType() {
 			return dataType;
 		}
 
+		/**
+		 * setDataType.
+		 * 
+		 * @param dataType
+		 */
 		@JsonProperty("dataType")
 		public void setDataType(String dataType) {
 			this.dataType = dataType;
 		}
 
+		/**
+		 * isIsPartOfUniqueness.
+		 * 
+		 * @return isPartOfUniqueness
+		 */
 		@JsonProperty("isPartOfUniqueness")
 		public Boolean isIsPartOfUniqueness() {
 			return isPartOfUniqueness;
 		}
 
+		/**
+		 * setIsPartOfUniqueness.
+		 * 
+		 * @param isPartOfUniqueness
+		 */
 		@JsonProperty("isPartOfUniqueness")
 		public void setIsPartOfUniqueness(Boolean isPartOfUniqueness) {
 			this.isPartOfUniqueness = isPartOfUniqueness;
 		}
 
+		/**
+		 * getAdditionalProperties.
+		 * 
+		 * @return additionalProperties
+		 */
 		@JsonAnyGetter
 		public Map<String, Object> getAdditionalProperties() {
 			return this.additionalProperties;
 		}
 
+		/**
+		 * setAdditionalProperties.
+		 * 
+		 * @param key
+		 * @param val
+		 */
 		@JsonAnySetter
-		public void setAdditionalProperties(String key, Object value) {
-			this.additionalProperties.put(key, value);
+		public void setAdditionalProperties(String key, Object val) {
+			this.additionalProperties.put(key, val);
 		}
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vROPs Rest Model.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.rest.model.vrops;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -31,13 +31,11 @@ Cloud template no longer supports versioning. There are no alternatives.
 
 #### Previous Behaviour
 
-When pushing vROPs enabled vRLI alerts on large scale environments with more than 100000 the target vROPs integration data could 
-not be found due to page limits in the vROPs resources (fetched only the first 10000 resources on the vROPs level).
+When pushing vROPs enabled vRLI alerts on large scale environments with more than 100000 the target vROPs integration data could  not be found due to page limits in the vROPs resources (fetched only the first 10000 resources on the vROPs level).
 
 #### New Behaviour
 
-When pushing vROPs enabled vRLI alerts on large scale environments all vROPs resources pages are fetched and for each of the pages
-the target resources is searched, thus finding the correct one in order the alert to be pushed successfully.
+When pushing vROPs enabled vRLI alerts on large scale environments all vROPs resources pages are fetched and for each of the pages the target resources is searched, thus finding the correct one in order the alert to be pushed successfully.
 
 ### Fixed vro push requests from vscode having multiline or no description in pom.xml
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -27,7 +27,20 @@ Cloud template no longer supports versioning. There are no alternatives.
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
 
+### Fixed pushing vROPs enabled vRLI alerts on large scale environments
+
+#### Previous Behaviour
+
+When pushing vROPs enabled vRLI alerts on large scale environments with more than 100000 the target vROPs integration data could 
+not be found due to page limits in the vROPs resources (fetched only the first 10000 resources on the vROPs level).
+
+#### New Behaviour
+
+When pushing vROPs enabled vRLI alerts on large scale environments all vROPs resources pages are fetched and for each of the pages
+the target resources is searched, thus finding the correct one in order the alert to be pushed successfully.
+
 ### Fixed vro push requests from vscode having multiline or no description in pom.xml
+
 #### Previous Behaviour
 
 When no description is specified description is taken from Aria Build Tools' pom.xml files.


### PR DESCRIPTION
Signed-off-by: Alexander Kantchev <akantchev@vmware.com>


### Description
Add support for pagination when searching for vROPs resources when pushing vROPs enabled vRLI alerts on large scale environment, thus making possible to find the correct resource name from the target vROPs server during rewriting the vROPs integration data on the vRLI alert. This applies for vRLI alert v1 and v2 API support.


### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Pushing vROPs enabled vRLI alerts on large scale environments can be done via maven command on a vRLI project:
mvn clean package vrealize:push -P <ENV_NAME>

### Release Notes

#### Old Behavior
When pushing vROPs enabled vRLI alerts on large scale environments with more than 100000 the target vROPs integration data could not be found due to page limits in the vROPs resources (fetched only the first 10000 resources on the vROPs level).

#### New Behavior
When pushing vROPs enabled vRLI alerts on large scale environments all vROPs resources pages are fetched and for each of the pages the target resources is searched, thus finding the correct one in order the alert to be pushed successfully.

### Related Issue

IAC-780
