### PR TITLE
Iac 778 backup on clean environment throws exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Fixes
 * [artifact-manager] IAC-788 / Fix vRA Custom Forms not enabled with vRA Version prior 8.12.x.
 * [artifact-manager] IAC-788 / Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x.
+* [artifact-manager] IAC-778 / Backup only works with current package version, otherwise throws exception 404 not found
 
 ### Enhancements
 * [vro-types/o11n-plugin-aria] IAC-789 / Adding new Aria Automation Plugin vRO inventory Types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+* [artifact-manager] IAC-778 / Backup only works with current package version, otherwise throws exception 404 not found
+
+## v2.36.0 - 16 Nov 2023
+
 ### Fixes
 * [artifact-manager] IAC-788 / Fix vRA Custom Forms not enabled with vRA Version prior 8.12.x.
 * [artifact-manager] IAC-788 / Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x.
-* [artifact-manager] IAC-778 / Backup only works with current package version, otherwise throws exception 404 not found
 
 ### Enhancements
 * [vro-types/o11n-plugin-aria] IAC-789 / Adding new Aria Automation Plugin vRO inventory Types

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VroPackageStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VroPackageStore.java
@@ -187,7 +187,7 @@ public class VroPackageStore extends GenericPackageStore<VroPackageDescriptor> {
 							samePackagesInDest.add(destinationEndpointPackages.get(i));
 						}
 					}
-					logger.info("Package versions to backup: " + pkg.getName());
+					logger.info("Package versions to backup: " + samePackagesInDest);
 					if (!samePackagesInDest.isEmpty()) {
 						for (Package eachPkgVersion: samePackagesInDest) {
 							String backupFilePath = this.createBackupFilePath(eachPkgVersion, currentDateTimeString, backupFilesDirectory);

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -9,13 +9,9 @@
 [//]: # (Describe the breaking change AND explain how to resolve it)
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
 
-
-
 ## Deprecations
 [//]: # (### *Deprecation*)
 [//]: # (Explain what is deprecated and suggest alternatives)
-
-
 
 [//]: # (Features -> New Functionality)
 ## Features
@@ -23,8 +19,6 @@
 [//]: # (Describe the feature)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
-
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
@@ -38,10 +32,6 @@
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
-
-
-
 
 ### Fixed backup of vRO packages so that the all available version are backed up
 #### Previous Behavior

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -41,35 +41,7 @@
 
 
 
-#### Current Behaviour
-When pushing vRA custom forms to vRA version 8.11.2 they are get enabled by default and visible in the blueprint section.
 
-### Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x
-
-#### Previous Behaviour
-If the vRA returns an empty versions array when fetching of latest vRA blueprint version would throw a null pointer exception.
-
-#### Current Behaviour
-If the vRA returns an empty versions array when fetching of latest vRA blueprint version it would not throw null pointer exception and add an empty string in the blueprint version string.
-
-### Update Deprecated Policy APIs for vROPs 8.12.x
-
-#### Previous Behaviour
-When pushing vROPs policies to vROPs 8.12.0 and above the deprecated internal policy API in vROPs is used.
-
-#### Current Behaviour
-When pushing vROPs policies to vROPs 8.12.0 and above the new public policy API in vROPs is used. The older versions of vROPs is also supported.
-
-### Fix SSH Session exitCode type
-
-#### Previous Behaviour
-When using SSH with typescript, the `exitCode` method has the type `void`. But technically, it returns an integer. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `exitCode` has type `Number`.
-
-#### Current Behaviour
-Method `.exitCode` should return type `Number` instead of type `void`
-
-#### Related issue
-<https://github.com/vmware/build-tools-for-vmware-aria/issues/180>
 
 ### Fixed backup of vRO packages so that the all available version are backed up
 #### Previous Behavior

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -102,6 +102,19 @@ Method `.exitCode` should return type `Number` instead of type `void`
 #### Related issue
 <https://github.com/vmware/build-tools-for-vmware-aria/issues/180>
 
+### Fixed backup of vRO packages so that the all available version are backed up
+#### Previous Behavior
+
+Back up of vRO packages (using the flag in the environment.properties file: vro_enable_backup=true)
+would only work if the currently imported packages (which are to back up), had the same version as the one in vRO.
+Otherwise, the import would throw an '404 Not found' exception and break the import process,
+due to not finding the same package and version to back up.
+
+#### New Behavior
+Back up of vRO packages now works by:
+- backing up all available versions in vRO of the imported package,
+- logging a message that back up is skipped for the package, if no versions of it are found in vRO, continuing with backup of next packages, and the import process.
+
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 


### PR DESCRIPTION
### Checklist

- [X] Lint and unit tests pass locally with my changes
- [X] I have added relevant error handling and logging messages to help troubleshooting
- [X] I have added necessary documentation (if appropriate)
- [X] I have updated CHANGELOG.md with a short summary of the changes introduced
- [X] I have tested against live environment, if applicable
- [X] My changes have been rebased and squashed to the minimal number of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date

### Testing

Testing was done through a regular import of packages through the installer, with a flag in the 'environment.properties' file: 'vro_enable_backup=true'
Tests were performed by having a different set of packages and versions in the local VMware Aria Orchestrator instance, in order to validate that the highest available version per package name is backed up (in the 'vro' folder), or that if no versions are found for the package in vRO to back up, a message is logged that the back up for this package is skipped. 
