### PR TITLE
[163] Fix typescript saga workflow imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixes
+* [typescript] 163 / The compiled SAGA workflow crashes when no imports are defined in saga yaml
+
 ## v2.35.0 - 11 Aug 2023
 
 ### Fixes

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -28,16 +28,16 @@
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
-[//]: # (### *Improvement Name* )
-[//]: # (Talk ONLY regarding the improvement)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### Previous Behavior)
-[//]: # (Explain how it used to behave, regarding to the change)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### New Behavior)
-[//]: # (Explain how it behaves now, regarding to the change)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
+### Fixed the compiled SAGA workflow crashes when no imports are defined in saga yaml
+
+#### Previous Behaviour
+
+When no imports were defined in typescript SAGA workflow file format, the compiled vRO workflow failed when being executied in vRO on Initilize scriptable task
+with null object error.
+
+#### New Behaviour
+
+When no imports are defined in typescript SAGA workflow file format, the compiled vRO workflow runs successfully.
 
 
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -1,33 +1,14 @@
-[//]: # (VERSION_PLACEHOLDER DO NOT DELETE)
-[//]: # (Used when working on a new release. Placed together with the Version.md)
-[//]: # (Nothing here is optional. If a step must not be performed, it must be said so)
-[//]: # (Do not fill the version, it will be done automatically)
-[//]: # (Quick Intro to what is the focus of this release)
-
 ## Breaking Changes
-[//]: # (### *Breaking Change*)
-[//]: # (Describe the breaking change AND explain how to resolve it)
-[//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
-
 
 
 ## Deprecations
-[//]: # (### *Deprecation*)
-[//]: # (Explain what is deprecated and suggest alternatives)
 
 
-
-[//]: # (Features -> New Functionality)
 ## Features
-[//]: # (### *Feature Name*)
-[//]: # (Describe the feature)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
 
 
-
-[//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
+
 ### Fixed the compiled SAGA workflow crashes when no imports are defined in saga yaml
 
 #### Previous Behaviour
@@ -39,10 +20,4 @@ with null object error.
 
 When no imports are defined in typescript SAGA workflow file format, the compiled vRO workflow runs successfully.
 
-
-
 ## Upgrade procedure:
-[//]: # (Explain in details if something needs to be done)
-
-[//]: # (## Changelog:)
-[//]: # (Pull request links)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -20,4 +20,4 @@ with null object error.
 
 When no imports are defined in typescript SAGA workflow file format, the compiled vRO workflow runs successfully.
 
-## Upgrade procedure:
+## Upgrade procedure

--- a/typescript/vrotsc/src/compiler/transformers/scripts/saga.ts
+++ b/typescript/vrotsc/src/compiler/transformers/scripts/saga.ts
@@ -6,9 +6,9 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -708,7 +708,7 @@ namespace vrotsc {
             }
             else {
                 builder.append(`var actionName = "${taskName}"`).appendLine();
-                builder.append(`var imports = [${saga.imports.map(x => `"${x}"`).join(", ")}];`).appendLine();
+                builder.append(`var imports = [${(saga.imports || []).map(x => `"${x}"`).join(", ")}];`).appendLine();
                 builder.append(`for (var i = 0; i < imports.length; i++) {`).appendLine();
                 builder.indent();
                 builder.append(`var moduleName = imports[i];`).appendLine();


### PR DESCRIPTION
### Description

Fixing issue The compiled SAGA workflow crashes when no imports are defined in saga yaml #163

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [ ] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1. Create typescript project with SAGA workflow (workflowName.saga.yaml)
2. Leave imports section empty
3. Build the typescript project with maven and push it to vRO environment.
4. Run the compiled saga workflow on vRO environment

### Release Notes

Fixed the compiled SAGA workflow crashes when no imports are defined in saga yaml

### Related issues and PRs

N/A