### PR TITLE
Using api version 37 if 38 or above is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Fixes
 * [typescript] 163 / The compiled SAGA workflow crashes when no imports are defined in saga yaml
+* [vCD-NG] 167 / When pushing extensibility plugins, if API version 38 or above is detected, the code will automatically switch to API version 37. Otherwise push doesn't work for vCD 10.5 and above.
 
 ## v2.35.0 - 11 Aug 2023
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
@@ -47,29 +47,86 @@ import com.vmware.pscoe.iac.artifact.rest.model.VcdPluginResourceDTO;
 import net.minidev.json.JSONArray;
 
 public class RestClientVcd extends RestClient {
+
+	/**
+	 * packageType.
+	 */
 	private static final PackageType packageType = PackageType.VCDNG;
 
+	/**
+	 * logger.
+	 */
 	private final Logger logger = LoggerFactory.getLogger(RestClientVcd.class);
 
+	/**
+	 * configuration.
+	 */
 	private ConfigurationVcd configuration;
+
+	/**
+	 * restTemplate.
+	 */
 	private RestTemplate restTemplate;
+
+	/**
+	 * apiVersion.
+	 */
 	private String apiVersion;
 
+	/**
+	 * versions api path.
+	 */
 	private static final String URL_VERSIONS = "api/versions";
+
+	/**
+	 * extensions api path.
+	 */
 	private static final String URL_UI_EXTENSION_BASE = "cloudapi/extensions/ui";
+
+	/**
+	 * extension base.
+	 */
 	private static final String URL_UI_EXTENSION_BY_ID = URL_UI_EXTENSION_BASE + "/%s";
+
+	/**
+	 * plugin base.
+	 */
 	private static final String URL_UI_PLUGIN_BY_ID = URL_UI_EXTENSION_BASE + "/%s/plugin";
+
+	/**
+	 * publish all path.
+	 */
 	private static final String URL_UI_PLUGIN_PUBLISH_ALL = URL_UI_EXTENSION_BASE + "/%s/tenants/publishAll";
+
+	/**
+	 * api version that is supported.
+	 */
+	private static final String API_VERSION_37 = "37.0";
+
+	/**
+	 * api version that is not yet supported.
+	 */
+	private static final String API_VERSION_38 = "38.0";
 
 	protected RestClientVcd(ConfigurationVcd configuration, RestTemplate restTemplate) {
 		this.configuration = configuration;
 		this.restTemplate = restTemplate;
 	}
 
+	/**
+	 * getRestTemplate.
+	 * 
+	 * @return RestTemplate
+	 */
 	public RestTemplate getRestTemplate() {
 		return restTemplate;
 	}
 
+	/**
+	 * getConfiguration.
+	 * 
+	 * @return Configuration
+	 */
 	@Override
 	protected Configuration getConfiguration() {
 		return this.configuration;
@@ -92,6 +149,9 @@ public class RestClientVcd extends RestClient {
 		return headers;
 	}
 
+	/**
+	 * getVersion.
+	 */
 	@Override
 	public String getVersion() {
 		if (this.apiVersion == null) {
@@ -108,12 +168,21 @@ public class RestClientVcd extends RestClient {
 					new HttpEntity<String>(headers), String.class);
 			JSONArray versionArray = JsonPath.parse(response.getBody()).read("$.versionInfo[*].version");
 			this.apiVersion = versionArray.get(versionArray.size() - 1).toString();
+			if (Double.parseDouble(this.apiVersion) >= Double.parseDouble(API_VERSION_38)) {
+				this.apiVersion = API_VERSION_37;
+			}
+
 			logger.debug("API version is: " + this.apiVersion);
 		}
 
 		return this.apiVersion;
 	}
 
+	/**
+	 * getAllUiExtensions.
+	 * 
+	 * @return List<Package>
+	 */
 	public List<Package> getAllUiExtensions() {
 		URI url = getURI(getURIBuilder().setPath(URL_UI_EXTENSION_BASE));
 		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, getVcdHttpEntity(), String.class);
@@ -127,6 +196,13 @@ public class RestClientVcd extends RestClient {
 		return extensions;
 	}
 	
+	/**
+	 * 
+	 * @param id extension id
+	 * @return Package
+	 * 
+	 * getUiExtension.
+	 */
 	public Package getUiExtension(String id) {
 		logger.debug("Getting UI extension for ID [" + id + "]...");
 		URI url = getURI(getURIBuilder().setPath(String.format(URL_UI_EXTENSION_BY_ID, id)));
@@ -141,6 +217,13 @@ public class RestClientVcd extends RestClient {
 				new File(pluginName + "-" + pluginVersion + "." + packageType));
 	}
 
+	/**
+	 * 
+	 * @param localPkg local package
+	 * @return Package
+	 * 
+	 * getUiExtension.
+	 */
 	public Package getUiExtension(Package localPkg) {
 		List<Package> extensions = getAllUiExtensions();
 		for (Package remotePkg : extensions) {
@@ -152,6 +235,13 @@ public class RestClientVcd extends RestClient {
 		return null;
 	}
 
+	/**
+	 * 
+	 * @param pkg package
+	 * @return Package
+	 * 
+	 * addUiExtension.
+	 */
 	public Package addUiExtension(Package pkg) {
 		logger.debug("Adding UI extension for [" + pkg + "]...");
 		VcdNgPackageManifest manifest = VcdNgPackageManifest.getInstance(pkg);
@@ -167,6 +257,12 @@ public class RestClientVcd extends RestClient {
 		return getUiExtension(pluginId);
 	}
 
+	/**
+	 * 
+	 * @param remotePkg remote package
+	 * 
+	 * removeUiExtension.
+	 */
 	public void removeUiExtension(Package remotePkg) {
 		logger.debug("Removing UI extension for [" + remotePkg + "]...");
 		URI url = getURI(getURIBuilder().setPath(String.format(URL_UI_EXTENSION_BY_ID, remotePkg.getId())));
@@ -174,6 +270,13 @@ public class RestClientVcd extends RestClient {
 		logger.debug("UI extension for [" + remotePkg + "] removed.");
 	}
 
+	/**
+	 * 
+	 * @param localPkg local package
+	 * @param remotePkg remote package
+	 * 
+	 * uploadUiPlugin.
+	 */
 	public void uploadUiPlugin(Package localPkg, Package remotePkg) {
 		logger.debug("Uploading plugin resource for [" + remotePkg + "].");
 		File pkgFile = new File(localPkg.getFilesystemPath());
@@ -206,6 +309,12 @@ public class RestClientVcd extends RestClient {
 		logger.debug("Plugin resource for [" + remotePkg + "] uploaded.");
 	}
 
+	/**
+	 * 
+	 * @param remotePkg remote package
+	 * 
+	 * deleteUiPlugin.
+	 */
 	public void deleteUiPlugin(Package remotePkg) {
 		logger.debug("Deleting plugin resource for [" + remotePkg + "]...");
 		URI url = getURI(getURIBuilder().setPath(String.format(URL_UI_PLUGIN_BY_ID, remotePkg.getId())));
@@ -213,6 +322,13 @@ public class RestClientVcd extends RestClient {
 		logger.debug("Plugin resource for [" + remotePkg + "] deleted.");
 	}
 	
+	/**
+	 * 
+	 * @param pkg package
+	 * @return Package
+	 * 
+	 * addOrReplaceUiPlugin.
+	 */
 	public Package addOrReplaceUiPlugin(Package pkg) {
 		Package remotePkg = this.getUiExtension(pkg);
 		if (remotePkg != null) {
@@ -227,6 +343,12 @@ public class RestClientVcd extends RestClient {
 		return remotePkg;
 	}
 	
+	/**
+	 * 
+	 * @param remotePkg remote package
+	 * 
+	 * publishUiPlugin.
+	 */
 	public void publishUiPlugin(Package remotePkg) {
 		logger.debug("Publishing UI extension [" + remotePkg + "] to all tenants...");
 		URI url = getURI(getURIBuilder().setPath(String.format(URL_UI_PLUGIN_PUBLISH_ALL, remotePkg.getId())));

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
@@ -181,7 +181,7 @@ public class RestClientVcd extends RestClient {
 	/**
 	 * getAllUiExtensions.
 	 * 
-	 * @return List<Package>
+	 * @return list of packages
 	 */
 	public List<Package> getAllUiExtensions() {
 		URI url = getURI(getURIBuilder().setPath(URL_UI_EXTENSION_BASE));

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
@@ -169,6 +169,7 @@ public class RestClientVcd extends RestClient {
 			JSONArray versionArray = JsonPath.parse(response.getBody()).read("$.versionInfo[*].version");
 			this.apiVersion = versionArray.get(versionArray.size() - 1).toString();
 			if (Double.parseDouble(this.apiVersion) >= Double.parseDouble(API_VERSION_38)) {
+				logger.warn("Detected vCD API version equal or greater than " + API_VERSION_38 + ". Switching to using API version " + API_VERSION_37);
 				this.apiVersion = API_VERSION_37;
 			}
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcd.java
@@ -51,7 +51,7 @@ public class RestClientVcd extends RestClient {
 	/**
 	 * packageType.
 	 */
-	private static final PackageType packageType = PackageType.VCDNG;
+	private static final PackageType PACKAGE_TYPE = PackageType.VCDNG;
 
 	/**
 	 * logger.
@@ -213,8 +213,8 @@ public class RestClientVcd extends RestClient {
 		String pluginVersion = JsonPath.parse(response.getBody()).read("$.version");
 
 		logger.debug("UI extension for ID [" + id + "] retrieved.");
-		return PackageFactory.getInstance(packageType, pluginId,
-				new File(pluginName + "-" + pluginVersion + "." + packageType));
+		return PackageFactory.getInstance(PACKAGE_TYPE, pluginId,
+				new File(pluginName + "-" + pluginVersion + "." + PACKAGE_TYPE));
 	}
 
 	/**

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
@@ -98,6 +98,7 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 			String apiVersion) {
 		super(configuration, restTemplate);
 		if (Double.parseDouble(apiVersion) >= Double.parseDouble(API_VERSION_38)) {
+			logger.warn("Detected vCD API version equal or greater than " + API_VERSION_38 + ". Switching to using API version " + API_VERSION_37);
 			apiVersion = API_VERSION_37;
 		}
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
@@ -38,24 +38,80 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RestClientVcdBasicAuthInterceptor extends RestClientRequestInterceptor<ConfigurationVcd> {
+
+	/**
+	 * logger.
+	 */
 	private final Logger logger = LoggerFactory.getLogger(RestClientVcdBasicAuthInterceptor.class);
 
+	/**
+	 * vcloudToken.
+	 */
 	private String vcloudToken;
+
+	/**
+	 * bearerToken.
+	 */
 	private String bearerToken;
+
+	/**
+	 * contentType.
+	 */
 	private MediaType contentType;
 
+	/**
+	 * session api path.
+	 */
 	private static final String URL_SESSION = "/api/sessions";
+	
+	/**
+	 * version api path.
+	 */
 	private static final String URL_VERSION = "/api/versions";
+
+	/**
+	 * vcloud header key.
+	 */
 	private static final String HEADER_VCLOUD_TOKEN = "x-vcloud-authorization";
+
+	/**
+	 * bearer token header key.
+	 */
 	private static final String HEADER_BEARER_TOKEN = "x-vmware-vcloud-access-token";
+
+	/**
+	 * authorization header key.
+	 */
 	private static final String HEADER_AUTHORIZATION = "Authorization";
+
+	/**
+	 * api version that is supported.
+	 */
+	private static final String API_VERSION_37 = "37.0";
+
+	/**
+	 * api version that is not yet supported.
+	 */
+	private static final String API_VERSION_38 = "38.0";
 
 	protected RestClientVcdBasicAuthInterceptor(ConfigurationVcd configuration, RestTemplate restTemplate,
 			String apiVersion) {
 		super(configuration, restTemplate);
+		if (Double.parseDouble(apiVersion) >= Double.parseDouble(API_VERSION_38)) {
+			apiVersion = API_VERSION_37;
+		}
+
 		this.contentType = VcdApiHelper.buildMediaType("application/*+json", apiVersion);
 	}
 
+	/**
+	 * Intercepts all requests done to the vCD API.
+	 * 
+	 * @param request Http request
+	 * @param body body
+	 * @param execution request execution
+	 * @return ClientHttpResponse
+	 */
 	@Override
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) {
 		try {
@@ -90,6 +146,10 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 				this.getConfiguration().getDomain(), this.getConfiguration().getPassword()));
 		final HttpEntity<String> entity = new HttpEntity<>(headers);
 		
+		logger.warn("token uri: " + tokenUri);
+		logger.warn("Auth: " + VcdApiHelper.buildBasicAuth(this.getConfiguration().getUsername(),
+				this.getConfiguration().getDomain(), this.getConfiguration().getPassword()));
+
 		final ResponseEntity<String> response = getRestTemplate().exchange(tokenUri, HttpMethod.POST, entity,
 				String.class);
 		this.vcloudToken = response.getHeaders().get(HEADER_VCLOUD_TOKEN).get(0);

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -20,4 +20,14 @@ with null object error.
 
 When no imports are defined in typescript SAGA workflow file format, the compiled vRO workflow runs successfully.
 
+### Fixed push to vCD failing if API version is >= 38.0
+
+#### Previous Behaviour
+
+When using vCD 10.5 there is a breaking change affecting the way authentication works and as a consequence the push to vCD is failing.
+
+#### New Behaviour
+
+This introduces a quick fix to the problem: if API version 38.0 or later is detected, simply use 37.0 which we know works as expected.
+
 ## Upgrade procedure


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

When using vCD 10.5 there is a breaking change affecting the way authentication works. This PR introduces a quick fix to the problem.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [x] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested agains vCD 10.5 and 10.4

### Release Notes

Introduced a simple if logic which switches to API version 37.0 if it detects present API version is 38.0 or above

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
