### PR TITLE
[Task IAC-785] Fixed problem with pushing vRA content-items to vRA 8.13.x

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrang/VraNgCatalogItem.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrang/VraNgCatalogItem.java
@@ -206,6 +206,9 @@ public class VraNgCatalogItem {
 	 * @return VraNgContentSourceType
 	 */
 	public VraNgContentSourceType getType() {
+		if (this.type == null) {
+			return VraNgContentSourceType.UNKNOWN;
+		}
 		return this.type.getId();
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNgPrimitive.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNgPrimitive.java
@@ -296,10 +296,13 @@ public class RestClientVraNgPrimitive extends RestClient {
 	 */
 	private Version productVersion;
 	/**
-	 * productVersion.
+	 * default page size.
 	 */
 	private static final int PAGE_SIZE = 500;
-
+	/**
+	 * vRA 8.12 version.
+	 */
+	private static final String VRA_8_12 = "8.12.0.21583018";
 	/**
 	 * isVraAbove812.
 	 */
@@ -315,7 +318,7 @@ public class RestClientVraNgPrimitive extends RestClient {
 		this.configuration = config;
 		this.restTemplate = restTemp;
 		this.productVersion = this.getProductVersion();
-		this.isVraAbove812 = this.isVraAbove(new Version("8.12.0.21583018"));
+		this.isVraAbove812 = this.isVraAbove(new Version(VRA_8_12));
 	}
 
 	/**
@@ -2063,7 +2066,7 @@ public class RestClientVraNgPrimitive extends RestClient {
 	protected void updateStorageProfilePrimitive(final String profileId, final VraNgStorageProfile profile)
 			throws URISyntaxException {
 		URI url = getURI(getURIBuilder().setPath(SERVICE_STORAGE_PROFILE + "/" + profileId));
-		ResponseEntity<String> response = this.putJsonPrimitive(url, profile.getJson());
+		this.putJsonPrimitive(url, profile.getJson());
 	}
 
 	/**
@@ -2201,7 +2204,7 @@ public class RestClientVraNgPrimitive extends RestClient {
 			final VraNgStorageProfile profile)
 			throws URISyntaxException {
 		URI url = getURI(getURIBuilder().setPath(SERVICE_IAAS_BASE + "/" + patchTarget + "/" + profileId));
-		ResponseEntity<String> response = this.postJsonPrimitive(url, HttpMethod.PATCH, profile.getJson());
+		this.postJsonPrimitive(url, HttpMethod.PATCH, profile.getJson());
 	}
 
 	/**

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class CustomFolderFileFilter implements FilenameFilter {
-	/*
+	/**
 	 * Descriptor names (content.yaml contents per asset).
 	 */
 	private final List<String> descriptionNames;
-	/*
+	/**
 	 * Logger instance.
 	 */
 	private final Logger logger;

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
@@ -24,25 +24,29 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class CustomFolderFileFilter implements FilenameFilter {
+	/*
+	 * Descriptor names (content.yaml contents per asset).
+	 */
 	private final List<String> descriptionNames;
+	/*
+	 * Logger instance.
+	 */
 	private final Logger logger;
 
 	public CustomFolderFileFilter(List<String> descriptionNames) {
 		super();
-		// convert the descriptor content to lower case (in order search to be case insensitive)
-		this.descriptionNames = descriptionNames == null ?
-				null :
-				descriptionNames.stream().map(item -> item.toLowerCase().trim()).collect(Collectors.toList());
+		// convert the descriptor content to lower case (in order search to be case insensitive).
+		this.descriptionNames = descriptionNames == null ? null : descriptionNames.stream().map(item -> item.toLowerCase().trim()).collect(Collectors.toList());
 		this.logger = LoggerFactory.getLogger(this.getClass());
 	}
 
 	/**
-	 * Method that filters files based on what is defined in the content.yaml
-	 * Accepts only files and filters them by name as defined in their respective categories in the content.yaml
+	 * Method that filters files based on what is defined in the content.yaml.
+	 * Accepts only files and filters them by name as defined in their respective categories in the content.yaml.
 	 * 
-	 * @param dir File to filter
-	 * @param name name of the file
-	 * @return boolean
+	 * @param dir File to filter.
+	 * @param name name of the file.
+	 * @return boolean.
 	 */
 	@Override
 	public boolean accept(File dir, String name) {
@@ -51,14 +55,14 @@ public class CustomFolderFileFilter implements FilenameFilter {
 		logger.debug("Items in descriptor (content.yaml): {}", items);
 
 		File currentFile = new File(dir, name);
-		//There are cases where in the main item folder, there is a sub-directory, e.g. catalog-item/forms/
+		// There are cases where in the main item folder, there is a sub-directory, e.g. catalog-item/forms/.
 		if (currentFile.isDirectory()) { 
 			return false;
 		}
 
-		// following name replace regex, matches the file extension only, by which it enables to have "." in the names 
-		// for the different entities - bps, forms, etc. e.g. Name "RHEL 8.X Family" -> produced "RHEL 8.X Family.json" 
-		// -> run replaceFirst [.][^.]+$ = "" -> RHEL 8.X Family, furthermore the search in the descriptor is case insensitive
+		// Following name replace regex, matches the file extension only, by which it enables to have "." in the names
+		// for the different entities - bps, forms, etc. e.g. Name "RHEL 8.X Family" -> produced "RHEL 8.X Family.json"
+		// -> run replaceFirst [.][^.]+$ = "" -> RHEL 8.X Family, furthermore the search in the descriptor is case insensitive.
 		return descriptionNames == null || descriptionNames.contains(name.replaceFirst("[.][^.]+$", "").toLowerCase().trim());
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CustomFolderFileFilter implements FilenameFilter {
 	private final List<String> descriptionNames;
@@ -28,7 +29,10 @@ public class CustomFolderFileFilter implements FilenameFilter {
 
 	public CustomFolderFileFilter(List<String> descriptionNames) {
 		super();
-		this.descriptionNames = descriptionNames;
+		// convert the descriptor content to lower case (in order search to be case insensitive)
+		this.descriptionNames = descriptionNames == null ?
+				null :
+				descriptionNames.stream().map(item -> item.toLowerCase().trim()).collect(Collectors.toList());
 		this.logger = LoggerFactory.getLogger(this.getClass());
 	}
 
@@ -45,14 +49,16 @@ public class CustomFolderFileFilter implements FilenameFilter {
 		logger.debug("Process file for filtering '{}/{}'", dir.getAbsolutePath(), name);
 		String items = descriptionNames != null ? String.join(", ", descriptionNames) : "NULL";
 		logger.debug("Items in descriptor (content.yaml): {}", items);
+
 		File currentFile = new File(dir, name);
 		//There are cases where in the main item folder, there is a sub-directory, e.g. catalog-item/forms/
 		if (currentFile.isDirectory()) { 
 			return false;
 		}
+
 		// following name replace regex, matches the file extension only, by which it enables to have "." in the names 
 		// for the different entities - bps, forms, etc. e.g. Name "RHEL 8.X Family" -> produced "RHEL 8.X Family.json" 
-		// -> run replaceFirst [.][^.]+$ = "" -> RHEL 8.X Family
-		return descriptionNames == null || descriptionNames.contains(name.replaceFirst("[.][^.]+$", ""));
+		// -> run replaceFirst [.][^.]+$ = "" -> RHEL 8.X Family, furthermore the search in the descriptor is case insensitive
+		return descriptionNames == null || descriptionNames.contains(name.replaceFirst("[.][^.]+$", "").toLowerCase().trim());
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/CustomFolderFileFilter.java
@@ -33,6 +33,10 @@ public class CustomFolderFileFilter implements FilenameFilter {
 	 */
 	private final Logger logger;
 
+	/**
+	 * Constructor.
+	 * @param descriptionNames Items as they appear in the content.yaml file.
+	 */	
 	public CustomFolderFileFilter(List<String> descriptionNames) {
 		super();
 		// convert the descriptor content to lower case (in order search to be case insensitive).

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/filters/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vRA 8 Vrang file filters.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.store.filters;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore.java
@@ -477,8 +477,9 @@ public class VraNgCatalogItemStore extends AbstractVraNgStore {
 		// Building a map of content sources (by ID) to catalog items that should be
 		// available for them
 		VrangContentSourceUtils utils = new VrangContentSourceUtils(restClient, vraNgPackage);
+		// fetch the unique content source names
 		List<String> contentSourceNames = catalogItems.stream().map(VraNgCatalogItem::getSourceName)
-				.collect(Collectors.toList());
+				.distinct().collect(Collectors.toList());
 		restClient.getContentSourcesForProject(restClient.getProjectId()).forEach(contentSource -> {
 			String contentSourceName = contentSource.getName();
 			if (contentSourceNames.contains(contentSourceName)) {

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -9,6 +9,20 @@
 
 ## Improvements
 
+### Fixed importing of vRA content items on vRA 8.13.x
+
+#### Previous Behavior
+
+When pushing vRA content items to vRA 8.13.x the pushing fails with the following error:
+Cannot invoke "com.vmware.pscoe.iac.artifact.model.vrang.VraNgCatalogItemType.getId()" because "this.type" is null 
+When the content item naming case in the content.yaml file is different from the file names that are in the content-items directory 
+they are not pushed to the target environment (skipped).
+
+#### New Behavior
+
+When pushing the vRA content items to  vRA 8.13.x it no longer fails. The content naming in the content.yaml is no longer case sensitive 
+againist the file names in the content-items directory, thus the content-items names in the content.yaml file are no longer case sensitive.
+
 ### Fixed the compiled SAGA workflow crashes when no imports are defined in saga yaml
 
 #### Previous Behaviour

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -14,13 +14,13 @@
 #### Previous Behavior
 
 When pushing vRA content items to vRA 8.13.x the pushing fails with the following error:
-Cannot invoke "com.vmware.pscoe.iac.artifact.model.vrang.VraNgCatalogItemType.getId()" because "this.type" is null 
-When the content item naming case in the content.yaml file is different from the file names that are in the content-items directory 
+Cannot invoke "com.vmware.pscoe.iac.artifact.model.vrang.VraNgCatalogItemType.getId()" because "this.type" is null
+When the content item naming case in the content.yaml file is different from the file names that are in the content-items directory
 they are not pushed to the target environment (skipped).
 
 #### New Behavior
 
-When pushing the vRA content items to  vRA 8.13.x it no longer fails. The content naming in the content.yaml is no longer case sensitive 
+When pushing the vRA content items to  vRA 8.13.x it no longer fails. The content naming in the content.yaml is no longer case sensitive
 againist the file names in the content-items directory, thus the content-items names in the content.yaml file are no longer case sensitive.
 
 ### Fixed the compiled SAGA workflow crashes when no imports are defined in saga yaml


### PR DESCRIPTION
 Fixed problem with pushing vRA content-items to vRA 8.13.x, made content-items in the content.yaml to be no longer case sensitive againist the files in the content-items directory.

Signed-off-by: Alexander Kantchev <akantchev@vmware.com>

<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixed problem with pushing vRA content-items to vRA 8.13.x, made content-items in the content.yaml to be no longer case sensitive againist the files in the content-items directory.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have tested against live environment, if applicable
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Change the casing of the content-items in the content.yaml (to be different from the file names casing) and try to push the content to vRA environment.

### Release Notes

When pushing the vRA content items to  vRA 8.13.x it no longer fails. The content naming in the content.yaml is no longer case sensitive 

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
