### PR TITLE
[Task IAC-786] Implementation of the vROPs default policy feature for vROPs 8.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## v2.35.2
+### Enhancements
+* [artifact-manager] IAC-786 / Set Aria Operations Default Policy vROPs 8.12.x.
+
 ## v2.35.1 - 29 Sep 2023
 
 ### Fixes
+* [artifact-manager] IAC-785 / vRA custom form import failure with vRA version 8.11.2 and above, made content-item search in content.yaml case insensitive againist the directory item names.
 * [typescript] 163 / The compiled SAGA workflow crashes when no imports are defined in saga yaml
 * [vCD-NG] 167 / When pushing extensibility plugins, if API version 38 or above is detected, the code will automatically switch to API version 37. Otherwise push doesn't work for vCD 10.5 and above.
 

--- a/common/artifact-manager/pom.xml
+++ b/common/artifact-manager/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<parent>
 		<artifactId>iac</artifactId>
@@ -57,25 +58,26 @@
 			<artifactId>httpclient</artifactId>
 			<version>4.5.13</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
 			<version>2.4.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.9</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>2.12.7</version>
 		</dependency>
-
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.15.2</version>
+		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
@@ -116,20 +118,17 @@
 			<artifactId>spring-core</artifactId>
 			<version>5.2.24.RELEASE</version>
 		</dependency>
-
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.7</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.3.2</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
@@ -159,14 +158,11 @@
 			<artifactId>snakeyaml</artifactId>
 			<version>1.33</version>
 		</dependency> -->
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.22</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
-
 </project>

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
@@ -1153,16 +1153,16 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 	 * @return VropsPackageDescriptor POJO with the populated values from the content.yaml file.
 	 * @throws RuntimeException if the content yaml cannot be parsed.
 	 */
-    @SuppressWarnings("deprecation")
+	@SuppressWarnings("deprecation")
 	private VropsPackageDescriptor parseContentYamlFile(final File contentYamlFile) {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
-        try {
-            return mapper.readValue(contentYamlFile, VropsPackageDescriptor.class);
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Unable to load vROps Package Descriptor ['%s'] : %s", contentYamlFile.getName(), e.getMessage()));
-        }
-    }
+		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+		mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+		try {
+			return mapper.readValue(contentYamlFile, VropsPackageDescriptor.class);
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Unable to load vROps Package Descriptor ['%s'] : %s", contentYamlFile.getName(), e.getMessage()));
+		}
+	}
 
 	/**
 	 * Updates the default policy in the content yaml file (if there is one set).

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/VropsPackageStore.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -56,8 +57,12 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.jcraft.jsch.JSchException;
 import com.vmware.pscoe.iac.artifact.cli.CliManagerVrops;
 import com.vmware.pscoe.iac.artifact.cli.ZipUtilities;
@@ -102,12 +107,10 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 	 * Variable for logging.
 	 */
     private final Logger logger = LoggerFactory.getLogger(VropsPackageStore.class);
-
 	/**
 	 * The vRO rest client.
 	 */
 	private RestClientVrops restClient;
-
 	/**
 	 * Constant for policy metadata file name.
 	 */
@@ -128,7 +131,6 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 	 * Action constant.
 	 */
     private static final String ACTION_SHARE = "share";
-
 	/**
 	 * Constant for action unshare.
 	 */
@@ -142,10 +144,13 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 	 */
 	private static final String ACTION_DEACTIVATE = "deactivate";
 	/**
+	 * Content yaml file name.
+	 */
+	private static final String CONTENT_YAML_FILE_NAME = "content.yaml";
+	/**
 	 * CLI Manager.
 	 */
     private CliManagerVrops cliManager;
-
 	/**
 	 * Variable for temp dir.
 	 */
@@ -154,7 +159,6 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 	 * Variable for temp vROPS export dir.
 	 */
     private final File tempVropsExportDir;
-
 	/**
 	 * Variable for temp vROPS import dir.
 	 */
@@ -379,6 +383,7 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         try {
             if (!dryrun) {
                 File destDir = new File(vropsPackage.getFilesystemPath());
+                this.setDefaultPolicyInContentYaml(vropsPackageDescriptor, destDir.getParentFile().getParentFile().getParentFile());
                 PackageManager.copyContents(tempVropsExportDir, destDir);
             }
         } catch (IOException ioe) {
@@ -396,6 +401,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         return vropsPackage;
     }
 
+	/**
+     * Export views from vROPs.
+     * @param vropsPackage Package to export views to.
+     * @param viewNames   List of views to be exported.
+     * @throws RuntimeException if there are no views on vROPs server or the export fails.
+     */
     private void exportViews(final Package vropsPackage, final List<String> viewNames) {
         ViewDefinitionDTO allViewDefinitions = restClient.getAllViewDefinitions();
         if (allViewDefinitions.getViewDefinitions().isEmpty()) {
@@ -424,6 +435,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Export super metrics from vROPs.
+     * @param vropsPackage Package to export super metrics to.
+     * @param superMetricNames   List of super metrics to be exported.
+     * @throws RuntimeException if there are no super metrics on vROPs server or the export fails.
+     */
     private void exportSuperMetrics(final Package vropsPackage, final List<String> superMetricNames) {
         SupermetricDTO allSupermetrics = restClient.getAllSupermetrics();
         if (allSupermetrics.getSuperMetrics().isEmpty()) {
@@ -454,6 +471,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Export metrics configs from vROPs.
+     * @param vropsPackage Package to export metric configs to.
+     * @param metricConfigNames List of metric configs to be exported.
+     * @throws RuntimeException If the the export fails.
+     */
     private void exportMetricConfigs(final Package vropsPackage, final List<String> metricConfigNames) {
         File metricConfigsDir = new File(this.tempVropsExportDir, "metricconfigs");
         if (!metricConfigsDir.exists()) {
@@ -482,6 +505,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Copy the exported views from vROPs to the local file system.
+     * @param view view to be copied.
+     * @param dir directory where the view to be copied.
+     * @throws RuntimeException If the the copy fails.
+     */
     private void copyViewToFilesystem(final String view, final File dir) {
         try {
             File viewDir = new File(tempDir, "iac-view-" + UUID.randomUUID().toString() + "-" + System.currentTimeMillis());
@@ -502,6 +531,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Copy the exported super metric from vROPs to the local file system.
+     * @param superMetric super metric to be copied.
+     * @param dir directory where the view to be copied.
+     * @throws RuntimeException If the the copy fails.
+     */
     private void copySuperMetricToFilesystem(final String superMetric, final File dir) {
         try {
             File superMetricDir = new File(this.tempDir, "iac-supermetric-" + UUID.randomUUID().toString() + "-" + System.currentTimeMillis());
@@ -518,6 +553,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Copy the exported metric config from vROPs to the local file system.
+     * @param metricConfig metric config to be copied.
+     * @param dir directory where the view to be copied.
+     * @throws RuntimeException If the the copy fails.
+     */
     private void copyMetricConfigToFilesystem(final String metricConfig, final File dir) {
         try {
             File metricConfigsDir = new File(this.tempDir, "iac-metricconfig-" + UUID.randomUUID().toString() + "-" + System.currentTimeMillis());
@@ -537,6 +578,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Export dashboards from vROPs.
+     * @param vropsPackage Package to export dashboards to.
+     * @param dashboardNames   List of dashboards to be exported.
+     * @throws RuntimeException if the export fails.
+     */
     private void exportDashboards(final Package vropsPackage, final List<String> dashboardNames) {
         File dashboardsDir = new File(tempVropsExportDir, "dashboards");
         logger.info("Created dashboard temporary directory {} ", dashboardsDir.getAbsolutePath());
@@ -567,6 +614,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Export reports from vROPs.
+     * @param vropsPackage Package to export reports to.
+     * @param reportNames   List of reports to be exported.
+     * @throws RuntimeException if there are no reports on the server or the export fails.
+     */
     private void exportReports(final Package vropsPackage, final List<String> reportNames) {
         ReportDefinitionDTO allReportDefinitions = restClient.getAllReportDefinitions();
         if (allReportDefinitions.getReportDefinitions().isEmpty()) {
@@ -595,7 +648,13 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
             cliManager.close();
         }
     }
-    
+
+	/**
+     * Import definitions in vROPs. The following definitions are supported: alert definitions, symptom definitions, recommendations.
+     * @param vropsPackage Package to export reports to.
+     * @param tmpDir   Directory where the definitions will be read from.
+     * @throws RuntimeException if the import fails.
+     */
     private void importDefinitions(final Package vropsPackage, final File tmpDir) throws IOException {
         StringBuilder messages = new StringBuilder();
         ObjectMapper mapper = new ObjectMapper();
@@ -663,6 +722,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+     * Activate / Deactivate dashboards per user or group, based on the data in the activation metadata file.
+     * @param rootDir Root directory where the dashboards and the metadata files reside.
+     * @param isGroupActivation flag wheter group activation is specified.
+     * @throws RuntimeException if the activation / deactivation per user or group fails.
+     */
 	private void manageDashboardActivation(final File rootDir, final boolean isGroupActivation) {
 		Map<String, Map<String, List<String>>> activationMetadata = this.getDashboardActivationMetadata(rootDir, isGroupActivation);
 		if (activationMetadata.isEmpty()) {
@@ -705,6 +770,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 		});
 	}
 
+	/**
+     * Share / un-share dashboards based on the dashboard sharing metadata file.
+     * @param rootDir Root directory where the dashboards and the metadata file reside.
+     * @throws RuntimeException if the sharing / unsharing per user or group fails.
+     */
     private void manageDashboardSharing(final File rootDir) {
         Map<String, Map<String, List<String>>> sharingMetadata = this.getDashboardSharingMetadata(rootDir);
 		if (sharingMetadata.isEmpty()) {
@@ -746,6 +816,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         });
     }
 
+	/**
+     * Return the missing groups for dashboard sharing / unsharing / activation / deactivation.
+     * @param groups List of groups to be checked whether they are present on vROPs server.
+     * @return list of missing groups.
+     */
     private List<String> getMissingGroups(final List<String> groups) {
         List<AuthGroupDTO> foundGroups = this.restClient.findAuthGroupsByNames(groups);
         if (foundGroups == null || foundGroups.isEmpty()) {
@@ -755,6 +830,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         return groups.stream().filter(group -> foundGroups.stream().noneMatch(t -> t.getDisplayName().equals(group))).collect(Collectors.toList());
     }
 
+	/**
+     * Return the missing users for dashboard sharing / unsharing / activation / deactivation.
+     * @param users List of users to be checked whether they are present on vROPs server.
+     * @return list of missing users.
+     */
     private List<String> getMissingUsers(final List<String> users) {
         List<AuthUserDTO> foundUsers = this.restClient.findAuthUsersByNames(users);
         if (foundUsers == null || foundUsers.isEmpty()) {
@@ -798,8 +878,8 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 
 	/**
 	 * Gets dashboard sharing metadata.
-	 * @param rootDir
-	 * @return the dashboard sharing metadata.
+	 * @param rootDir root directory of the dashboard sharing metadata file.
+	 * @return the dashboard sharing metadata hashmap.
 	 */
     @SuppressWarnings("unchecked")
     private Map<String, Map<String, List<String>>> getDashboardSharingMetadata(final File rootDir) {
@@ -828,6 +908,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Gets dashboard activation metadata.
+	 * @param rootDir root directory of the dashboard activation metadata file.
+	 * @param isGroupActivation return the group activation metadata.
+	 * @return the dashboard activation metadata hashmap.
+	 */
     @SuppressWarnings("unchecked")
     private Map<String, Map<String, List<String>>> getDashboardActivationMetadata(final File rootDir, final boolean isGroupActivation) {
         // get dashboard activation metadata
@@ -855,6 +941,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Store the policy metadata file.
+	 * @param rootDir root directory where to store policy metadata file.
+	 * @param policyMetadata hashmap with policy meta data.
+	 */
     private void storePolicyMetadata(final File rootDir, final Map<String, String> policyMetadata) {
         // generate policy metadata file
         File policyMetadataFile = new File(rootDir, POLICY_METADATA_FILENAME);
@@ -876,6 +967,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Store the dashboard sharing metadata file.
+	 * @param rootDir root directory where to store the dashboard sharing metadata file.
+	 * @param dashboards list of dashboards to be put in the file.
+	 */
     private void storeDashboardSharingMetadata(final File rootDir, final List<String> dashboards) {
         // generate dashboard sharing metadata file
         File dashboardShareMetadataFile = new File(rootDir, DASHBOARD_SHARE_METADATA_FILENAME);
@@ -907,6 +1003,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Store the dashboard activation / deactivation metadata file.
+	 * @param rootDir root directory where to store the dashboard activation / deactivation metadata file.
+	 * @param dashboards list of dashboards to be put in the file.
+	 * @param isGroupActivation flag whether the metadata is for group activation / deactivation.
+	 */
     private void storeDashboardActivationMetadata(final File rootDir, final List<String> dashboards, final boolean isGroupActivation) {
         // generate dashboard activation metadata file
         String fileName = isGroupActivation ? DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME : DASHBOARD_USER_ACTIVATE_METADATA_FILENAME;
@@ -940,6 +1042,11 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Import custom groups to vROPs server.
+	 * @param vropsPackage package to read the custom groups from.
+	 * @param tmpDir temporary directory where to unwrap custom groups to.
+	 */
     private void importCustomGroups(final Package vropsPackage, final File tmpDir) {
         File customGroupsDir = new File(tmpDir.getPath(), "custom_groups");
         if (!customGroupsDir.exists()) {
@@ -966,6 +1073,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Read custom group file.
+	 * @param customGroupFile JSON file to read from.
+	 * @return string with JSON data read from file.
+	 * @throws IOException if the file cannot be read.
+	 */
     private String readCustomGroupFile(final File customGroupFile) throws IOException {
         try {
             return FileUtils.readFileToString(customGroupFile, StandardCharsets.UTF_8);
@@ -974,6 +1087,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
 		}
     }
 
+	/**
+	 * Import policies to vROPs.
+	 * @param vropsPackage package to read policies from.
+	 * @param tmpDir temporary dir where to unwrap polices to.
+	 * @throws RuntimeException if the polices cannot be imported.
+	 */
     private void importPolicies(final Package vropsPackage, final File tmpDir) {
         File policiesDir = new File(tmpDir.getPath(), "policies");
         if (!policiesDir.exists()) {
@@ -999,6 +1118,105 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Set the default policy in vROPs. Note it will not do anything if:
+     * 1. vROPs version is below 8.12 (as it is not supported by the vROPS API).
+     * 2. No default policy is set in the content.yaml file.
+	 * @param vropsPackage package to read policies from.
+	 * @param tmpDir temporary directory where the content.yaml file resides.
+	 * @throws RuntimeException if the default policy cannot be set.
+	 */
+    private void setDefaultPolicy(final Package vropsPackage, final File tmpDir) {
+        if (!tmpDir.exists()) {
+            return;
+        }
+        File contentYamlFile = new File(tmpDir, CONTENT_YAML_FILE_NAME);
+        VropsPackageDescriptor descriptor = this.parseContentYamlFile(contentYamlFile);
+
+        if (descriptor.getDefaultPolicy() == null || descriptor.getDefaultPolicy().size() == 0) {
+            return;
+        }
+        String defaultPolicyName = descriptor.getDefaultPolicy().stream().findFirst().orElse(null);
+        if (StringUtils.isEmpty(defaultPolicyName)) {
+            return;
+        }
+        try {
+            restClient.setDefaultPolicy(defaultPolicyName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+	/**
+	 * Parse the content.yaml file.
+	 * @param contentYamlFile content.yaml file handle.
+	 * @return VropsPackageDescriptor POJO with the populated values from the content.yaml file.
+	 * @throws RuntimeException if the content yaml cannot be parsed.
+	 */
+    @SuppressWarnings("deprecation")
+	private VropsPackageDescriptor parseContentYamlFile(final File contentYamlFile) {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+        try {
+            return mapper.readValue(contentYamlFile, VropsPackageDescriptor.class);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to load vROps Package Descriptor ['%s'] : %s", contentYamlFile.getName(), e.getMessage()));
+        }
+    }
+
+	/**
+	 * Updates the default policy in the content yaml file (if there is one set).
+	 * @param packageDescriptor the package descriptor POJO that will be serialized to the content.yaml file.
+	 * @param destDir destination directory where the content.yaml file resides.
+	 */
+	private void setDefaultPolicyInContentYaml(final VropsPackageDescriptor packageDescriptor, final File destDir) {
+		// if there is already a default policy set in the package descriptor skip setting it
+		if (packageDescriptor.getDefaultPolicy() != null && !packageDescriptor.getDefaultPolicy().isEmpty()) {
+			return;
+		}
+		PolicyDTO.Policy defaultPolicy;
+		try {
+			defaultPolicy = restClient.getDefaultPolicy();
+			// if there is no default policy set in the vROPs then skip setting it
+			if (defaultPolicy == null) {
+				return;
+			}
+			packageDescriptor.setDefaultPolicy(Arrays.asList(new String[] { defaultPolicy.getName() }));
+			this.updateContentYamlFile(new File(String.format("%s/%s", destDir, CONTENT_YAML_FILE_NAME)), packageDescriptor);
+		} catch (Exception e) {
+			logger.warn("Unable to set default policy in the content.yaml file: {}", e.getMessage());
+		}
+	}
+
+    /**
+     * Updates the package descriptor value to the content.yaml file.
+	 * @param contentYamlFile content.yaml file handle.
+	 * @param packageDescriptor the package descriptor POJO that will be serialized to the content.yaml file.
+	 * @throws RuntimeException if the content yaml cannot be written.
+     */
+    @SuppressWarnings("deprecation")
+    private void updateContentYamlFile(final File contentYamlFile, final VropsPackageDescriptor packageDescriptor) {
+        String defaultPolicyName = packageDescriptor.getDefaultPolicy().stream().findFirst().orElse(null);
+        if (defaultPolicyName == null) {
+            return;
+        }
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+        ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());
+        try {
+            logger.info("Updating the default vROPs policy in file '{}' to '{}'", contentYamlFile.getName(), defaultPolicyName);
+            writer.writeValue(contentYamlFile, packageDescriptor);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to write the vROps Package Descriptor to file '%s' : %s", contentYamlFile.getName(), e.getMessage()));
+        }
+    }
+
+	/**
+	 * Export definitions from vrops (alert definitions, symptom definitions definitions, recommendations).
+	 * @param definitionType definition type to be exported (aler, symptom, recommendation).
+	 * @param definitions list of definitions to be exported.
+	 * @throws RuntimeException if the export fails.
+	 */
     private void exportDefinitions(final VropsPackageMemberType definitionType, final List<String> definitions) {
         File definitionsDir;
         String definitionsSubDir;
@@ -1029,6 +1247,13 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         generateDefinitionsFile(definitionsJsonMap, definitionsDir);
     }
 
+	/**
+	 * Generate the definitions JSON mapping.
+	 * @param definitionData the definition data.
+	 * @param definitions list of definitions (alert, symptom or recommendation).
+	 * @param definitionType type of the definition.
+	 * @return Mapping of definition name and data.
+	 */
     private Map<String, String> generateDefinitionsJsonMap(final Object definitionData, final List<String> definitions, final VropsPackageMemberType definitionType) {
         Map<String, String> retVal = new HashMap<>();
 
@@ -1069,6 +1294,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         return retVal;
     }
 
+	/**
+	 * Generate the definition file based on definition data.
+	 * @param definitionJson mapping of the definition JSON data.
+	 * @param dir directory where to put generated file.
+	 * @throws IOException if the writing of the file fails.
+	 */
     private void generateDefinitionsFile(final Map<String, String> definitionJson, final File dir) {
         for (Map.Entry<String, String> definition : definitionJson.entrySet()) {
             File definitionFile = new File(dir, definition.getKey() + ".json");
@@ -1080,6 +1311,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Export custom groups from vROPs server.
+	 * @param vropsPackage package where to put the custom groups to.
+	 * @param customGroupNames names of the custom groups to be exported.
+	 * @throws RuntimeException if the export fails.
+	 */
     private void exportCustomGroups(final Package vropsPackage, final List<String> customGroupNames) {
         File customGroupTargetDir = new File(this.tempVropsExportDir, "custom_groups");
         if (!customGroupTargetDir.exists()) {
@@ -1114,6 +1351,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Export policies from vROPs server.
+	 * @param vropsPackage package where to put the exported polices to.
+	 * @param policyEntries names the polices to be exported.
+	 * @throws RuntimeException if the export fails.
+	 */
     private void exportPolicies(final Package vropsPackage, final List<String> policyEntries) {
         File policyDir = new File(tempVropsExportDir, "policies");
         policyDir.mkdir();
@@ -1147,6 +1390,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         storePolicyMetadata(policyDir, policyIdNameMap);
     }
 
+	/**
+	 * Copy dashboard contents to the file system.
+	 * @param dashboard dashboard name to be copied.
+	 * @param dir directory where dashboard to be copied to.
+	 * @throws IOException | JSchException if copy fails.
+	 */
     private void copyDashboardToFilesystem(final String dashboard, final File dir) {
         try {
             File dashboardDir = new File(tempDir, "iac-dash-" + UUID.randomUUID().toString() + "-"
@@ -1172,6 +1421,12 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
         }
     }
 
+	/**
+	 * Copy report contents to the file system.
+	 * @param report report name to be copied.
+	 * @param dir directory where report to be copied to.
+	 * @throws IOException | JSchException if copy fails.
+	 */
     private void copyReportToFilesystem(final String report, final File dir) {
         try {
             File reportDir = new File(tempDir, "iac-dash-" + UUID.randomUUID().toString() + "-"
@@ -1265,6 +1520,8 @@ public final class VropsPackageStore extends GenericPackageStore<VropsPackageDes
             manageDashboardActivation(tmpDir, true);
             // manage dashboard activation per users
             manageDashboardActivation(tmpDir, false);
+            // set default policy after importing policies
+            setDefaultPolicy(pkg, tmpDir);
         } catch (IOException | JSchException | ConfigurationException e) {
             String message = String.format("Unable to push package '%s' to vROps Server '%s' : %s : %s", pkg.getFQName(), cliManager, e.getClass().getName(),
                     e.getMessage());

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageDescriptor.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageDescriptor.java
@@ -70,7 +70,7 @@ public class VropsPackageDescriptor extends PackageDescriptor {
 	/**
 	 * defaultPolicy.
 	 */
-	private List<String> defaultPolicy;
+	private String defaultPolicy;
 
 	/**
 	 * getView().
@@ -183,18 +183,18 @@ public class VropsPackageDescriptor extends PackageDescriptor {
 	/**
 	 * getDefaultPolicy().
 	 * 
-	 * @return list of default policies.
+	 * @return string with default policy.
 	 */
-	public List<String> getDefaultPolicy() {
+	public String getDefaultPolicy() {
 		return defaultPolicy;
 	}
 
 	/**
 	 * setDefaultPolicy().
 	 * 
-	 * @param defaultPolicy list of default polices.
+	 * @param defaultPolicy default policy to be set.
 	 */
-	public void setDefaultPolicy(List<String> defaultPolicy) {
+	public void setDefaultPolicy(String defaultPolicy) {
 		this.defaultPolicy = defaultPolicy;
 	}
 
@@ -308,8 +308,6 @@ public class VropsPackageDescriptor extends PackageDescriptor {
 				return getSymptomDefinition();
 			case POLICY:
 				return getPolicy();
-			case DEFAULT_POLICY:
-				return getDefaultPolicy();
 			case RECOMMENDATION:
 				return getRecommendation();
 			case SUPERMETRIC:

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageDescriptor.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageDescriptor.java
@@ -23,133 +23,323 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.vmware.pscoe.iac.artifact.model.PackageDescriptor;
 
+/**
+ * VropsPackageDescriptor.
+ */
 public class VropsPackageDescriptor extends PackageDescriptor {
-    private List<String> view;
-    private List<String> dashboard;
-    private List<String> report;
-    private List<String> alertDefinition;
-    private List<String> symptomDefinition;
-    private List<String> policy;
-    private List<String> recommendation;
-    private List<String> supermetric;
-    private List<String> metricConfig;
-    private List<String> customGroup;
+	/**
+	 * view.
+	 */
+	private List<String> view;
+	/**
+	 * dashboard.
+	 */
+	private List<String> dashboard;
+	/**
+	 * report.
+	 */
+	private List<String> report;
+	/**
+	 * alertDefinition.
+	 */
+	private List<String> alertDefinition;
+	/**
+	 * alertDefinition.
+	 */
+	private List<String> symptomDefinition;
+	/**
+	 * symptomDefinition.
+	 */
+	private List<String> recommendation;
+	/**
+	 * supermetric.
+	 */
+	private List<String> supermetric;
+	/**
+	 * metricConfig.
+	 */
+	private List<String> metricConfig;
+	/**
+	 * customGroup.
+	 */
+	private List<String> customGroup;
+	/**
+	 * policy.
+	 */
+	private List<String> policy;
+	/**
+	 * defaultPolicy.
+	 */
+	private List<String> defaultPolicy;
 
-    public List<String> getView() {
-        return this.view;
-    }
+	/**
+	 * getView().
+	 * 
+	 * @return list of views.
+	 */
+	public List<String> getView() {
+		return this.view;
+	}
 
-    public void setView(List<String> view) {
-        this.view = view;
-    }
+	/**
+	 * setView().
+	 * 
+	 * @param view list of views.
+	 */
+	public void setView(List<String> view) {
+		this.view = view;
+	}
 
-    public List<String> getDashboard() {
-        return this.dashboard;
-    }
+	/**
+	 * getDashboard().
+	 * 
+	 * @return list of dashboards.
+	 */
+	public List<String> getDashboard() {
+		return this.dashboard;
+	}
 
-    public void setDashboard(List<String> dashboard) {
-        this.dashboard = dashboard;
-    }
+	/**
+	 * setDashboard().
+	 * 
+	 * @param dashboard list of dashboards.
+	 */
+	public void setDashboard(List<String> dashboard) {
+		this.dashboard = dashboard;
+	}
 
-    public List<String> getReport() {
-        return this.report;
-    }
+	/**
+	 * getReport().
+	 * 
+	 * @return list of reports.
+	 */
+	public List<String> getReport() {
+		return this.report;
+	}
 
-    public void setReport(List<String> report) {
-        this.report = report;
-    }
+	/**
+	 * setReport().
+	 * 
+	 * @param report list of reports.
+	 */
+	public void setReport(List<String> report) {
+		this.report = report;
+	}
 
-    public List<String> getAlertDefinition() {
-        return this.alertDefinition;
-    }
+	/**
+	 * getAlertDefinition().
+	 * 
+	 * @return list of alert definitions.
+	 */
+	public List<String> getAlertDefinition() {
+		return this.alertDefinition;
+	}
 
-    public void setAlertDefinition(List<String> alertDefinition) {
-        this.alertDefinition = alertDefinition;
-    }
+	/**
+	 * setAlertDefinition().
+	 * 
+	 * @param alertDefinition list of alert definitions.
+	 */
+	public void setAlertDefinition(List<String> alertDefinition) {
+		this.alertDefinition = alertDefinition;
+	}
 
-    public List<String> getSymptomDefinition() {
-        return this.symptomDefinition;
-    }
+	/**
+	 * getSymptomDefinition().
+	 * 
+	 * @return list of symptom definitions.
+	 */
+	public List<String> getSymptomDefinition() {
+		return this.symptomDefinition;
+	}
 
-    public void setSymptomDefinition(List<String> symptomDefinition) {
-        this.symptomDefinition = symptomDefinition;
-    }
+	/**
+	 * setSymptomDefinition().
+	 * 
+	 * @param symptomDefinition list of symptom definitions.
+	 */
+	public void setSymptomDefinition(List<String> symptomDefinition) {
+		this.symptomDefinition = symptomDefinition;
+	}
 
-    public List<String> getPolicy() {
-        return this.policy;
-    }
+	/**
+	 * getPolicy().
+	 * 
+	 * @return list of policies.
+	 */
+	public List<String> getPolicy() {
+		return policy;
+	}
 
-    public void setPolicy(List<String> policy) {
-        this.policy = policy;
-    }
-    
-    public List<String> getRecommendation() {
-        return recommendation;
-    }
+	/**
+	 * setPolicy().
+	 * 
+	 * @param policy list of symptom definitions.
+	 */
+	public void setPolicy(List<String> policy) {
+		this.policy = policy;
+	}
 
-    public void setRecommendation(List<String> recommendation) {
-        this.recommendation = recommendation;
-    }
+	/**
+	 * getDefaultPolicy().
+	 * 
+	 * @return list of default policies.
+	 */
+	public List<String> getDefaultPolicy() {
+		return defaultPolicy;
+	}
 
-    public List<String> getSuperMetric() {
-        return this.supermetric;
-    }
+	/**
+	 * setDefaultPolicy().
+	 * 
+	 * @param defaultPolicy list of default polices.
+	 */
+	public void setDefaultPolicy(List<String> defaultPolicy) {
+		this.defaultPolicy = defaultPolicy;
+	}
 
-    public void setSuperMetric(List<String> supermetric) {
-        this.supermetric = supermetric;
-    }
+	/**
+	 * getSupermetric().
+	 * 
+	 * @return list of super metrics.
+	 */
+	public List<String> getSupermetric() {
+		return supermetric;
+	}
 
-    public List<String> getMetricConfig() {
-        return this.metricConfig;
-    }
+	/**
+	 * setSupermetric().
+	 * 
+	 * @param supermetric list of super metrics.
+	 */
+	public void setSupermetric(List<String> supermetric) {
+		this.supermetric = supermetric;
+	}
 
-    public void setMetricConfig(List<String> metricConfig) {
-        this.metricConfig = metricConfig;
-    }
+	/**
+	 * getRecommendation().
+	 * 
+	 * @return list of recommendations.
+	 */
+	public List<String> getRecommendation() {
+		return recommendation;
+	}
 
-    public List<String> getCustomGroup() {
-        return this.customGroup;
-    }
+	/**
+	 * setRecommendation().
+	 * 
+	 * @param recommendation list of recommendations.
+	 */
+	public void setRecommendation(List<String> recommendation) {
+		this.recommendation = recommendation;
+	}
 
-    public void setCustomGroup(List<String> customGroup) {
-        this.customGroup = customGroup;
-    }
+	/**
+	 * getSuperMetric().
+	 * 
+	 * @return list of super metrics.
+	 */
+	public List<String> getSuperMetric() {
+		return this.supermetric;
+	}
 
-    public List<String> getMembersForType(VropsPackageMemberType type) {
-        switch (type) {
-            case VIEW:
-                return getView();
-            case DASHBOARD:
-                return getDashboard();
-            case REPORT:
-                return getReport();
-            case ALERT_DEFINITION:
-                return getAlertDefinition();
-            case SYMPTOM_DEFINITION:
-                return getSymptomDefinition();
-            case POLICY:
-                return getPolicy();
-            case RECOMMENDATION:
-            	return getRecommendation();
-            case SUPERMETRIC:
-                return getSuperMetric();
-            case METRICCONFIG:
-                return getMetricConfig();
-            case CUSTOM_GROUP:
-                return getCustomGroup();
-            default:
-                throw new RuntimeException("ContentType is not supported!");
-        }
-    }
+	/**
+	 * setSuperMetric().
+	 * 
+	 * @param sm list of super metrics.
+	 */
+	public void setSuperMetric(List<String> sm) {
+		this.supermetric = sm;
+	}
 
-    public static VropsPackageDescriptor getInstance(File filesystemPath) {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
-        try {
-            return mapper.readValue(filesystemPath, VropsPackageDescriptor.class);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to load vROps Package Descriptor [" + filesystemPath.getAbsolutePath() + "]", e);
-        }
-    }
+	/**
+	 * getMetricConfig().
+	 * 
+	 * @return list of metric configs.
+	 */
+	public List<String> getMetricConfig() {
+		return this.metricConfig;
+	}
+
+	/**
+	 * setMetricConfig().
+	 * 
+	 * @param metricConfig of metric configs.
+	 */
+	public void setMetricConfig(List<String> metricConfig) {
+		this.metricConfig = metricConfig;
+	}
+
+	/**
+	 * getCustomGroup().
+	 * 
+	 * @return list of custom groups.
+	 */
+	public List<String> getCustomGroup() {
+		return this.customGroup;
+	}
+
+	/**
+	 * setCustomGroup().
+	 * 
+	 * @param customGroup of custom groups.
+	 */
+	public void setCustomGroup(List<String> customGroup) {
+		this.customGroup = customGroup;
+	}
+
+	/**
+	 * Returns the members based on the member type.
+	 * 
+	 * @param type the type of the vrops package member.
+	 * @return List of the members for given member type.
+	 */
+	public List<String> getMembersForType(VropsPackageMemberType type) {
+		switch (type) {
+			case VIEW:
+				return getView();
+			case DASHBOARD:
+				return getDashboard();
+			case REPORT:
+				return getReport();
+			case ALERT_DEFINITION:
+				return getAlertDefinition();
+			case SYMPTOM_DEFINITION:
+				return getSymptomDefinition();
+			case POLICY:
+				return getPolicy();
+			case DEFAULT_POLICY:
+				return getDefaultPolicy();
+			case RECOMMENDATION:
+				return getRecommendation();
+			case SUPERMETRIC:
+				return getSuperMetric();
+			case METRICCONFIG:
+				return getMetricConfig();
+			case CUSTOM_GROUP:
+				return getCustomGroup();
+			default:
+				throw new RuntimeException("ContentType is not supported!");
+		}
+	}
+
+	/**
+	 * Returns the vrops package descriptor based on the contents of the
+	 * content.yaml file.
+	 * 
+	 * @param filesystemPath path to the content.yaml file.
+	 * @return instance of the descriptor based on the contents of the content.yaml
+	 *         file.
+	 */
+	@SuppressWarnings("deprecation")
+	public static VropsPackageDescriptor getInstance(File filesystemPath) {
+		ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+		mapper.setPropertyNamingStrategy(PropertyNamingStrategy.KEBAB_CASE);
+		try {
+			return mapper.readValue(filesystemPath, VropsPackageDescriptor.class);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to load vROps Package Descriptor [" + filesystemPath.getAbsolutePath() + "]", e);
+		}
+	}
 
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageMemberType.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/VropsPackageMemberType.java
@@ -15,28 +15,94 @@ package com.vmware.pscoe.iac.artifact.model.vrops;
  * #L%
  */
 
+/**
+ * VropsPackageMemberType defines the asset types that vROPs package supports.
+ */
 public enum VropsPackageMemberType {
-    VIEW("view"), DASHBOARD("dashboard"), REPORT("report"), ALERT_DEFINITION("alert_definition"), SYMPTOM_DEFINITION("symptom_definition"), POLICY("policy"),
-    SUPERMETRIC("supermetric"), RECOMMENDATION("recommendation"), METRICCONFIG("metric_config"), CUSTOM_GROUP("custom_group");
 
-    private final String name;
+	/**
+	 * VIEW.
+	 */
+	VIEW("view"),
+	/**
+	 * DASHBOARD.
+	 */
+	DASHBOARD("dashboard"),
+	/**
+	 * REPORT.
+	 */
+	REPORT("report"),
+	/**
+	 * ALERT_DEFINITION.
+	 */
+	ALERT_DEFINITION("alert_definition"),
 
-    VropsPackageMemberType(String name) {
-        this.name = name;
-    }
+	/**
+	 * SYMPTOM_DEFINITION.
+	 */
+	SYMPTOM_DEFINITION("symptom_definition"),
+	/**
+	 * POLICY.
+	 */
+	POLICY("policy"),
+	/**
+	 * DEFAULT_POLICY.
+	 */
+	DEFAULT_POLICY("default_policy"),
+	/**
+	 * SUPERMETRIC.
+	 */
+	SUPERMETRIC("supermetric"),
+	/**
+	 * RECOMMENDATION.
+	 */
+	RECOMMENDATION("recommendation"),
+	/**
+	 * METRICCONFIG.
+	 */
+	METRICCONFIG("metric_config"),
+	/**
+	 * CUSTOM_GROUP.
+	 */
+	CUSTOM_GROUP("custom_group");
 
-    @Override
-    public String toString() {
-        return name;
-    }
+	/**
+	 * name.
+	 */
+	private final String name;
 
-    public static VropsPackageMemberType fromString(String name) {
-        for (VropsPackageMemberType type : VropsPackageMemberType.values()) {
-            if (type.name.equalsIgnoreCase(name)) {
-                return type;
-            }
-        }
+	/**
+	 * Constructor.
+	 * 
+	 * @param name of the member type.
+	 */
+	VropsPackageMemberType(String name) {
+		this.name = name;
+	}
 
-        return null;
-    }
+	/**
+	 * toString().
+	 * 
+	 * @return string representation.
+	 */
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	/**
+	 * fromString().
+	 * 
+	 * @param name name of the type.
+	 * @return VropsPackageMemberType.
+	 */
+	public static VropsPackageMemberType fromString(String name) {
+		for (VropsPackageMemberType type : VropsPackageMemberType.values()) {
+			if (type.name.equalsIgnoreCase(name)) {
+				return type;
+			}
+		}
+
+		return null;
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/model/vrops/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vROPs 8 model.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.model.vrops;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyDTO.java
@@ -22,90 +22,204 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/**
+ * PolicyDTO.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PolicyDTO {
 
-    @JsonProperty("policy-summaries")
-    private List<Policy> policies;
+	/**
+	 * policies.
+	 */
+	@JsonProperty("policy-summaries")
+	private List<Policy> policies;
 
-    @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<>();
+	/**
+	 * additionalProperties.
+	 */
+	@JsonIgnore
+	private Map<String, Object> additionalProperties = new HashMap<>();
 
-    @JsonProperty("policy-summaries")
-    public List<Policy> getPolicies() {
-        return this.policies;
-    }
+	/**
+	 * getPolicies().
+	 * 
+	 * @return list of policies.
+	 */
+	@JsonProperty("policy-summaries")
+	public List<Policy> getPolicies() {
+		return this.policies;
+	}
 
-    @JsonProperty("policy-summaries")
-    public void setPolicies(List<Policy> policies) {
-        this.policies = policies;
-    }
+	/**
+	 * setPolicies().
+	 * 
+	 * @param policies policies to be set.
+	 */
+	@JsonProperty("policy-summaries")
+	public void setPolicies(List<Policy> policies) {
+		this.policies = policies;
+	}
 
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
-    }
+	/**
+	 * getAdditionalProperties().
+	 * 
+	 * @return map of additional properties.
+	 */
+	@JsonAnyGetter
+	public Map<String, Object> getAdditionalProperties() {
+		return this.additionalProperties;
+	}
 
-    @JsonAnySetter
-    public void setAdditionalProperties(String name, Object value) {
-        this.additionalProperties.put(name, value);
-    }
+	/**
+	 * setAdditionalProperties().
+	 * 
+	 * @param propName name of the property.
+	 * @param value    value of the property.
+	 */
+	@JsonAnySetter
+	public void setAdditionalProperties(String propName, Object value) {
+		this.additionalProperties.put(propName, value);
+	}
 
-    @JsonPropertyOrder({ "id", "name" })
-    public static class Policy {
+	/**
+	 * Policy.
+	 */
+	@JsonPropertyOrder({ "id", "name", "defaultPolicy" })
+	public static class Policy {
 
-        @JsonProperty("id")
-        private String id;
+		/**
+		 * id.
+		 */
+		@JsonProperty("id")
+		private String id;
 
-        @JsonProperty("name")
-        private String name;
+		/**
+		 * name.
+		 */
+		@JsonProperty("name")
+		private String name;
 
-        @JsonIgnore
-        private byte[] zipFile;
+		/**
+		 * zipFile.
+		 */
+		@JsonIgnore
+		private byte[] zipFile;
 
-        @JsonIgnore
-        private Map<String, Object> additionalProperties = new HashMap<>();
+		/**
+		 * defaultPolicy.
+		 */
+		@JsonProperty("defaultPolicy")
+		private boolean defaultPolicy;
 
-        @JsonProperty("id")
-        public String getId() {
-            return id;
-        }
+		/**
+		 * additionalProperties.
+		 */
+		@JsonIgnore
+		private Map<String, Object> additionalProperties = new HashMap<>();
 
-        @JsonProperty("id")
-        public void setId(String id) {
-            this.id = id;
-        }
+		/**
+		 * getId().
+		 * 
+		 * @return string with id.
+		 */
+		@JsonProperty("id")
+		public String getId() {
+			return id;
+		}
 
-        @JsonProperty("name")
-        public String getName() {
-            return name;
-        }
+		/**
+		 * setId().
+		 * 
+		 * @param id id to be set.
+		 */
+		@JsonProperty("id")
+		public void setId(String id) {
+			this.id = id;
+		}
 
-        @JsonProperty("name")
-        public void setName(String name) {
-            this.name = name;
-        }
+		/**
+		 * getName().
+		 * 
+		 * @return string with name.
+		 */
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
 
-        @JsonIgnore
-        public void setZipFile(byte[] file) {
-            this.zipFile = file;
-        }
+		/**
+		 * setName().
+		 * 
+		 * @param name name of the policy.
+		 */
+		@JsonProperty("name")
+		public void setName(String name) {
+			this.name = name;
+		}
 
-        @JsonIgnore
-        public byte[] getZipFile() {
-            return this.zipFile;
-        }
+		/**
+		 * setZipFile().
+		 * 
+		 * @param file byte array of the file.
+		 */
+		@JsonIgnore
+		public void setZipFile(byte[] file) {
+			this.zipFile = file;
+		}
 
-        @JsonAnyGetter
-        public Map<String, Object> getAdditionalProperties() {
-            return this.additionalProperties;
-        }
+		/**
+		 * getZipFile().
+		 * 
+		 * @return byte array of the file.
+		 */
+		@JsonIgnore
+		public byte[] getZipFile() {
+			return this.zipFile;
+		}
 
-        @JsonAnySetter
-        public void setAdditionalProperties(String name, Object value) {
-            this.additionalProperties.put(name, value);
-        }
-    }
+		/**
+		 * getDefaultPolicy().
+		 * 
+		 * @return whether it is default policy.
+		 */
+		@JsonProperty("defaultPolicy")
+		public boolean getDefaultPolicy() {
+			return defaultPolicy;
+		}
+
+		/**
+		 * setDefaultPolicy().
+		 * 
+		 * @param defaultPolicy default policy flag.
+		 */
+		@JsonProperty("defaultPolicy")
+		public void setDefaultPolicy(boolean defaultPolicy) {
+			this.defaultPolicy = defaultPolicy;
+		}
+
+		/**
+		 * getAdditionalProperties().
+		 * 
+		 * @return map with additional properties.
+		 */
+		@JsonAnyGetter
+		public Map<String, Object> getAdditionalProperties() {
+			return this.additionalProperties;
+		}
+
+		/**
+		 * setAdditionalProperties().
+		 * 
+		 * @param propName name of the property.
+		 * @param value    value of the property.
+		 */
+		@JsonAnySetter
+		public void setAdditionalProperties(String propName, Object value) {
+			this.additionalProperties.put(propName, value);
+		}
+	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
@@ -75,7 +75,7 @@ public final class PackageMocked {
 	 */
 	public static File createSamplePackageZip(File dir, String viewName, String viewId, String dashboardName, String alertDefinitionName) throws IOException {
 		String contentXml = "<Content><Views><ViewDef id=\"" + viewId + "\"></ViewDef></Views></Content>";
-		String contentYaml = "---\npolicy:\n  - policy1\ndefault-policy:\n  - policy1\n";
+		String contentYaml = "---\npolicy:\n  - policy1\ndefault-policy: policy1\n";
 
 		String resourceProp = "view." + viewId + ".title: value\nview." + viewId + ".something: value2\n";
 

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/PackageMocked.java
@@ -23,10 +23,25 @@ import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-public class PackageMocked {
+/**
+ * PackageMocked mock class for vrops packages.
+ */
+public final class PackageMocked {
 
+	/**
+	 * PackageMocked() private constructor.
+	 */
+	private PackageMocked() {
+	}
+
+	/**
+	 * createSampleViewsZip() create a zip file with views.
+	 * 
+	 * @param dir directory where to put file.
+	 * @return file handle to the generated file.
+	 * @throws IOException if creation fails.
+	 */
 	public static File createSampleViewsZip(File dir) throws IOException {
-
 		String contentXml = "<Content><Views><ViewDef id=\"123\"></ViewDef></Views></Content>";
 		String resourceProp = "view.123.title: value\nview.123.something: value2\n";
 
@@ -47,17 +62,30 @@ public class PackageMocked {
 		return tempZip;
 	}
 
+	/**
+	 * createSamplePackageZip() create a mocked package zip file.
+	 * 
+	 * @param dir                 directory where to put the package file.
+	 * @param viewName            name to be generated.
+	 * @param viewId              id to be generated.
+	 * @param dashboardName       name of the dashboard to be generated.
+	 * @param alertDefinitionName name of the alert definition to be generated.
+	 * @return file handle to the generated file.
+	 * @throws IOException if creation fails.
+	 */
 	public static File createSamplePackageZip(File dir, String viewName, String viewId, String dashboardName, String alertDefinitionName) throws IOException {
 		String contentXml = "<Content><Views><ViewDef id=\"" + viewId + "\"></ViewDef></Views></Content>";
-		String resourceProp = "view." + viewId + ".title: value\nview." + viewId +".something: value2\n";
+		String contentYaml = "---\npolicy:\n  - policy1\ndefault-policy:\n  - policy1\n";
+
+		String resourceProp = "view." + viewId + ".title: value\nview." + viewId + ".something: value2\n";
 
 		String dashboardsJson = "{\"dashboards\": [{\"autoswitchEnabled\": false}]}";
 		String dashResourceProp = dashboardName + "=" + dashboardName + "\n" + dashboardName + ".Something=Somevalue";
 
 		String alertDefsJson = "{\"id\": \"1\"}";
-		String shareMetadata = "{ \"share\": {\""+dashboardName+"\" : [\"group1\"]}, \"unshare\" : {} }";
-		String activateUserMetadata = "{ \"activate\": {\""+dashboardName+"\" : [\"user1\"]}, \"deactivate\" : {} }";
-		String activateGroupMetadata = "{ \"activate\": {\""+dashboardName+"\" : [\"group1\"]}, \"deactivate\" : {} }";
+		String shareMetadata = "{ \"share\": {\"" + dashboardName + "\" : [\"group1\"]}, \"unshare\" : {} }";
+		String activateUserMetadata = "{ \"activate\": {\"" + dashboardName + "\" : [\"user1\"]}, \"deactivate\" : {} }";
+		String activateGroupMetadata = "{ \"activate\": {\"" + dashboardName + "\" : [\"group1\"]}, \"deactivate\" : {} }";
 
 		File tempZip = new File(dir, UUID.randomUUID() + ".zip");
 		FileOutputStream fos = new FileOutputStream(tempZip);
@@ -66,6 +94,10 @@ public class PackageMocked {
 		ZipEntry contentZipEntry = new ZipEntry("/views/" + viewName + ".xml");
 		zipOut.putNextEntry(contentZipEntry);
 		zipOut.write(contentXml.getBytes(StandardCharsets.UTF_8));
+
+		ZipEntry contentYamlZipEntry = new ZipEntry("/content.yaml");
+		zipOut.putNextEntry(contentYamlZipEntry);
+		zipOut.write(contentYaml.getBytes(StandardCharsets.UTF_8));
 
 		ZipEntry resourcePropZipEntry = new ZipEntry("/views/resources/content.properties");
 		zipOut.putNextEntry(resourcePropZipEntry);

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/package-info.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that represents vROPs test classes.
+ *
+ */
+package com.vmware.pscoe.iac.artifact;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
@@ -44,6 +44,7 @@ import com.vmware.pscoe.iac.artifact.model.vrops.VropsPackageMemberType;
 import com.vmware.pscoe.iac.artifact.rest.RestClientVrops;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.AuthGroupDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.AuthUserDTO;
+import com.vmware.pscoe.iac.artifact.rest.model.vrops.PolicyDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.ReportDefinitionDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.SupermetricDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.ViewDefinitionDTO;
@@ -54,7 +55,7 @@ public class VropsPackageStoreTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
-    void exportPackageWhenPackageIsAvailable() throws IOException {
+    void exportPackageWhenPackageIsAvailable() throws Exception {
         // GIVEN
         tempFolder.create();
         String testViewName = "Test View";
@@ -84,13 +85,19 @@ public class VropsPackageStoreTest {
         viewDefs.add(viewDef);
         allViewDefs.setViewDefinitions(viewDefs);
 
+        PolicyDTO.Policy defaultPolicy = new PolicyDTO.Policy();
+        defaultPolicy.setName("default policy");
+        defaultPolicy.setId("1");
+        defaultPolicy.setZipFile(new byte[] {'1'});
+
         Mockito.doReturn(allReportDefs).when(restClientMock).getAllReportDefinitions();
         Mockito.doReturn(allSupermetrics).when(restClientMock).getAllSupermetrics();
         Mockito.doReturn(allViewDefs).when(restClientMock).getAllViewDefinitions();
+		Mockito.doReturn(defaultPolicy).when(restClientMock).getDefaultPolicy();
 
         VropsPackageStore store = new VropsPackageStore(cliMock, restClientMock);
         Package vropsPkg = PackageFactory.getInstance(PackageType.VROPS, packageDir);
-        VropsPackageDescriptor descriptor = getVropsPackageDescriptorMock(testViewName);
+        VropsPackageDescriptor descriptor = getVropsPackageDescriptorMock(testViewName, defaultPolicy.getName());
 
         // WHEN
         Package pkg = store.exportPackage(vropsPkg, descriptor, false);
@@ -111,6 +118,8 @@ public class VropsPackageStoreTest {
         String existingGroup = "group1";
         String existingUser = "user1";
         String existingDashboard = "DashboardName";
+        String defaultPolicy = "policy";
+        String contentYaml = "content.yaml";
 
         String[] shareGroups = new String[] { existingGroup };
         String[] unshareGroups = new String[] { existingGroup };
@@ -155,6 +164,7 @@ public class VropsPackageStoreTest {
         Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.SYMPTOM_DEFINITION, new HashMap<>());
         Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.RECOMMENDATION, new HashMap<>());
         Mockito.doNothing().when(restClientMock).importCustomGroupInVrops(testCustomGroupName, testCustomGroupPayload, new HashMap<>());
+        Mockito.doNothing().when(restClientMock).setDefaultPolicy(defaultPolicy);
 
         VropsPackageStore store = new VropsPackageStore(cliMock, restClientMock, tempFolder.newFolder());
 
@@ -173,13 +183,19 @@ public class VropsPackageStoreTest {
         Mockito.verify(cliMock, Mockito.times(packages.size())).importFilesToVrops();
     }
 
-    private static VropsPackageDescriptor getVropsPackageDescriptorMock(String viewName) {
+    private static VropsPackageDescriptor getVropsPackageDescriptorMock(String viewName, String policyName) {
         VropsPackageDescriptor mock = new VropsPackageDescriptor() {
             @Override
             public List<String> getView() {
                 List<String> list = new ArrayList<String>();
                 list.add(viewName);
                 return list;
+            }
+            @Override
+            public List<String> getDefaultPolicy() {
+                 List<String> list = new ArrayList<String>();
+                 list.add(policyName);
+                 return list;
             }
         };
         return mock;

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
@@ -192,10 +192,8 @@ public class VropsPackageStoreTest {
                 return list;
             }
             @Override
-            public List<String> getDefaultPolicy() {
-                 List<String> list = new ArrayList<String>();
-                 list.add(policyName);
-                 return list;
+            public String getDefaultPolicy() {
+                 return policyName;
             }
         };
         return mock;

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -35,6 +35,7 @@ default-policy:
 ```
 
 Then the 'Policy Name' will be set to the default policy in vROPs.
+If more policies are specified in the default-policy tag, then only the first one is applied (as vROPs supports only one default policy).
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -30,12 +30,11 @@ Added option for setting default policy for vROPs version 8.12.x by setting it i
 If in the content.yaml file for a vROPs project the following section is present:
 
 ```yaml
-default-policy:
-  - Policy Name
+default-policy: Policy Name
 ```
 
 Then the 'Policy Name' will be set to the default policy in vROPs.
-If more policies are specified in the default-policy tag, then only the first one is applied (as vROPs supports only one default policy).
+
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -50,7 +50,7 @@ Then the 'Policy Name' will be set to the default policy in vROPs.
 [//]: # (#### Relevant Documentation)
 
 
-## Upgrade procedure:
+## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 
 [//]: # (## Changelog)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -10,11 +10,9 @@
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
 
 
-
 ## Deprecations
 [//]: # (### *Deprecation*)
 [//]: # (Explain what is deprecated and suggest alternatives)
-
 
 
 [//]: # (Features -> New Functionality)
@@ -22,9 +20,21 @@
 [//]: # (### *Feature Name*)
 [//]: # (Describe the feature)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
+[//]: # (#### Relevant Documentation)
 
+### Setting Default Policy for vROPs 8.12.x
 
+Added option for setting default policy for vROPs version 8.12.x by setting it in the default-policy configuration item in the content.yaml file.
+
+#### Relevant Documentation
+If in the content.yaml file for a vROPs project the following section is present:
+
+```yaml
+default-policy:
+  - Policy Name
+```
+
+Then the 'Policy Name' will be set to the default policy in vROPs.
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
@@ -37,12 +47,11 @@
 [//]: # (#### New Behavior)
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
-
+[//]: # (#### Relevant Documentation)
 
 
 ## Upgrade procedure:
 [//]: # (Explain in details if something needs to be done)
 
-[//]: # (## Changelog:)
+[//]: # (## Changelog)
 [//]: # (Pull request links)

--- a/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
+++ b/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
@@ -16,9 +16,10 @@
 #    - SymptomDefinition-VMWARE-HostTeamingMismatch
 #  policy:
 #    - Default Policy
-#      - vSphere World, vSAN Datastores
+#    - vSphere World, vSAN Datastores
 #    - Foundation Policy
-#      - vSphere World, vSAN Datastores
+#    - vSphere World, vSAN Datastores
+#  default-policy: vSphere World
 #  recommendation:
 #    - Recommendation-df-physicaldisks.physdiskcapacity
 #  super-metric:

--- a/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
+++ b/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
@@ -31,6 +31,7 @@
 #    - AWS World
 #    - Agents Running Remote Checks
 #
+
 ---
 view:
 dashboard:

--- a/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
+++ b/maven/archetypes/vrops/src/main/resources/archetype-resources/content.yaml
@@ -37,6 +37,7 @@ dashboard:
 alert-definition:
 symptom-definition:
 policy:
+default-policy:
 recommendation:
 super-metric:
 metric-config:

--- a/maven/base-package/pom.xml
+++ b/maven/base-package/pom.xml
@@ -594,7 +594,7 @@ for (String definition : checksumDefs.split(',')) {
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>3.0.9</version>
+                        <version>3.0.19</version>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>

--- a/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/PackageMojo.java
+++ b/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/PackageMojo.java
@@ -46,25 +46,58 @@ import edu.emory.mathcs.backport.java.util.Arrays;
 
 @Mojo(name = "package", defaultPhase = LifecyclePhase.PACKAGE)
 public class PackageMojo extends AbstractMojo {
+	/**
+	 * Policy metadata file name.
+	 */
     private static final String POLICY_METADATA_FILE_NAME = "policiesMetadata.vrops.json";
+	/**
+	 * Dashboard sharing metadata file name.
+	 */
     private static final String DASHBOARD_SHARE_METADATA_FILENAME = "metadata/dashboardSharingMetadata.vrops.json";
+	/**
+	 * Dashboard user activation metadata file name.
+	 */
     private static final String DASHBOARD_USER_ACTIVATE_METADATA_FILENAME = "metadata/dashboardUserActivationMetadata.vrops.json";
+	/**
+	 * Dashboard group activation metadata file name.
+	 */
     private static final String DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME = "metadata/dashboardGroupActivationMetadata.vrops.json";
-    
+	/**
+	 * Zip file type.
+	 */
     private static final String ZIP_FILE_TYPE = "zip";
+	/**
+	 * XML file type.
+	 */
     private static final String XML_FILE_TYPE = "xml";
+	/**
+	 * JSON file type.
+	 */
     private static final String JSON_FILE_TYPE = "json";
-
+    /**
+	 * Content yaml file name.
+	 */
+    private static final String CONTENT_YAML_FILE_NAME = "content.yaml";
+	/**
+	 * Project build directory.
+	 */
     @Parameter(defaultValue = "${project.build.directory}", readonly = true)
     private File directory;
-
+	/**
+	 * Project handle.
+	 */
     @Parameter(defaultValue = "${project}")
     private MavenProject project;
 
+	/**
+	 * Execute the vROPs package MoJo, that will generate the target bundle with the assets defined in the content.yaml file.
+	 *
+	 * @throws MojoExecutionException MojoFailureException if package creation fails.
+	 */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         MavenProjectPackageInfoProvider pkgInfoProvider = new MavenProjectPackageInfoProvider(project);
-        File contentsYamlFile = new File(project.getBasedir(), "content.yaml");
+        File contentsYamlFile = new File(project.getBasedir(), CONTENT_YAML_FILE_NAME);
         VropsPackageDescriptor contentsYaml = VropsPackageDescriptor.getInstance(contentsYamlFile);
 
         getLog().info("vROps Package Plugin: Executing in Project Base: " + project.getBasedir());
@@ -75,48 +108,55 @@ public class PackageMojo extends AbstractMojo {
         try {
             filterSourcesByContentYaml(pkgInfoProvider.getSourceDirectory(), contentsYaml, filteredDir);
             Package pkg = PackageFactory.getInstance(PackageType.VROPS, pkgFile);
-
+            // add content.yaml to the target package.
+            addContentYamlFile(contentsYamlFile, filteredDir);
             getLog().info("vROps Package Plugin: Packaging bundle from: \"" + filteredDir + "\"");
             new PackageManager(pkg).pack(filteredDir);
             project.getArtifact().setFile(pkgFile);
             getLog().info("vROps Package Plugin: Artifact:              \"" + pkgFile.getAbsolutePath() + "\"");
-
-            // FileUtils.deleteDirectory(filteredDir); // Only if everything is fine. Leave
-            // it for troubleshoting on error.
-        } catch (IOException e) {
+         } catch (IOException e) {
             String message = "Error creating vROps bundle. (" + e.getClass().getName() + " : " + e.getLocalizedMessage() + ").";
             throw new MojoExecutionException(e, message, message);
         }
     }
 
-    private File filterSourcesByContentYaml(final File sources, final VropsPackageDescriptor contentYaml, final File filteredDir) throws IOException {
-        if (filteredDir.exists()) {
-            FileUtils.deleteDirectory(filteredDir);
+	/**
+	 * Filter the assets based on the definitions in the content.yaml file.
+	 *
+	 * @param sources source directory.
+	 * @param contentYaml package descriptor based on the content.yaml file.
+	 * @param assetDir directory that contains all assets (dashboards, views, supermetrics, etc).
+	 * @return directory with filtered resources.
+	 * @throws IOException if the copying files fails.
+	 */
+    private File filterSourcesByContentYaml(final File sources, final VropsPackageDescriptor contentYaml, final File assetDir) throws IOException {
+        if (assetDir.exists()) {
+            FileUtils.deleteDirectory(assetDir);
         }
-        if (!filteredDir.exists() && !filteredDir.mkdirs()) {
-            throw new IOException("Cannot create directory \"" + filteredDir + "\" or some of its parents. Please check file system permisions.");
+        if (!assetDir.exists() && !assetDir.mkdirs()) {
+            throw new IOException("Cannot create directory \"" + assetDir + "\" or some of its parents. Please check file system permisions.");
         }
 
         final File srcDashboardsDir = new File(sources, "dashboards");
-        final File destDashboardsDir = new File(filteredDir, "dashboards");
+        final File destDashboardsDir = new File(assetDir, "dashboards");
         final File srcViewsDir = new File(sources, "views");
-        final File destViewsDir = new File(filteredDir, "views");
+        final File destViewsDir = new File(assetDir, "views");
         final File srcReportsDir = new File(sources, "reports");
-        final File destReportsDir = new File(filteredDir, "reports");
+        final File destReportsDir = new File(assetDir, "reports");
         final File srcAlertDefsDir = new File(sources, "alert_definitions");
-        final File destAlertDefsDir = new File(filteredDir, "alert_definitions");
+        final File destAlertDefsDir = new File(assetDir, "alert_definitions");
         final File srcSymptomDefsDir = new File(sources, "symptom_definitions");
-        final File destSymptomDefsDir = new File(filteredDir, "symptom_definitions");
+        final File destSymptomDefsDir = new File(assetDir, "symptom_definitions");
         final File srcPoliciesDir = new File(sources, "policies");
-        final File destPoliciesDir = new File(filteredDir, "policies");
+        final File destPoliciesDir = new File(assetDir, "policies");
         final File srcSuperMetricsDir = new File(sources, "supermetrics");
-        final File destSuperMetricsDir = new File(filteredDir, "supermetrics");
+        final File destSuperMetricsDir = new File(assetDir, "supermetrics");
         final File srcRecommendationsDir = new File(sources, "recommendations");
-        final File destRecommendationsDir = new File(filteredDir, "recommendations");
+        final File destRecommendationsDir = new File(assetDir, "recommendations");
         final File srcMetricConfigsDir = new File(sources, "metricconfigs");
-        final File destMetricConfigsDir = new File(filteredDir, "metricconfigs");
+        final File destMetricConfigsDir = new File(assetDir, "metricconfigs");
         final File srcCustomGroupDir = new File(sources, "custom_groups");
-        final File destCustomGroupDir = new File(filteredDir, "custom_groups");
+        final File destCustomGroupDir = new File(assetDir, "custom_groups");
 
         destDashboardsDir.mkdirs();
         destViewsDir.mkdirs();
@@ -149,9 +189,17 @@ public class PackageMojo extends AbstractMojo {
         filterMetricConfigs(srcMetricConfigsDir, destMetricConfigsDir, metricConfigsToPackage);
         filterCustomGroups(srcCustomGroupDir, destCustomGroupDir, customGroupsToPackage);
 
-        return filteredDir;
+        return assetDir;
     }
 
+	/**
+	 * Filter and copy the dashboards based on the content.yaml dashboard definitions.
+	 *
+	 * @param srcDashboardsDir source dashboard directory.
+	 * @param destDashboardsDir destination dashboard directory.
+	 * @param dashboardsToPackage list of dashboard names to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterDashboards(final File srcDashboardsDir, final File destDashboardsDir, final List<String> dashboardsToPackage) throws IOException {
         if (dashboardsToPackage == null || dashboardsToPackage.isEmpty()) {
             return;
@@ -169,7 +217,6 @@ public class PackageMojo extends AbstractMojo {
                 }
             }
         }
-
         // copy dashboard sharing metadata file for dashboards
         try {
             this.copyDashboardSharingMetadataFile(srcDashboardsDir, destDashboardsDir);
@@ -183,12 +230,19 @@ public class PackageMojo extends AbstractMojo {
         } catch (IOException e) {
             messages.append(String.format("Unable to copy dashboard activation metadata files: %s",  e.getMessage()));
         }
-
         if (messages.length() > 0) {
             throw new IOException(messages.toString());
         }
     }
 
+	/**
+	 * Filter and copy the super metrics based on the content.yaml super metrics definitions.
+	 *
+	 * @param srcSuperMetricsDir source super metrics directory.
+	 * @param destSuperMetricsDir destination super metrics directory.
+	 * @param superMetricsToPackage list of super metrics names to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterSuperMetrics(final File srcSuperMetricsDir, final File destSuperMetricsDir, final List<String> superMetricsToPackage) throws IOException {
         if (superMetricsToPackage == null || superMetricsToPackage.isEmpty()) {
             return;
@@ -212,6 +266,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the metric configs based on the content.yaml metric config definitions.
+	 *
+	 * @param srcMetricConfigsDir source metric configs directory.
+	 * @param destMetricConfigsDir destination metric configs directory.
+	 * @param metricConfigsToPackage list of super metric names to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterMetricConfigs(File srcMetricConfigsDir, File destMetricConfigsDir, List<String> metricConfigsToPackage) throws IOException {
         if (metricConfigsToPackage == null || metricConfigsToPackage.isEmpty()) {
             return;
@@ -236,6 +298,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the views based on the content.yaml view definitions.
+	 *
+	 * @param srcViewsDir source views directory.
+	 * @param destViewsDir destination views directory.
+	 * @param viewsToPackage list of view names to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterViews(File srcViewsDir, File destViewsDir, List<String> viewsToPackage) throws IOException {
         if (viewsToPackage == null || viewsToPackage.isEmpty()) {
             return;
@@ -266,14 +336,22 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Gets asset files from a specific directory based on their extension.
+	 *
+	 * @param dir directory to fetch files from.
+	 * @param fileName name of the file.
+	 * @param fileExtension extension of the file.
+	 * @return List<File> list of fetched files.
+	 */
     @SuppressWarnings("unchecked")
-    private List<File> getAssetFiles(File directory, String fileName, String fileExtension) {
+    private List<File> getAssetFiles(File dir, String fileName, String fileExtension) {
         List<File> retVal = new ArrayList<>();
 
         FileFilter fileFilter = StringUtils.isEmpty(fileExtension) ? new WildcardFileFilter(fileName) : new WildcardFileFilter(fileName + "." + fileExtension);
         File[] fileList;
         try {
-            fileList = directory.listFiles(fileFilter);
+            fileList = dir.listFiles(fileFilter);
         } catch (Exception e) {
             getLog().warn(String.format("Error when retrieving file listing for directory '%s' with file pattern '%s' : '%s'", directory.getName(), fileName,
                     e.getMessage()));
@@ -290,6 +368,14 @@ public class PackageMojo extends AbstractMojo {
         return retVal;
     }
 
+	/**
+	 * Filter and copy the reports based on the content.yaml view definitions.
+	 *
+	 * @param srcReportsDir source reports directory.
+	 * @param destReportsDir destination reports directory.
+	 * @param reportsToPackage list of reports to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterReports(File srcReportsDir, File destReportsDir, List<String> reportsToPackage) throws IOException {
         if (reportsToPackage == null || reportsToPackage.isEmpty()) {
             return;
@@ -314,6 +400,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the alert definitions based on the content.yaml view definitions.
+	 *
+	 * @param srcAlertDefsDir source alert definitions directory.
+	 * @param destAlertDefsDir destination alert definitions directory.
+	 * @param alertDefinitionsToPackage list of alert definitions to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterAlertDefinitions(File srcAlertDefsDir, File destAlertDefsDir, List<String> alertDefinitionsToPackage) throws IOException {
         if (alertDefinitionsToPackage == null || alertDefinitionsToPackage.isEmpty()) {
             return;
@@ -336,6 +430,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the symptom definitions based on the content.yaml view definitions.
+	 *
+	 * @param srcSymptomDefsDir source symptom definitions directory.
+	 * @param destSymptomDefsDir destination symptom definitions directory.
+	 * @param symptomDefinitionsToPackage list of symptom definitions to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterSymptomDefinitions(File srcSymptomDefsDir, File destSymptomDefsDir, List<String> symptomDefinitionsToPackage) throws IOException {
         if (symptomDefinitionsToPackage == null || symptomDefinitionsToPackage.isEmpty()) {
             return;
@@ -358,6 +460,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the recommendations based on the content.yaml view definitions.
+	 *
+	 * @param srcRecommendationsDir source recommendations directory.
+	 * @param destRecommendationsDir destination recommendations directory.
+	 * @param recommendationsToPackage list of recommendations to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterRecommendation(File srcRecommendationsDir, File destRecommendationsDir, List<String> recommendationsToPackage) throws IOException {
         if (recommendationsToPackage == null || recommendationsToPackage.isEmpty()) {
             return;
@@ -380,6 +490,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the resources based on a prefix.
+	 *
+	 * @param srcDir source directory.
+	 * @param prefix prefix of the file.
+	 * @param destDir destination destination directory.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterResources(File srcDir, String prefix, File destDir) throws IOException {
         File resourcesDir = new File(srcDir, "resources");
         File[] files = resourcesDir.listFiles(); // One level deep
@@ -403,6 +521,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the custom groups based on the content.yaml view definitions.
+	 *
+	 * @param srcCustomGroupsDir source custom groups directory.
+	 * @param destCustomGroupsDir destination custom groups directory.
+	 * @param customGroupsToPackage list of custom groups to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterCustomGroups(File srcCustomGroupsDir, File destCustomGroupsDir, List<String> customGroupsToPackage) throws IOException {
         File[] files = srcCustomGroupsDir.listFiles();
         if (files == null || files.length == 0) {
@@ -426,6 +552,14 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Filter and copy the policies based on the content.yaml view definitions.
+	 *
+	 * @param srcPoliciesDir source policies directory.
+	 * @param destPoliciesDir destination policies directory.
+	 * @param policiesToPackage list of policies to be packaged.
+	 * @throws IOException if the copying files fails.
+	 */
     private void filterPolicies(File srcPoliciesDir, File destPoliciesDir, List<String> policiesToPackage) throws IOException {
         if (policiesToPackage == null || policiesToPackage.isEmpty()) {
             return;
@@ -456,11 +590,25 @@ public class PackageMojo extends AbstractMojo {
         }
     }
 
+	/**
+	 * Copy the policy metadata json file to the target directory.
+	 *
+	 * @param srcPoliciesDir source policies directory.
+	 * @param destPoliciesDir destination policies directory.
+	 * @throws IOException if the copying files fails.
+	 */
     private void copyPolicyMetadataFile(File srcPoliciesDir, File destPoliciesDir) throws IOException {
         File policyMetadataFile = new File(srcPoliciesDir, POLICY_METADATA_FILE_NAME);
         FileUtils.copyFile(policyMetadataFile, new File(destPoliciesDir, POLICY_METADATA_FILE_NAME));
     }
 
+	/**
+	 * Copy the dashboard sharing metadata json file to the target directory.
+	 *
+	 * @param srcDashboardDir source dashboards directory.
+	 * @param destDashboardDir destination dashboards directory.
+	 * @throws IOException if the copying files fails.
+	 */
     private void copyDashboardSharingMetadataFile(File srcDashboardDir, File destDashboardDir) throws IOException {
         File dashboardSharingMetadataFile = new File(srcDashboardDir, DASHBOARD_SHARE_METADATA_FILENAME);
         if (dashboardSharingMetadataFile.exists()) {
@@ -468,6 +616,13 @@ public class PackageMojo extends AbstractMojo {
         }
     }
     
+	/**
+	 * Copy the dashboard activation metadata json file to the target directory.
+	 *
+	 * @param srcDashboardDir source dashboards directory.
+	 * @param destDashboardDir destination dashboards directory.
+	 * @throws IOException if the copying files fails.
+	 */
     private void copyDashboardActivationMetadataFiles(File srcDashboardDir, File destDashboardDir) throws IOException {
         // users activation metadata file
     	File dashboardUserActivateFile = new File(srcDashboardDir, DASHBOARD_USER_ACTIVATE_METADATA_FILENAME);
@@ -479,5 +634,18 @@ public class PackageMojo extends AbstractMojo {
         if (dashboardGroupActivateFile.exists()) {
             FileUtils.copyFile(dashboardGroupActivateFile, new File(destDashboardDir, DASHBOARD_GROUP_ACTIVATE_METADATA_FILENAME));
         }        
+    }
+
+	/**
+	 * Copy the content.yaml file itself to the target directory in order to be part of the target package.
+	 *
+	 * @param contentYamlFile content yaml file handle.
+	 * @param targetDirectory target directory to be copied to.
+	 * @throws IOException if the copying files fails.
+	 */
+    private void addContentYamlFile(File contentYamlFile, File targetDirectory) throws IOException {
+		if (contentYamlFile.exists()) {
+            FileUtils.copyFile(contentYamlFile, new File(targetDirectory, contentYamlFile.getName()));
+		}
     }
 }

--- a/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/package-info.java
+++ b/maven/plugins/vrops/src/main/java/com/vmware/pscoe/maven/plugins/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Package that represents maven actions.
+ *
+ */
+
+package com.vmware.pscoe.maven.plugins;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */


### PR DESCRIPTION
[Task IAC-786] Implementation of the vROPs default policy feature for vROPs 8.12.x.

### Description

Added option for setting default policy for vROPs version 8.12.x by setting it in the default-policy configuration item in the content.yaml file.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

On a vROPs project add the following line to the content.yaml file

default-policy:
  - Policy Name
  
After pushing the package to vROPs 8.12.x the default policy should be set to 'Policy Name'. 

### Release Notes

Added support for setting default policy in the content.yaml file in the following format:

default-policy:
  - Policy Name
 