### PR TITLE
[Task IAC-788] Fix Problem with enabling of vRA blueprint of type workflow for vRA prior 8.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1105,7 +1105,9 @@
 * Support hint collection for dependencies present only on the local machine
 
 ### Fixes
-* Log4j2 logs an error that configuration is missing when building/testing packages
+* Log4j2 logs an error that configuration is missing when building/testing packages.
+* Fix vRA Custom Forms not enabled with vRA Version prior 8.12.x.
+* Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x.
 
 ## v1.0.1 - 13 Mar 2018
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNg.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNg.java
@@ -853,14 +853,14 @@ public class RestClientVraNg extends RestClientVraNgPrimitive {
 	/**
 	 * getCatalogItemVersions.
 	 *
-	 * @param sourceId source id
+	 * @param catalogItemId catalog item id.
 	 * @return catalogItemVersion
 	 */
-	public JsonArray getCatalogItemVersions(final String sourceId) {
+	public JsonArray getCatalogItemVersions(final String catalogItemId) {
 		try {
-			return this.getCatalogItemVersionsPrimitive(sourceId);
+			return this.getCatalogItemVersionsPrimitive(catalogItemId);
 		} catch (Exception e) {
-			throw new RuntimeException(String.format("Could not get custom form by source '%s'.", sourceId, e));
+			throw new RuntimeException(String.format("Could not get custom form by id '%s'.", catalogItemId, e));
 		}
 	}
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore812.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore812.java
@@ -168,7 +168,7 @@ public class VraNgCatalogItemStore812 extends VraNgCatalogItemStore {
 			logger.error("Provided versions array is null");
 		}
 
-		return newList.isEmpty() ? null: newList.get(newList.size() - 1);
+		return newList.isEmpty() ? null : newList.get(newList.size() - 1);
 	}
 
 	// =================================================

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore812.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCatalogItemStore812.java
@@ -76,7 +76,7 @@ public class VraNgCatalogItemStore812 extends VraNgCatalogItemStore {
 			String sourceId = catalogItem.getId() + "/" + versionName;
 			JsonElement formId = versionObj.get("formId");
 			if (formId != null) {
-				form = this.restClient.fetchRequestForm("com.vmw.blueprint.version", sourceId, formId.getAsString());
+				form = this.restClient.fetchRequestForm(BLUEPRINT_VERSION, sourceId, formId.getAsString());
 				catalogItem.setFormId(form.getId());
 
 			} else {
@@ -167,7 +167,8 @@ public class VraNgCatalogItemStore812 extends VraNgCatalogItemStore {
 		} catch (NullPointerException npe) {
 			logger.error("Provided versions array is null");
 		}
-		return newList.get(newList.size() - 1);
+
+		return newList.isEmpty() ? null: newList.get(newList.size() - 1);
 	}
 
 	// =================================================
@@ -184,27 +185,31 @@ public class VraNgCatalogItemStore812 extends VraNgCatalogItemStore {
 	@Override
 	protected void importCustomForm(final VraNgCatalogItem catalogItem, final File catalogItemFolder) {
 		String formName = getName(catalogItem) + CUSTOM_RESOURCE_SUFFIX;
-		String formDataName = getName(catalogItem) + CATALOG_ITEM_SEPARATOR + CUSTOM_FORM_DATA_SUFFIX
-				+ CUSTOM_RESOURCE_SUFFIX;
+		String formDataName = getName(catalogItem) + CATALOG_ITEM_SEPARATOR + CUSTOM_FORM_DATA_SUFFIX + CUSTOM_RESOURCE_SUFFIX;
 		File customFormFile = Paths.get(catalogItemFolder.getPath(), CUSTOM_FORMS_SUBDIR, formName).toFile();
 		File customFormDataFile = Paths.get(catalogItemFolder.getPath(), CUSTOM_FORMS_SUBDIR, formDataName).toFile();
 
-		logger.info("Importing custom form: '{}'' with type '{}'", customFormFile.getAbsolutePath(),
-				catalogItem.getType());
+		logger.info("Importing custom form: '{}'' with type '{}'", customFormFile.getAbsolutePath(), catalogItem.getType());
 		VraNgCustomForm customForm = this.jsonFileToVraCustomForm(customFormFile, customFormDataFile);
-
 		// wait 250 ms between each custom form import in order catalog item to be
 		// retrievable by the VRA REST API
 		if (this.waitForCatalogItemToAppear(catalogItem.getName())) {
 			if (catalogItem.getType().equals(VraNgContentSourceType.BLUEPRINT)) {
 				JsonElement version = this.getCatalogItemLatestVersion(catalogItem);
-				JsonObject versionObj = version.getAsJsonObject();
-				String versionName = versionObj.get("id").getAsString();
+				String versionName = "";
+				// do sanity check on the version JSON element
+				if (version != null) {
+					JsonObject versionObj = version.getAsJsonObject();
+					// sanity check on the version object and its properties
+					if (versionObj != null && versionObj.get("id") != null) {
+						versionName = versionObj.get("id").getAsString();
+					}
+				}
 				String newFormName = catalogItem.getId() + CATALOG_ITEM_BLUEPRINT_VERSION_NAME_SEPARATOR + versionName;
 				String newSourceId = catalogItem.getId() + CATALOG_ITEM_BLUEPRINT_VERSION_SOURCE_ID_SEPARATOR + versionName;
 				// normalize here to accommodate < 8.12 to >=8.12
 				customForm.setSourceId(newSourceId);
-				customForm.setSourceType("com.vmw.blueprint.version");
+				customForm.setSourceType(BLUEPRINT_VERSION);
 				customForm.setName(newFormName);
 				logger.info("Importing custom form for blueprint version '{}'", customForm.getName());
 				this.restClient.importCustomForm(customForm, customForm.getSourceId());

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -49,6 +49,21 @@ Then the 'Policy Name' will be set to the default policy in vROPs.
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation)
 
+### vRA Custom Form not Enabled with vRA Version 8.11.2
+
+#### Previous Behaviour
+When pushing vRA custom forms to vRA version 8.11.2 they are not get enabled by default, thus not visible in the blueprint section.
+
+#### Current Behaviour
+When pushing vRA custom forms to vRA version 8.11.2 they are get enabled by default and visible in the blueprint section.
+
+### Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x
+
+#### Previous Behaviour
+If the vRA returns an empty versions array when fetching of latest vRA blueprint version would throw a null pointer exception.
+
+#### Current Behaviour
+If the vRA returns an empty versions array when fetching of latest vRA blueprint version it would not throw null pointer exception and add an empty string in the blueprint version string.
 
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
Fix Problem with enabling of vRA blueprint of type workflow for vRA prior 8.12.x
Signed-off-by: Alexander Kantchev <akantchev@vmware.com>

<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixed problem with enabling of vRA blueprints of type 'com.vmw.vro.workflow' during push of such blueprints on vRA prior 8.12.x

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have tested against live environment, if applicable
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested with pushing of vRA blueprints of type  'com.vmw.vro.workflow' on vRA 8.10.1 and 8.13.0. On both environments pushing works fine and vRA blueprints get enabled.

### Release Notes

### vRA Custom Form not Enabled with vRA Version 8.11.2

#### Previous Behaviour
When pushing vRA custom forms to vRA version 8.11.2 they are not get enabled by default, thus not visible in the blueprint section.

#### Current Behaviour
When pushing vRA custom forms to vRA version 8.11.2 they are get enabled by default and visible in the blueprint section.

### Improved Handling of Empty vRA Blueprint Versions for vRA 8.12.x

#### Previous Behavior
If the vRA returns an empty versions array when fetching of latest vRA blueprint version would throw a null pointer exception.

#### Current Behavior
If the vRA returns an empty versions array when fetching of latest vRA blueprint version it would not throw null pointer exception and add an empty string in the blueprint version string.


### Related issues and PRs

IAC-788
