### PR TITLE
[Task IAC-790] Update usage of deprecated vROPs policy (since vROPs 8.12.X)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1107,6 +1107,9 @@
 ### Fixes
 * Log4j2 logs an error that configuration is missing when building/testing packages
 
+### improvements
+* Update usage of deprecated policy APIs for vROPs 8.12.x.
+
 ## v1.0.1 - 13 Mar 2018
 
 ### Fixes

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVrops.java
@@ -66,6 +66,7 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrops.AuthUsersDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.AuthUserDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.CustomGroupDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.CustomGroupTypeDTO;
+import com.vmware.pscoe.iac.artifact.rest.model.vrops.PolicyCustomGroupAssignmentDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.PolicyDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.RecommendationDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.ReportDefinitionDTO;
@@ -100,7 +101,39 @@ public class RestClientVrops extends RestClient {
 	/**
 	 * POLICIES_API.
 	 */
-	private static final String POLICIES_API = INTERNAL_API_PREFIX + "policies/";
+	private static final String POLICIES_API = INTERNAL_API_PREFIX + "policies";
+	/**
+	 * POLICIES_IMPORT_INTERNAL_API.
+	 */
+	private static final String POLICIES_IMPORT_INTERNAL_API = POLICIES_API + "/import";
+	/**
+	 * POLICIES_IMPORT_PUBLIC_API.
+	 */
+	private static final String POLICIES_IMPORT_PUBLIC_API = PUBLIC_API_PREFIX + "policies/import";
+	/**
+	 * POLICIES_EXPORT_INTERNAL_API.
+	 */
+	private static final String POLICIES_EXPORT_INTERNAL_API = POLICIES_API + "/export";
+	/**
+	 * POLICIES_EXPORT_PUBLIC_API.
+	 */
+	private static final String POLICIES_EXPORT_PUBLIC_API = PUBLIC_API_PREFIX + "policies/export";
+	/**
+	 * POLICIES_APPLY_INTERNAL_API.
+	 */
+	private static final String POLICIES_APPLY_INTERNAL_API = POLICIES_API + "/apply";
+	/**
+	 * POLICIES_APPLY_PUBLIC_API.
+	 */
+	private static final String POLICIES_APPLY_PUBLIC_API = PUBLIC_API_PREFIX + "policies/apply";
+	/**
+	 * POLICIES_FETCH_INTERNAL_API.
+	 */
+	private static final String POLICIES_FETCH_INTERNAL_API = POLICIES_API;
+	/**
+	 * POLICIES_FETCH_PUBLIC_API.
+	 */
+	private static final String POLICIES_FETCH_PUBLIC_API = PUBLIC_API_PREFIX + "policies";
 	/**
 	 * DEFAULT_POLICY_API.
 	 */
@@ -170,10 +203,6 @@ public class RestClientVrops extends RestClient {
 	 */
 	private static final int DEFAULT_PAGE_SIZE = 10000;
 	/**
-	 * VROPS_8_2 version.
-	 */
-	private static final String VROPS_8_2 = "8.2";
-	/**
 	 * VROPS_KIND_ALL.
 	 */
 	private static final String VROPS_KIND_ALL = "ALL";
@@ -181,6 +210,10 @@ public class RestClientVrops extends RestClient {
 	 * vROPs 8.12 version.
 	 */
 	private static final String VROPS_8_12 = "8.12";
+	/**
+	 * VROPS_8_2 version.
+	 */
+	private static final String VROPS_8_2 = "8.2";	
 	/**
 	 * configuration.
 	 */
@@ -193,7 +226,15 @@ public class RestClientVrops extends RestClient {
 	 * mapper.
 	 */
 	private ObjectMapper mapper = new ObjectMapper();
-
+	/**
+	 * isAbove812 flag.
+	 */
+	private Boolean isAbove812 = null;	
+	/**
+	 * isAbove82 flag.
+	 */
+	private Boolean isAbove82 = null;
+	
 	/**
 	 * RestClientVrops.
 	 * @param configuration
@@ -273,6 +314,32 @@ public class RestClientVrops extends RestClient {
 	}
 
 	/**
+	 * Checks whether vROPs version is above 8.12.
+	 *
+	 * @return true if version is above 8.12 otherwise false.
+	 */
+	public Boolean isVersionAbove812() {
+		if (this.isAbove812 == null) {
+			this.isAbove812 = this.isVersionAbove(VROPS_8_12);
+		}
+
+		return this.isAbove812;
+	}	
+
+	/**
+	 * Checks whether vROPs version is above 8.2.
+	 *
+	 * @return true if version is above 8.2 otherwise false.
+	 */
+	public Boolean isVersionAbove82() {
+		if (this.isAbove82 == null) {
+			this.isAbove82 = this.isVersionAbove(VROPS_8_2);
+		}
+
+		return this.isAbove82;
+	}	
+	
+	/**
 	 * Import policies from a zip file.
 	 * 
 	 * @param file       policy zip file as byte[]
@@ -285,16 +352,21 @@ public class RestClientVrops extends RestClient {
 	public void importPolicyFromZip(String policyName, File file, Boolean force) throws Exception {
 		URI uri;
 		try {
-			uri = getURI(getURIBuilder().setPath(POLICIES_API + "import"));
+			// for newer vROPs versions the policies API is no longer internal.
+			if (this.isVersionAbove812()) {
+				uri = getURI(getURIBuilder().setPath(POLICIES_IMPORT_PUBLIC_API));
+			} else {
+				uri = getURI(getURIBuilder().setPath(POLICIES_IMPORT_INTERNAL_API));
+			}
 		} catch (RuntimeException e) {
 			throw e;
 		}
-
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-		// Required header for internal API
-		headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
-
+		// older vROPs versions use internal API, thus header must be set for it
+		if (!this.isVersionAbove812()) {
+			headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		}
 		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 		body.add("policy", new FileSystemResource(file));
 		body.add("forceImport", force);
@@ -315,7 +387,7 @@ public class RestClientVrops extends RestClient {
 	 */
 	public void setDefaultPolicy(final String policyName) throws Exception {
 		// default policy setting is available since vROPs 8.12 only
-		if (!this.isVersionAbove(VROPS_8_12)) {
+		if (!this.isVersionAbove812()) {
 			logger.warn("Cannot set default policy to '{}' as vROPs version is older than '{}'", policyName, VROPS_8_12);
 			return;
 		}
@@ -346,7 +418,7 @@ public class RestClientVrops extends RestClient {
 	 */
 	public PolicyDTO.Policy getDefaultPolicy() throws Exception {
 		// default policy is available since vROPs 8.12 only
-		if (!this.isVersionAbove(VROPS_8_12)) {
+		if (!this.isVersionAbove812()) {
 			return null;
 		}
 
@@ -363,17 +435,25 @@ public class RestClientVrops extends RestClient {
 	public List<PolicyDTO.Policy> exportPoliciesFromVrops(List<String> policyEntries) {
 		List<PolicyDTO.Policy> policies = filterPoliciesByName(policyEntries);
 		restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
-		for (PolicyDTO.Policy policy : policies) {
-			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
-			uriBuilder.queryParam("id", policy.getId());
 
+		UriComponentsBuilder uriBuilder;
+		// for newer vROPs versions the policies API is no longer internal.
+		if (this.isVersionAbove812()) {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_EXPORT_PUBLIC_API)));
+		} else {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_EXPORT_INTERNAL_API)));
+		}
+
+		for (PolicyDTO.Policy policy : policies) {
+			uriBuilder.queryParam("id", policy.getId());
 			HttpHeaders exportHeader = new HttpHeaders();
 			exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
-			// internal header is needed for vROPs internal API
-			exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+			// older vROPs versions use internal API for policies export, thus internal header needs to be set.
+			if (!this.isVersionAbove812()) {
+				exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+			}
 			HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
 			ResponseEntity<byte[]> exportResponse = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.GET, exportEntity, byte[].class);
-
 			policy.setZipFile(exportResponse.getBody());
 		}
 
@@ -389,12 +469,21 @@ public class RestClientVrops extends RestClient {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
 
-		// Required header for internal API
-		headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		// older vROPs versions use internal API for policies, thus internal header needs to be set.
+		if (!this.isVersionAbove812()) {
+			headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());			
+		}		
 		HttpEntity<String> entity = new HttpEntity<>(headers);
 		ResponseEntity<String> response;
 		try {
-			UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(new URI(getURIBuilder().setPath(POLICIES_API).toString()));
+			UriComponentsBuilder uriBuilder;
+			// for newer vROPs versions the policies API is no longer internal.
+			if (this.isVersionAbove812()) {
+				uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_FETCH_PUBLIC_API)));
+			} else {
+				uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_FETCH_INTERNAL_API)));
+				
+			}			
 			uriBuilder.queryParam("pageSize", DEFAULT_PAGE_SIZE);
 			URI restUri = uriBuilder.build().toUri();
 			response = restTemplate.exchange(restUri, HttpMethod.GET, entity, String.class);
@@ -402,13 +491,14 @@ public class RestClientVrops extends RestClient {
 			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
 				return new ArrayList<>();
 			}
-			throw new RuntimeException(String.format("Error ocurred trying to fetching policies. Message: %s", e.getMessage()));
-		} catch (URISyntaxException e) {
-			throw new RuntimeException(String.format("Error building REST URI to fetch policies. Message: %s", e.getMessage()));
+			throw new RuntimeException(String.format("HTTP error ocurred trying to fetching policies. Message: %s", e.getMessage()));
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("General error building REST URI to fetch policies. Message: %s", e.getMessage()));
 		}
 		PolicyDTO policyDto = deserializePolicies(response.getBody());
 
-		return policyDto == null ? Collections.emptyList() : policyDto.getPolicies();
+		// in vROPs version 8.12 and above the DTO key is called 'policySummaries', however in older versions the key is called 'policy-summaries'
+		return policyDto == null ? Collections.emptyList() : policyDto.getPolicySummaries() != null ? policyDto.getPolicySummaries() : policyDto.getPolicies();
 	}
 
 	/**
@@ -419,19 +509,24 @@ public class RestClientVrops extends RestClient {
 	 * @return policy
 	 */
 	public PolicyDTO.Policy getPolicyContent(PolicyDTO.Policy policy) {
-		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_API + "export")));
-		uriBuilder.queryParam("id", policy.getId());
-
+		UriComponentsBuilder uriBuilder;
 		HttpHeaders exportHeader = new HttpHeaders();
-		if (this.isVersionAbove(VROPS_8_2)) {
-			// The API vROPs 8.2 or later expects accept to be MediaType.ALL
-			exportHeader.setAccept(Arrays.asList(MediaType.ALL));
-		} else {
-			exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
-		}
-		// internal header is needed for the internal API of vROPs
-		exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		exportHeader.setAccept(Arrays.asList(MediaType.ALL));
 
+		// The API vROPs 8.2 or later expects accept to be MediaType.ALL
+		if (this.isVersionAbove82()) {			
+			exportHeader.setAccept(Arrays.asList(MediaType.ALL));
+		}		
+		// for newer vROPs versions the policies API is no longer internal.
+		if (this.isVersionAbove812()) {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_EXPORT_PUBLIC_API)));
+		} else {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_EXPORT_INTERNAL_API)));
+			exportHeader.setAccept(Arrays.asList(MediaType.APPLICATION_OCTET_STREAM));
+			// older vROPs versions use internal API for policies, thus internal header needs to be set.
+			exportHeader.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		}
+		uriBuilder.queryParam("id", policy.getId());
 		HttpEntity<String> exportEntity = new HttpEntity<>(exportHeader);
 		ResponseEntity<byte[]> response;
 		try {
@@ -441,12 +536,59 @@ public class RestClientVrops extends RestClient {
 		}
 
 		if (!HttpStatus.OK.equals(response.getStatusCode())) {
-			throw new RuntimeException(
-					String.format("Error exporting all policy %s from vROPS : remote REST service returned: %s", policy.getName(), response.getStatusCode()));
+			throw new RuntimeException(String.format("Error exporting all policy %s from vROPS : remote REST service returned: %s", policy.getName(), response.getStatusCode()));
 		}
 		policy.setZipFile(response.getBody());
 
 		return policy;
+	}
+
+	/**
+	 * Applies policy to given custom groups.
+	 * 
+	 * @param policy policy DTO object.
+	 * @param groups list of custom group group DTO objects.
+	 *
+	 */
+	public void applyPolicyToCustomGroups(PolicyDTO.Policy policy, List<CustomGroupDTO.Group> groups) {
+		UriComponentsBuilder uriBuilder;
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+
+		// for newer vROPs versions the policies API is no longer internal.
+		if (this.isVersionAbove812()) {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_APPLY_PUBLIC_API)));
+		} else {
+			uriBuilder = UriComponentsBuilder.fromUri(getURI(getURIBuilder().setPath(POLICIES_APPLY_INTERNAL_API)));
+			// older vROPs versions use internal API for policies, thus internal header needs to be set.
+			headers.set(INTERNAL_API_HEADER_NAME, Boolean.TRUE.toString());
+		}
+		List<String> groupIds = groups.stream().filter(group -> !StringUtils.isEmpty(group.getId())).map(group -> (group.getId())).collect(Collectors.toList());
+
+		PolicyCustomGroupAssignmentDTO policyAssignmentDto = new PolicyCustomGroupAssignmentDTO();
+		policyAssignmentDto.setId(policy.getId());
+		policyAssignmentDto.setGroups(groupIds);
+		String policyAssignment = this.deserializePolicyCustomGroupAssignmentDto(policyAssignmentDto);
+
+		HttpEntity<String> entity = new HttpEntity<>(policyAssignment, headers);
+		ResponseEntity<String> responseEntity = new ResponseEntity<String>(HttpStatus.OK);
+		try {
+			responseEntity = restTemplate.exchange(uriBuilder.toUriString(), HttpMethod.POST, entity, String.class);
+		} catch (HttpClientErrorException e) {
+			if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+				throw new RuntimeException(String.format("Unable to find resource while applying policy '%s' to custom groups: %s: ", policy.getName(), e.getStatusText()));
+			} else if (HttpStatus.BAD_REQUEST.equals(e.getStatusCode())) {
+				throw new RuntimeException(String.format("Validation error while applying policy '%s' to custom groups: %s: ", policy.getName(), e.getStatusText()));
+			} else {
+				throw new RuntimeException(String.format("Error while applying policy '%s' to custom groups: %s: ", policy.getName(), e.getStatusText()));
+			}
+		} catch (RestClientException e) {
+			throw new RuntimeException(String.format("Error applying policy '%s' to custom groups: %s: ", policy.getName(), e.getMessage()));
+		}
+		// For all other HTTP errors than HTTP status OK, throw an error with the message returned by the API.
+		if (!HttpStatus.OK.equals(responseEntity.getStatusCode())) {
+			throw new RuntimeException(String.format("Error applying policy '%s' to custom groups: %s: ", policy.getName(), responseEntity.getBody()));
+		}
 	}
 
 	/**
@@ -2051,4 +2193,13 @@ public class RestClientVrops extends RestClient {
 		}
 	}
 
+	private String deserializePolicyCustomGroupAssignmentDto(PolicyCustomGroupAssignmentDTO policyCustomGroupAssignmentDto) {
+		try {
+			return mapper.writeValueAsString(policyCustomGroupAssignmentDto);
+		} catch (JsonMappingException e) {
+			throw new RuntimeException(String.format("Failed to de-serialize policy assignment DTO, JSON mapping error: %s", e.getMessage()));
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(String.format("Failed to de-serialize policy assignment DTO, JSON processing error: %s", e.getMessage()));
+		}
+	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyCustomGroupAssignmentDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyCustomGroupAssignmentDTO.java
@@ -1,0 +1,112 @@
+package com.vmware.pscoe.iac.artifact.rest.model.vrops;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2023 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "id", "groups" })
+public class PolicyCustomGroupAssignmentDTO implements Serializable {
+	private static final long serialVersionUID = -8042756118741033913L;
+
+	/**
+	 * id.
+	 */
+	@JsonProperty("id")
+	private String id;
+
+	/**
+	 * groups.
+	 */
+	@JsonProperty("groups")
+	private List<String> groups;
+
+	/**
+	 * additionalProperties.
+	 */
+	@JsonIgnore
+	private Map<String, Object> additionalProperties = new LinkedHashMap<String, Object>();
+
+	/**
+	 * getId().
+	 * 
+	 * @return policy id.
+	 */
+	@JsonProperty("id")
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * setId().
+	 * 
+	 * @param id policy id to be set.
+	 */
+	@JsonProperty("id")
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * getGroups().
+	 * 
+	 * @return list of assigned groups.
+	 */
+	@JsonProperty("groups")
+	public List<String> getGroups() {
+		return groups;
+	}
+
+	/**
+	 * setGroups().
+	 * 
+	 * @param groups to be assigned policy to.
+	 */
+	@JsonProperty("groups")
+	public void setGroups(List<String> groups) {
+		this.groups = groups;
+	}
+
+	/**
+	 * getAdditionalProperties().
+	 * 
+	 * @return map of additional properties.
+	 */
+	@JsonAnyGetter
+	public Map<String, Object> getAdditionalProperties() {
+		return this.additionalProperties;
+	}
+
+	/**
+	 * setAdditionalProperties().
+	 * 
+	 * @param name the name of the property.
+	 * @param value the value of the property.
+	 */
+	@JsonAnySetter
+	public void setAdditionalProperty(String name, Object value) {
+		this.additionalProperties.put(name, value);
+	}
+}

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/model/vrops/PolicyDTO.java
@@ -39,6 +39,12 @@ public class PolicyDTO {
 	private List<Policy> policies;
 
 	/**
+	 * policySummaries.
+	 */
+	@JsonProperty("policySummaries")
+	private List<Policy> policySummaries;
+
+	/**
 	 * additionalProperties.
 	 */
 	@JsonIgnore
@@ -55,6 +61,26 @@ public class PolicyDTO {
 	}
 
 	/**
+	 * setPolicySummaries().
+	 * 
+	 * @param policySummaries policies to be set.
+	 */
+	@JsonProperty("policySummaries")
+	public void setPolicySummaries(List<Policy> policySummaries) {
+		this.policySummaries = policySummaries;
+	}
+
+	/**
+	 * policySummaries().
+	 * 
+	 * @return list of policySummaries.
+	 */
+	@JsonProperty("policySummaries")
+	public List<Policy> getPolicySummaries() {
+		return this.policySummaries;
+	}
+
+	/**
 	 * setPolicies().
 	 * 
 	 * @param policies policies to be set.
@@ -62,7 +88,7 @@ public class PolicyDTO {
 	@JsonProperty("policy-summaries")
 	public void setPolicies(List<Policy> policies) {
 		this.policies = policies;
-	}
+	}	
 
 	/**
 	 * getAdditionalProperties().

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrops/VropsPackageStoreTest.java
@@ -18,6 +18,8 @@ package com.vmware.pscoe.iac.artifact.store.vrops;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +52,9 @@ import com.vmware.pscoe.iac.artifact.rest.model.vrops.SupermetricDTO;
 import com.vmware.pscoe.iac.artifact.rest.model.vrops.ViewDefinitionDTO;
 
 public class VropsPackageStoreTest {
-
+	/**
+	 * Temp Folder.
+	 */
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -109,79 +113,90 @@ public class VropsPackageStoreTest {
     }
 
     @Test
-    void importPackageWhenPackageIsOK() throws Exception {
-        // GIVEN
-        tempFolder.create();
-        String testViewName = "Test View";
-        String testCustomGroupName = "Test custom group";
-        String testCustomGroupPayload = "{}";
-        String existingGroup = "group1";
-        String existingUser = "user1";
-        String existingDashboard = "DashboardName";
-        String defaultPolicy = "policy";
-        String contentYaml = "content.yaml";
-
-        String[] shareGroups = new String[] { existingGroup };
-        String[] unshareGroups = new String[] { existingGroup };
-        String[] activateGroups = new String[] { existingUser };
-        String[] activateUsers = new String[] { existingUser };
-
-        List<AuthGroupDTO> allGroups = new ArrayList<>();
-        AuthGroupDTO group1Dto = new AuthGroupDTO();
-        group1Dto.setDisplayName(existingGroup);
-        allGroups.add(group1Dto);
-
-        List<AuthUserDTO> allUsers = new ArrayList<>();
-        AuthUserDTO user1Dto = new AuthUserDTO();
-        user1Dto.setUsername(existingUser);
-        allUsers.add(user1Dto);
-
-        CliManagerVrops cliMock = Mockito.mock(CliManagerVrops.class);
-        Mockito.doNothing().when(cliMock).connect();
-        Mockito.doNothing().when(cliMock).importFilesToVrops();
-        Mockito.doNothing().when(cliMock).addDashboardToImportList(Mockito.isA(File.class));
-
-        Mockito.doNothing().when(cliMock).activateDashboard(existingDashboard, Arrays.asList(activateGroups), true);
-        Mockito.doNothing().when(cliMock).activateDashboard(existingDashboard, Arrays.asList(activateUsers), false);
-        Mockito.doNothing().when(cliMock).deactivateDashboard(existingDashboard, Arrays.asList(activateGroups), true);
-        Mockito.doNothing().when(cliMock).deactivateDashboard(existingDashboard, Arrays.asList(activateUsers), false);
-
-        Mockito.doNothing().when(cliMock).shareDashboard(existingDashboard, shareGroups);
-        Mockito.doNothing().when(cliMock).unshareDashboard(existingDashboard, unshareGroups);
-
-        Mockito.doNothing().when(cliMock).addViewToImportList(Mockito.isA(File.class));
-        Mockito.doNothing().when(cliMock).addReportToImportList(Mockito.isA(File.class));
-
-        Mockito.doReturn(true).when(cliMock).hasAnyCommands();
-
-        RestClientVrops restClientMock = Mockito.mock(RestClientVrops.class);
-        Mockito.doReturn(allGroups).when(restClientMock).findAllAuthGroups();
-        Mockito.doReturn(allUsers).when(restClientMock).findAllAuthUsers();
-        Mockito.doReturn(allGroups).when(restClientMock).findAuthGroupsByNames(Arrays.asList(new String[] {existingGroup}));
-        Mockito.doReturn(allUsers).when(restClientMock).findAuthUsersByNames(Arrays.asList(new String[] {existingUser}));
-
-        Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.ALERT_DEFINITION, new HashMap<>());
-        Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.SYMPTOM_DEFINITION, new HashMap<>());
-        Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.RECOMMENDATION, new HashMap<>());
-        Mockito.doNothing().when(restClientMock).importCustomGroupInVrops(testCustomGroupName, testCustomGroupPayload, new HashMap<>());
-        Mockito.doNothing().when(restClientMock).setDefaultPolicy(defaultPolicy);
-
-        VropsPackageStore store = new VropsPackageStore(cliMock, restClientMock, tempFolder.newFolder());
-
-        File packageZip = PackageMocked.createSamplePackageZip(tempFolder.newFolder(), "ViewName", "viewid123", existingDashboard, "AlertDefinitions");
-        Package vropsPkg = PackageFactory.getInstance(PackageType.VROPS, packageZip);
-        List<Package> packages = new ArrayList<>();
-        packages.add(vropsPkg);
-
-        // WHEN
-        List<Package> importedPackages = store.importAllPackages(packages, false, false);
-
-        // THEN
-        assertNotNull(importedPackages);
-        assertEquals(importedPackages.size(), packages.size());
-        Mockito.verify(cliMock, Mockito.times(packages.size())).connect();
-        Mockito.verify(cliMock, Mockito.times(packages.size())).importFilesToVrops();
+    void importPackageWhenPackageIsOkForVrops812andAbove() throws Exception {
+    	this.importVropsPackage(true);
     }
+    
+    @Test
+    void importPackageWhenPackageIsOkForVrops812andBelow() throws Exception {
+    	this.importVropsPackage(false);
+    }    
+
+	private void importVropsPackage(boolean isVropsAbove812) throws Exception {
+		// GIVEN
+		tempFolder.create();
+		String testViewName = "Test View";
+		String testCustomGroupName = "Test custom group";
+		String testCustomGroupPayload = "{}";
+		String existingGroup = "group1";
+		String existingUser = "user1";
+		String existingDashboard = "DashboardName";
+		String defaultPolicy = "policy";
+		String contentYaml = "content.yaml";
+
+		String[] shareGroups = new String[] { existingGroup };
+		String[] unshareGroups = new String[] { existingGroup };
+		String[] activateGroups = new String[] { existingUser };
+		String[] activateUsers = new String[] { existingUser };
+
+		List<AuthGroupDTO> allGroups = new ArrayList<>();
+		AuthGroupDTO group1Dto = new AuthGroupDTO();
+		group1Dto.setDisplayName(existingGroup);
+		allGroups.add(group1Dto);
+
+		List<AuthUserDTO> allUsers = new ArrayList<>();
+		AuthUserDTO user1Dto = new AuthUserDTO();
+		user1Dto.setUsername(existingUser);
+		allUsers.add(user1Dto);
+
+		CliManagerVrops cliMock = Mockito.mock(CliManagerVrops.class);
+		Mockito.doNothing().when(cliMock).connect();
+		Mockito.doNothing().when(cliMock).importFilesToVrops();
+		Mockito.doNothing().when(cliMock).addDashboardToImportList(Mockito.isA(File.class));
+
+		Mockito.doNothing().when(cliMock).activateDashboard(existingDashboard, Arrays.asList(activateGroups), true);
+		Mockito.doNothing().when(cliMock).activateDashboard(existingDashboard, Arrays.asList(activateUsers), false);
+		Mockito.doNothing().when(cliMock).deactivateDashboard(existingDashboard, Arrays.asList(activateGroups), true);
+		Mockito.doNothing().when(cliMock).deactivateDashboard(existingDashboard, Arrays.asList(activateUsers), false);
+
+		Mockito.doNothing().when(cliMock).shareDashboard(existingDashboard, shareGroups);
+		Mockito.doNothing().when(cliMock).unshareDashboard(existingDashboard, unshareGroups);
+
+		Mockito.doNothing().when(cliMock).addViewToImportList(Mockito.isA(File.class));
+		Mockito.doNothing().when(cliMock).addReportToImportList(Mockito.isA(File.class));
+
+		Mockito.doReturn(true).when(cliMock).hasAnyCommands();
+
+		RestClientVrops restClientMock = Mockito.mock(RestClientVrops.class);
+		Mockito.doReturn(isVropsAbove812).when(restClientMock).isVersionAbove812();
+		Mockito.doReturn(allGroups).when(restClientMock).findAllAuthGroups();
+		Mockito.doReturn(allUsers).when(restClientMock).findAllAuthUsers();
+		Mockito.doReturn(allGroups).when(restClientMock).findAuthGroupsByNames(Arrays.asList(new String[] { existingGroup }));
+		Mockito.doReturn(allUsers).when(restClientMock).findAuthUsersByNames(Arrays.asList(new String[] { existingUser }));
+
+		Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.ALERT_DEFINITION, new HashMap<>());
+		Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.SYMPTOM_DEFINITION, new HashMap<>());
+		Mockito.doNothing().when(restClientMock).importDefinitionsInVrops(new HashMap<>(), VropsPackageMemberType.RECOMMENDATION, new HashMap<>());
+		Mockito.doNothing().when(restClientMock).importCustomGroupInVrops(testCustomGroupName, testCustomGroupPayload, new HashMap<>());
+		Mockito.doNothing().when(restClientMock).setDefaultPolicy(defaultPolicy);
+		Mockito.doNothing().when(restClientMock).importPolicyFromZip(any(), Mockito.isA(File.class), anyBoolean());
+
+		VropsPackageStore store = new VropsPackageStore(cliMock, restClientMock, tempFolder.newFolder());
+
+		File packageZip = PackageMocked.createSamplePackageZip(tempFolder.newFolder(), "ViewName", "viewid123", existingDashboard, "AlertDefinitions");
+		Package vropsPkg = PackageFactory.getInstance(PackageType.VROPS, packageZip);
+		List<Package> packages = new ArrayList<>();
+		packages.add(vropsPkg);
+
+		// WHEN
+		List<Package> importedPackages = store.importAllPackages(packages, false, false);
+
+		// THEN
+		assertNotNull(importedPackages);
+		assertEquals(importedPackages.size(), packages.size());
+		Mockito.verify(cliMock, Mockito.times(packages.size())).connect();
+		Mockito.verify(cliMock, Mockito.times(packages.size())).importFilesToVrops();
+	}
 
     private static VropsPackageDescriptor getVropsPackageDescriptorMock(String viewName, String policyName) {
         VropsPackageDescriptor mock = new VropsPackageDescriptor() {
@@ -194,7 +209,7 @@ public class VropsPackageStoreTest {
             @Override
             public String getDefaultPolicy() {
                  return policyName;
-            }
+            }        
         };
         return mock;
     }

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -49,6 +49,13 @@ Then the 'Policy Name' will be set to the default policy in vROPs.
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation)
 
+### Update Deprecated Policy APIs for vROPs 8.12.x
+
+#### Previous Behaviour
+When pushing vROPs policies to vROPs 8.12.0 and above the deprecated internal policy API in vROPs is used.
+
+#### Current Behaviour
+When pushing vROPs policies to vROPs 8.12.0 and above the new public policy API in vROPs is used. The older versions of vROPs is also supported.
 
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
[Task IAC-790] Update usage of deprecated vROPs policy (since vROPs 8.12.X)

### Description

When pushing vROPs policies on vROPs 8.12.X and later make sure that public API is invoked only (as the older internal API gets deprecated), any internal API calls should be removed, when pushing vROPs policies for older versions of vROPs (prior 8.12.0) make sure that internal API is used only (for backward compatibility).

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested by pushing vROPs package that contains policies using vROPs version version 8.12.0 and 8.10 (for backward compatibility) .

### Release Notes

Update Deprecated Policy APIs for vROPs 8.12.x.
