### PR TITLE
Fix SSHSession exitCode type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Enhancements
 * [artifact-manager] IAC-786 / Set Aria Operations Default Policy vROPs 8.12.x.
 
+### Bugs
+* [o11n-plugin-ssh] session esxiCode returns type void() instead of number
+
 ## v2.35.1 - 29 Sep 2023
 
 ### Fixes

--- a/vro-types/o11n-plugin-ssh/index.d.ts
+++ b/vro-types/o11n-plugin-ssh/index.d.ts
@@ -115,7 +115,7 @@ declare class SSHCommand {
  * SSH Session to username@host:port. This object replace the old 'SSHCommand' object.
  */
 declare class SSHSession {
-	exitCode: void;
+	exitCode: number;
 	cmd: void;
 	pty: void;
 	terminal: void;


### PR DESCRIPTION
### Description

Fix SSHSession exitCode type

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [ ] My changes have been rebased and squashed to the minimal number of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing


### Release Notes

In the existing vRO API SSHSession exitCode has type `number`. In `o11n-plugin-ssh` it has type `void`.

### Related issues and PRs

