### PR TITLE
fix vrealize:push fails for vCD 10.5, API version 38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [packages/ecmascript] IAC-803 / Updated `Array.from()` to create shallow clone and to properly handle string, Map and Set input.
 * [artifact-manager] IAC-799 / Wrong unix file path separators when creating backup path.
 * [artifact-manager] IAC-778 / Backup only works with current package version, otherwise throws exception 404 not found.
+* [vCD-NG] 166 / fix VMware Cloud Director API version 38.0 and later do not support the /api/sessions API login endpoint
 
 ## v2.36.0 - 16 Nov 2023
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVcdBasicAuthInterceptor.java
@@ -60,9 +60,9 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 	private MediaType contentType;
 
 	/**
-	 * session api path.
+	 * Provider session api path.
 	 */
-	private static final String URL_SESSION = "/api/sessions";
+	private static final String PROVIDER_URL_SESSION = "/cloudapi/1.0.0/sessions/provider";
 	
 	/**
 	 * version api path.
@@ -102,7 +102,7 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 			apiVersion = API_VERSION_37;
 		}
 
-		this.contentType = VcdApiHelper.buildMediaType("application/*+json", apiVersion);
+		this.contentType = VcdApiHelper.buildMediaType("application/json", apiVersion);
 	}
 
 	/**
@@ -116,8 +116,8 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 	@Override
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) {
 		try {
-			if (!request.getURI().getPath().contains(URL_SESSION) && !request.getURI().getPath().contains(URL_VERSION)) {
-				if (this.vcloudToken == null) {
+			if (!request.getURI().getPath().contains(PROVIDER_URL_SESSION) && !request.getURI().getPath().contains(URL_VERSION)) {
+				if (this.bearerToken == null) {
 					logger.info("Aquiring vCD auth token...");
 					acquireToken(request);
 					logger.info("vCD auth token aquired");
@@ -135,7 +135,7 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 
 	private void acquireToken(HttpRequest request) throws JsonProcessingException {
 		final URI tokenUri = UriComponentsBuilder.newInstance().scheme(request.getURI().getScheme())
-				.host(request.getURI().getHost()).port(request.getURI().getPort()).path(URL_SESSION).build().toUri();
+				.host(request.getURI().getHost()).port(request.getURI().getPort()).path(PROVIDER_URL_SESSION).build().toUri();
 
 		// Prepare Headers
 		final HttpHeaders headers = new HttpHeaders();
@@ -153,7 +153,7 @@ public class RestClientVcdBasicAuthInterceptor extends RestClientRequestIntercep
 
 		final ResponseEntity<String> response = getRestTemplate().exchange(tokenUri, HttpMethod.POST, entity,
 				String.class);
-		this.vcloudToken = response.getHeaders().get(HEADER_VCLOUD_TOKEN).get(0);
+		this.vcloudToken = response.getHeaders().get(HEADER_VCLOUD_TOKEN) == null ? null : response.getHeaders().get(HEADER_VCLOUD_TOKEN).get(0); 
 		this.bearerToken = response.getHeaders().get(HEADER_BEARER_TOKEN).get(0);
 	}
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -10,8 +10,15 @@
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
 
 ## Deprecations
-[//]: # (### *Deprecation*)
-[//]: # (Explain what is deprecated and suggest alternatives)
+### `vrealize:push` is no longer supported for vCloud Director for Service Providers 9.7 (API version 32.0) - officially unsupported
+The new authorization endpoint cloudapi/1.0.0/sessions/provider/post is available after API Version 33.0
+Reference:
+[VMware Cloud Director API Programming Guide](https://developer.vmware.com/docs/14143/vmware-cloud-director-api-programming-guide)
+[VMware Cloud Director OpenAPI  Sessions](https://developer.vmware.com/apis/vmware-cloud-director/latest/cloudapi/1.0.0/sessions/provider/post/)
+
+### Deprecating SQLDatabaseManager.getDatabase() function
+
+SQLDatabaseManager.getDatabase() function is removed in vRA 7.6 / Aria Automation 8 and above. The function uses name as parameter to retrieve a database. Use getDatabaseById() or getDatabases() and filter by name instead.
 
 [//]: # (Features -> New Functionality)
 ## Features
@@ -72,6 +79,18 @@ Back up of vRO packages now works by:
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
+
+### Support `vrealize:push` for VMware Cloud Director 10.5 (API version 38.0)
+
+#### Previous Behavior
+The /api/sessions API login endpoint is deprecated since VMware Cloud Director API version 33.0. For version 38.0 and later, the /api/sessions API login endpoint is no longer supported. You can use the VMware Cloud Director OpenAPI login endpoints to access VMware Cloud Director.
+
+#### New Behavior
+Service provider access to the system organization- POST cloudapi/1.0.0/sessions/provider
+Tenant access to all other organizations apart from the system organization- POST cloudapi/1.0.0/sessions
+
+As per the backward compatibility commitment of VMware Cloud Director, versions 37.2 and earlier continue to support the /api/sessions API login endpoint.
+Reference: [VMware Cloud Director 10.5 Release Notes](https://docs.vmware.com/en/VMware-Cloud-Director/10.5/rn/vmware-cloud-director-105-release-notes/index.html)
 
 ### Fix vRA Catalog Items Paging Issue when Fetching Catalog Items from Server
 


### PR DESCRIPTION
### Description
VMware Cloud Director 10.5 and later do not support the /api/sessions API login endpoint.


The /api/sessions API login endpoint is deprecated since VMware Cloud Director API version 33.0. For version 38.0 and later, the /api/sessions API login endpoint is no longer supported. You can use the VMware Cloud Director OpenAPI login endpoints to access VMware Cloud Director.
Service provider access to the system organization- POST cloudapi/1.0.0/sessions/provider
Tenant access to all other organizations apart from the system organization- POST cloudapi/1.0.0/sessions
As per the backward compatibility commitment of VMware Cloud Director, versions 37.2 and earlier continue to support the /api/sessions API login endpoint.


### Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing
### Release Notes

### Related issues and PRs
Fixed #166 
