### PR TITLE
Fix SSH Session exitCode type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * [artifact-manager] IAC-786 / Set Aria Operations Default Policy vROPs 8.12.x.
 * [artifact-manager] IAC-790 / Update usage of deprecated policy APIs for vROPs 8.12.x.
 
+### Bugs
+* [o11n-plugin-ssh] session esxiCode returns type void() instead of number
+
 ## v2.35.1 - 29 Sep 2023
 
 ### Fixes

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -82,7 +82,7 @@ When using SSH with typescript, the `exitCode` method has the type `void`. But t
 Method `.exitCode` should return type `Number` instead of type `void`
 
 #### Related issue
-https://github.com/vmware/build-tools-for-vmware-aria/issues/180
+<https://github.com/vmware/build-tools-for-vmware-aria/issues/180>
 
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -75,7 +75,7 @@ When pushing vROPs policies to vROPs 8.12.0 and above the new public policy API 
 
 ### Fix SSH Session exitCode type
 
- #### Previous Behaviour
+#### Previous Behaviour
 When using SSH with typescript, the `exitCode` method has the type `void`. But technically, it returns an integer. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `exitCode` has type `Number`.
 
 #### Current Behaviour

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -73,6 +73,17 @@ When pushing vROPs policies to vROPs 8.12.0 and above the deprecated internal po
 #### Current Behaviour
 When pushing vROPs policies to vROPs 8.12.0 and above the new public policy API in vROPs is used. The older versions of vROPs is also supported.
 
+### Fix SSH Session exitCode type
+
+ #### Previous Behaviour
+When using SSH with typescript, the `exitCode` method has the type `void`. But technically, it returns an integer. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `exitCode` has type `Number`.
+
+#### Current Behaviour
+Method `.exitCode` should return type `Number` instead of type `void`
+
+#### Related issue
+https://github.com/vmware/build-tools-for-vmware-aria/issues/180
+
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 

--- a/vro-types/o11n-plugin-ssh/index.d.ts
+++ b/vro-types/o11n-plugin-ssh/index.d.ts
@@ -115,7 +115,7 @@ declare class SSHCommand {
  * SSH Session to username@host:port. This object replace the old 'SSHCommand' object.
  */
 declare class SSHSession {
-	exitCode: void;
+	exitCode: number;
 	cmd: void;
 	pty: void;
 	terminal: void;


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [ ] My changes have been rebased and squashed to the minimal number of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->

### Release Notes
In the existing vRO API SSHSession exitCode has type number. In o11n-plugin-ssh it has type void.
<!--


