### PR TITLE
 IAC-643 Support subscription with ABX action - point to proper ABX action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Enhancements
-* [docs] IAC-800 - Document TS Array functions behaviour and recommended typization approach.
+* [docs] IAC-800 / Document TS Array functions behaviour and recommended typization approach.
+* [artifact-manager] IAC-643 / Support subscription with ABX action - point to proper ABX action.
 * [vropkg] IAC-793 / Support for vRO custom interaction forms in the vRO package during parsing and serializing.
 
 ### Fixes

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/filesystem/SubscriptionFsMocks.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/filesystem/SubscriptionFsMocks.java
@@ -19,30 +19,31 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.vmware.pscoe.iac.artifact.model.vrang.VraNgSubscription;
 
+import static com.vmware.pscoe.iac.artifact.store.vrang.VraNgDirs.DIR_SUBSCRIPTIONS;
+
 import java.io.File;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 
 public class SubscriptionFsMocks extends VraNgFsMock {
-	private final static String WORKDIR = "subscription";
-
+	/**
+	 * SubscriptionFsMocks constructor.
+	 * @param tempDir temporary directory.
+	 */
 	public SubscriptionFsMocks(File tempDir) {
 		super(tempDir);
 	}
-
+	/**
+	 * Returns working directory.
+	 */
 	@Override
 	public File getWorkdir() {
-		return Paths.get(this.tempDir.getPath(), WORKDIR).toFile();
+		return Paths.get(this.tempDir.getPath(), DIR_SUBSCRIPTIONS).toFile();
 	}
 
 	/**
-	 * JSON encodes a resource action and adds it to the resource actions directory.
-	 * This will also create the content.yaml based on the resource action and alternatively accepts a versions' data containing
-	 * information about the versions.
-	 *
-	 * @see    com.vmware.pscoe.iac.artifact.helpers.stubs.resource actionVersionsMockBuilder
-	 * @param    resourceAction - The resource action to store
-	 * @param    versionsData - A string containing the versioning data
+	 * Save subscription file to temporary directory.
+	 * @param subscription subscription object
 	 */
 	public void addSubscription(VraNgSubscription subscription) {
 		File file = Paths.get(
@@ -52,6 +53,6 @@ public class SubscriptionFsMocks extends VraNgFsMock {
 
 		Gson gson = new GsonBuilder().setLenient().setPrettyPrinting().serializeNulls().create();
 		Path itemName = Paths.get(file.getPath());
-		writeFileToPath(itemName, gson.toJson(subscription).getBytes());
+		writeFileToPath(itemName, subscription.getJson().getBytes());
 	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/stubs/SubscriptionMockBuilder.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/stubs/SubscriptionMockBuilder.java
@@ -26,44 +26,79 @@ import com.vmware.pscoe.iac.artifact.model.vrang.VraNgSubscription;
 import org.apache.commons.io.IOUtils;
 
 public class SubscriptionMockBuilder {
+	
+	/**
+	 * Subscription mock.
+	 */
 	private JsonElement mockData;
-	private String		id;
-	private	String		name;
 
+	/**
+	 * Subscription identity.
+	 */
+	private String id;
+
+	/**
+	 * Subscription name.
+	 */
+	private	String name;
+
+	/**
+	 * SubscriptionMockBuilder constructor.
+	 * @throws IOException
+	 */
 	public SubscriptionMockBuilder() throws IOException {
 		ClassLoader cl = getClass().getClassLoader();
 		try {
-			String read = IOUtils.toString( cl.getResourceAsStream("test/fixtures/subscription.json"), StandardCharsets.UTF_8 );;
+			String read = IOUtils.toString(cl.getResourceAsStream("test/fixtures/subscription.json"),
+					StandardCharsets.UTF_8);			
 			this.mockData = JsonParser.parseString(read);
-		}
-		catch (IOException ex) {
+		} catch (IOException ex) {
 			throw ex;
 		}
 	}
 
-	public SubscriptionMockBuilder setName(String name){
-		this.name = name;
+	/**
+	 * Set subscription Name.
+	 * @param value new name.
+	 * @return subscription with updated name.
+	 */
+	public SubscriptionMockBuilder setName(String value) {
+		this.name = value;
 		return this;
 	}
 
-	public SubscriptionMockBuilder setId(String id){
-		this.id = id;
+	/**
+	 * Set subscription Identity.
+	 * @param value new id.
+	 * @return subscription with updated identity.
+	 */
+	public SubscriptionMockBuilder setId(String value) {
+		this.id = value;
 		return this;
 	}
-
+	/**
+	 * Set property value.
+	 * @param key
+	 * @param value
+	 * @return subscription with updated (created) property.
+	 */
 	public SubscriptionMockBuilder setPropertyInRawData(String key, String value) {
 		JsonObject subscription = this.mockData.getAsJsonObject();
-		if(subscription.has(key)) {
+		if (subscription.has(key)) {
 			subscription.remove(key);
-			subscription.addProperty(key, value);
 		}
+		subscription.addProperty(key, value);
 		this.mockData = subscription.getAsJsonObject();
 		return this;
 	}
 
+	/**
+	 * Build subscription based on mock.
+	 * @return new subscription based on mock.
+	 */
 	public VraNgSubscription build() {
 		JsonObject subscription = this.mockData.getAsJsonObject();
-		
+
 		return new VraNgSubscription(this.id, this.name, subscription.toString());
 	}
 }

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -22,8 +22,35 @@ SQLDatabaseManager.getDatabase() function is removed in vRA 7.6 / Aria Automatio
 
 [//]: # (Features -> New Functionality)
 ## Features
-[//]: # (### *Feature Name*)
-[//]: # (Describe the feature)
+
+### *Support subscription with ABX action*
+Start support import/export operation for subscription with ABX action.\
+Example of definition
+
+~~~JSON
+{
+    "id": "sub_1615990481058",
+    "type": "RUNNABLE",
+    "eventTopicId": "compute.provision.pre",
+    "name": "Tagging VM",
+    "ownerId": "Administrator",
+    "subscriberId": "vro-gateway-lbcAbah7LZP1JTKZ",
+    "blocking": true,
+    "description": "",
+    "criteria": "",
+    "constraints": {
+       "projectId": null
+    },
+    "timeout": 0,
+    "broadcast": false,
+    "priority": 10,
+    "disabled": false,
+    "system": false,
+    "runnableType": "extensibility.vro",
+    "runnableName": "TaggingVM"
+}
+~~~
+
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 


### PR DESCRIPTION
### Description
IAC-643 Support subscription with ABX action - point to proper ABX action

### Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [x] I have added relevant usage information (As-built)
- [ ] Any structure and/or content vRA-NG improvements are synchronized with vra-ng and ts-vra-ng archetypes
- [ ] Every new or updated Installer property is documented in docs/archive/doc/markdown/use-bundle-installer.md
- [ ] Dependencies in pom.xml are up-to-date
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing
1. Create new subscription with execution element vRA ABX action from UI.
2. Export subscription to the package.
3. Delete subscription from  UI.
4. Import package with subscription.

### Release Notes
vRA supports subscriptions with execution element vRO Workflow or vRA ABX action. Both are marked as runnable ID when exported and their difference is runnable type. While we can define workflow ID for workflows, we can't do such for ABX actions, which causes issues when importing Subscriptions to different environments (as ABX actions does not have ABX action ID as editable property on POST request).

