### PR TITLE
Fix SSH Session 'output' type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [artifact-manager] 211 / A better error is thrown now in case of an error when 2 blueprints with the same name exist in a single project on the server.
 * [vCD-NG] 166 / fix VMware Cloud Director API version 38.0 and later do not support the /api/sessions API login endpoint
 * [installer] 133 / Delete old packages fails with 401 error in case vro is embedded.
+* [vro-types] Fix SSHSession 'output' type
 
 ## v2.36.0 - 16 Nov 2023
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -193,3 +193,12 @@ Reference: [VMware Cloud Director 10.5 Release Notes](https://docs.vmware.com/en
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
 
+### Fix SSH Session output type
+
+#### Previous Behaviour
+
+When using SSH with typescript, the `output` method has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `output` has type `String`.
+
+#### Current Behaviour
+
+Method `.output` should return type `String` instead of type `void`

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -59,7 +59,8 @@ Example of definition
 This feature enables the conditional execution of tasks/workflows based on a conditional variable (saga state value).
 
 #### Relevant Documentation
-```yaml
+
+~~~yaml
 tasks:
   TestOne:
     execute: testSagaTask
@@ -67,7 +68,7 @@ tasks:
   TestTwo:
     workflow: workflowId
     if: conditionalVariable # Newly introduced variable
-```
+~~~
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements

--- a/vro-types/o11n-plugin-ssh/index.d.ts
+++ b/vro-types/o11n-plugin-ssh/index.d.ts
@@ -119,7 +119,7 @@ declare class SSHSession {
 	cmd: void;
 	pty: void;
 	terminal: void;
-	output: void;
+	output: string;
 	error: void;
 	state: void;
 	constructor()


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->

### Release Notes
In the existing vRO API SSHSession 'output' has type string. In o11n-plugin-ssh it has type void.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
