### PR TITLE
Additional Information on Exception messages when REST API Call fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [vCD-NG] 166 / fix VMware Cloud Director API version 38.0 and later do not support the /api/sessions API login endpoint
 * [installer] 133 / Delete old packages fails with 401 error in case vro is embedded.
 * [vro-types] Fix SSHSession 'output' type
+* [artifact-manager] Extend Information on Exception messages for some of the  REST API Calls.
 
 ## v2.36.0 - 16 Nov 2023
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientFactory.java
@@ -186,8 +186,8 @@ public final class RestClientFactory {
                 HttpHeaders headers = response.getHeaders();
                 messageBuilder.append(response.getRawStatusCode()).append(" ").append(response.getStatusText()).append("\n");
                 messageBuilder.append(headers.keySet().stream().map(
-                    (String k)->headers.get(k).stream().map(
-                        h->k + ": " + h
+                    (String k) -> headers.get(k).stream().map(
+                        h -> k + ": " + h
                     ).collect(Collectors.joining("\n"))
                 ).collect(Collectors.joining("\n")));
                 if (response.getBody() != null && ! response.getBody().equals("")) {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientFactory.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientFactory.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
@@ -36,6 +37,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.HttpClientErrorException;
@@ -178,17 +180,24 @@ public final class RestClientFactory {
 				return response.getRawStatusCode() < STATUS_CODE_2XX_RANGE_BEGIN || response.getRawStatusCode() > STATUS_CODE_2XX_RANGE_END;
 			}
 
-			@Override
-			public void handleError(ClientHttpResponse response) throws IOException {
+            @Override
+            public void handleError(ClientHttpResponse response) throws IOException {
                 StringBuilder messageBuilder = new StringBuilder();
-                messageBuilder.append(response.getStatusText() + " ");
-                if (response.getBody() != null) {
+                HttpHeaders headers = response.getHeaders();
+                messageBuilder.append(response.getRawStatusCode()).append(" ").append(response.getStatusText()).append("\n");
+                messageBuilder.append(headers.keySet().stream().map(
+                    (String k)->headers.get(k).stream().map(
+                        h->k + ": " + h
+                    ).collect(Collectors.joining("\n"))
+                ).collect(Collectors.joining("\n")));
+                if (response.getBody() != null && ! response.getBody().equals("")) {
+                    messageBuilder.append("\n\n");
                     String message = org.apache.commons.io.IOUtils.toString(response.getBody(), StandardCharsets.UTF_8);
                     messageBuilder.append(message);
                 }
 
-                throw new HttpClientErrorException(response.getStatusCode(), "Invalid/Unreachable FQDN or IP address");
-			}
+                throw new HttpClientErrorException(response.getStatusCode(), "Invalid/Unreachable FQDN or IP address: " + messageBuilder.toString());
+            }
 
 		});
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/VraSsoAuth.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/VraSsoAuth.java
@@ -18,6 +18,7 @@ package com.vmware.pscoe.iac.artifact.rest.auth;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Option;
@@ -84,14 +85,17 @@ public class VraSsoAuth {
         final HttpEntity<?> httpEntity = (HttpEntity<?>) tokenUriAndHttpEntity.get(HTTP_ENTITY_TYPE);
         try {
             final ResponseEntity<String> response = this.restTemplate.exchange(tokenUri, HttpMethod.POST, httpEntity, String.class);
+
             final DocumentContext responseBody = JsonPath.parse(response.getBody());
+
             final String tokenValue = isTokenAuth
 				? responseBody.read("$.access_token")
 				: responseBody.read("$." + TOKEN_NAME);
 
             return new SsoToken(tokenValue, AuthProvider.VRA);
         } catch (Exception e) {
-            throw new RuntimeException(String.format("Unable to acquire token for VRO SSO authentication: %s", e.getMessage()));
+            throw new RuntimeException(String.format("Unable to acquire token for VRO SSO authentication: %s. Request was %s %s. Request body not shown due to sensitive data.",
+                e.getMessage(), HttpMethod.POST, tokenUri));
         }
     }
 

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/VraSsoAuth.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/VraSsoAuth.java
@@ -18,7 +18,6 @@ package com.vmware.pscoe.iac.artifact.rest.auth;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Option;
@@ -42,33 +41,62 @@ import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVro.AuthProvider
 import com.vmware.pscoe.iac.artifact.rest.model.sso.SsoEndpointDto;
 
 public class VraSsoAuth {
+    /** CAFE_CLI_OWNER. */
     private static final String CAFE_CLI_OWNER = "CAFE_CLI_OWNER";
+    /** Authorication endpoint for vRA 8.x. */
     private static final String AUTHORIZATION_SERVICE_URL_VRA_CLOUD = "/csp/gateway/am/api/auth/api-tokens/authorize";
+    /** Login endpoint for vRA 8.x . */
     private static final String AUTHORIZATION_SERVICE_URL_VRA_8 = "/csp/gateway/am/api/login";
+    /** Authentication endpoint for vRA 7.x . */
     private static final String AUTHORIZATION_SERVICE_URL_VRA_7 = "/SAAS/t/%s/auth/oauthtoken";
+    /** Single Sign On endpont for vRA 7.x . */
     private static final String COMPONENT_REGISTRY_URL_VRA_7 = "/component-registry/endpoints/types/sso";
-    private static final String VERSION_URL= "vco/api/about";
+    /** Endpont used to get the version. */
+    private static final String VERSION_URL = "vco/api/about";
+    /** Protocol scheme. */
     private static final String DEFAULT_HTTP_SCHEME = "https";
+    /** CSP Authentication token name. */
     private static final String TOKEN_NAME = "cspAuthToken";
+    /** Bearer token type. */
     private static final String DEFAULT_TOKEN_TYPE = "Bearer";
+    /**Version prefix for vRA versions 8.x. */
     private static final String VRA_8_VERSION_PREFIX = "8.";
+    /** Http Entity. */
     private static final String HTTP_ENTITY_TYPE = "httpEntity";
+    /** Token URI. */
     private static final String TOKEN_URL_TYPE = "tokenUri";
 
+    /** vRO Config.*/
     private ConfigurationVro vroConfig;
+    /** REST Tempalate to be used for communicating with  the REST API of the. */
     private RestTemplate restTemplate;
+    /** Aria Automation version. */
     private String serverVersion;
 
+    /**
+     * Create new instance of the class that is using the orivided configuraiton and REST Template.
+     * @param config Configuration on how to connect to Aria Automation.
+     * @param restTemplate REST Temaplate to be used to issue REST API calls.
+     */
     public VraSsoAuth(ConfigurationVro config, RestTemplate restTemplate) {
         this.vroConfig = config;
         this.restTemplate = restTemplate;
         this.serverVersion = this.getVersion();
     }
 
+    /**
+     * Accuire authentication token from Aria Automation.
+     * @return The token returned by Aria Automation.
+     */
     public SsoToken acquireToken() {
         return acquireToken(null);
     }
 
+    /**
+     * Accuire authentcation token from Aria Automation using the specified client id.
+     * @param clientId The client id.
+     * @return The token obtained from Aria Automation.
+     */
     public SsoToken acquireToken(String clientId) {
         final  Map<String, Object> tokenUriAndHttpEntity;
 		final boolean isTokenAuth = this.serverVersion.endsWith("-saas-enabled") || !StringUtils.isEmpty(this.vroConfig.getRefreshToken());
@@ -99,7 +127,13 @@ public class VraSsoAuth {
         }
     }
 
-    public Map<String, Object> getTokenUriAndHttpEntityVra7(String clientId){
+    /**
+     * Get authentication URL type and Entity type and entity from vRealize Automation 7.x using the specified client id.
+     * This will only work for vRealize Automation 7.x versions of vRA.
+     * @param clientId Client id.
+     * @return A map that is containing the Token URL type (TOKEN_URL_TYPE) and the entity type (HTTP_ENTITY_TYPE).
+     */
+    public Map<String, Object> getTokenUriAndHttpEntityVra7(String clientId) {
         if (StringUtils.isEmpty(clientId)) {
             clientId = retrieveClientId();
         }
@@ -131,7 +165,12 @@ public class VraSsoAuth {
         return tokenUriAndHttpEntity;
     }
 
-    public Map<String, Object> getTokenUriAndHttpEntityVra8(){
+    /**
+     * Obtain and return an authentication URL type and entity type from Aria Automation 8.x.
+     * This will only work with Aria Automation verison 8.x of Aria Automation.
+     * @return A map that is containing the Token URL type (TOKEN_URL_TYPE) and the entity type (HTTP_ENTITY_TYPE).
+     */
+    public Map<String, Object> getTokenUriAndHttpEntityVra8() {
         final URI tokenUri = UriComponentsBuilder.newInstance()
             .scheme(DEFAULT_HTTP_SCHEME)
             .host(this.vroConfig.getAuthHost())
@@ -161,7 +200,12 @@ public class VraSsoAuth {
         return tokenUriAndHttpEntity;
     }
 
-	public Map<String, Object> getTokenUriAndHttpEntityVraCloud(){
+    /**
+     * Obtain and return an authentication URL type and entity type from Aria Automation Cloud.
+     * This will only work with Aria Automation Cloud.
+     * @return A map that is containing the Token URL type (TOKEN_URL_TYPE) and the entity type (HTTP_ENTITY_TYPE).
+     */
+	public Map<String, Object> getTokenUriAndHttpEntityVraCloud() {
 		final URI tokenUri = UriComponentsBuilder.newInstance()
 			.scheme(DEFAULT_HTTP_SCHEME)
 			.host(this.vroConfig.getAuthHost())
@@ -172,7 +216,7 @@ public class VraSsoAuth {
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
 		final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.add("api_token",this.vroConfig.getRefreshToken());
+		map.add("api_token", this.vroConfig.getRefreshToken());
 
 		HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(map, headers);
 
@@ -183,6 +227,10 @@ public class VraSsoAuth {
 		return tokenUriAndHttpEntity;
 	}
 
+    /**
+     * Retrieve SSO Client Id.
+     * @return The client id.
+     */
     public String retrieveClientId() {
         final URI tokenUri = UriComponentsBuilder.newInstance()
                 .scheme(DEFAULT_HTTP_SCHEME)
@@ -196,6 +244,10 @@ public class VraSsoAuth {
                 .orElseThrow(() -> new RuntimeException("Could not find the SSO Client ID")).getValue();
     }
 
+    /**
+     * Retrive vRA version.
+     * @return the strig representation of the version.
+     */
     private String getVersion() {
         // vRA Cloud doesn't have vRO services and it's auth host (console.cloud.vmware.com)
         // is different than the Extensibility Proxy's vRO address (ext-proxy01.corp.local),
@@ -230,29 +282,56 @@ public class VraSsoAuth {
         return new HttpEntity<>(headers);
     }
 
+    /**
+     * Single Signe On token class.
+     */
     public static class SsoToken {
+        /** The token value. */
         private String value;
+        /** The token type, such as "Bearer". */
         private String tokenType;
+        /** Authentication provider. */
         private AuthProvider type;
 
+        /**
+         * Create a new Single Sign On token based on the given token string and Authentication Provider.
+         * @param token Toek string.
+         * @param type Authentication provider.
+         */
         public SsoToken(String token, AuthProvider type) {
             this.value = token;
             this.type = type;
             this.tokenType = DEFAULT_TOKEN_TYPE;
         }
 
+        /**
+         * Return the token string.
+         * @return the token string.
+         */
         public String getValue() {
             return value;
         }
 
+        /**
+         * Return true if expired and  false otherwise.
+         * @return true if expired and false otherwise.
+         */
         public boolean isExpired() {
             return Boolean.TRUE;
         }
 
+        /**
+        * Return the authentication provider type.
+         * @return the authentication provider type.
+         */
         public AuthProvider getType() {
             return type;
         }
 
+        /**
+         * The toekn type such as Bearer.
+         * @return toekn type such as Bearer.
+         */
         public String getTokenType() {
             return tokenType;
         }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/auth/package-info.java
@@ -1,7 +1,8 @@
 /**
- * Package that represents vRA 8 Rest Package.
+ * Package that represents vRA 8 Rest Authentication Package.
+ * Contains classes responsible to handle different authentication logics.
  */
-package com.vmware.pscoe.iac.artifact.rest;
+package com.vmware.pscoe.iac.artifact.rest.auth;
 
 /*-
  * #%L
@@ -11,9 +12,9 @@ package com.vmware.pscoe.iac.artifact.rest;
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
+ *
  * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
- * 
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */


### PR DESCRIPTION
### Improving some of the error messages when REST API call fails on vrealize:push

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [X] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works (tests done manually. see below.)
- [X] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [X] I have tested against live environment, if applicable
- [X] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [X] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [X] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested on a real environment. Currently build tools for VMware Aria does not support setting values on configuration elements which are of type Composite. So for example this is not supported:
```
@Configuration({
    name: "Microsoft-PowerShell",
    path: "PS CoE/Library/DNS",
    attributes:{
        msDnsPowershellHost: {
            type: "Array/CompositeType(dnsZone:string,dnsServer:PowerShell:PowerShellHost):MsDnsPowershellHost",
            value: [],
            description: "Allows you to define and use the DNS Servers per Zone/Domain dyrectly. The Powershell host must point to the DNS server itself and must use user with sufficient privileges to create DNS Entries. This is an alternative confifuration to msWindowsJumpVm."
        }
    }
})
```
so the generated package fails to push. And the REST response reports NullPointerException (on the server side).
Never the less the message returned by the build tools for VMware Aria was not showing the actual response, nor the corresponding request.

So it is quite difficult to understand what is really going on. 

The change introduces additional information in the Exceptions so it is more clear what the request was and what the response is. 

It was tested on a real environment (real Aria Automation Orchestrator) with the above wrong package and it was verified
that the additional information in the Exception is present. 

### Release Notes

Improving some of the error messages when REST API call fails on vrealize:push


