### PR TITLE
Fix #165, handle unsupported characters in legacy archetype workflow path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixes
 * [vro-types] Fix SSHSession 'error' and 'state' types
+* [typescript] 165 / vro:pull command for legacy archetype fails when workflow folder path name contains character '&'.
 
 ## v2.37.0 - 26 Jan 2024
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -36,12 +36,24 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### Fix on legacy archetype failing with vro:pull (when workflow folder path name contains special characters(&))
 
-## Upgrade procedure
-[//]: # (Explain in details if something needs to be done)
+#### Previous Behaviour
 
-[//]: # (## Changelog:)
-[//]: # (Pull request links)
+When executing a vro:pull command on a legacy archetype, the command will fail if the workflow path names contain
+special characters such as '&'.
+
+When executing a vro:pull command on JavaScript archetype, it succeeds, ignoring the
+special characters in the folder name.
+
+#### Current Behaviour
+
+When executing a vro:pull command on either Legacy or JS archetype, if the workflows paths contains special character(&),
+the command will successfully execute, ignoring folders with special characters(&).
+
+/test1/test&/test2 -> /test1/test2
+
+Additionally, a warning message will be printed on the console highlighting the issue with unsupported characters.
 
 ### Fix SSH Session methods type
 
@@ -52,3 +64,10 @@ When using SSH with typescript, the `error` and `state` methods has the type `vo
 #### Current Behavior
 
 Method `error` and `state` should return type `String` instead of type `void`
+
+
+## Upgrade procedure
+[//]: # (Explain in details if something needs to be done)
+
+[//]: # (## Changelog:)
+[//]: # (Pull request links)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -40,16 +40,13 @@
 
 #### Previous Behaviour
 
-When executing a vro:pull command on a legacy archetype, the command will fail if the workflow path names contain
-special characters such as '&'.
+When executing a vro:pull command on a legacy archetype, the command will fail if the workflow path names contain special characters such as '&'.
 
-When executing a vro:pull command on JavaScript archetype, it succeeds, ignoring the
-special characters in the folder name.
+When executing a vro:pull command on JavaScript archetype, it succeeds, ignoring the special characters in the folder name.
 
 #### Current Behaviour
 
-When executing a vro:pull command on either Legacy or JS archetype, if the workflows paths contains special character(&),
-the command will successfully execute, ignoring folders with special characters(&).
+When executing a vro:pull command on either Legacy or JS archetype, if the workflows paths contains special character(&), the command will successfully execute, ignoring folders with special characters(&).
 
 /test1/test&/test2 -> /test1/test2
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -40,17 +40,11 @@
 
 #### Previous Behaviour
 
-When executing a vro:pull command on a legacy archetype, the command will fail if the workflow path names contain special characters such as '&'.
-
-When executing a vro:pull command on JavaScript archetype, it succeeds, ignoring the special characters in the folder name.
+When executing a vro:pull command on a legacy archetype, the command will fail without proper error if the workflow paths contains special characters such as '&'.
 
 #### Current Behaviour
 
-When executing a vro:pull command on either Legacy or JS archetype, if the workflows paths contains special character(&), the command will successfully execute, ignoring folders with special characters(&).
-
-/test1/test&/test2 -> /test1/test2
-
-Additionally, a warning message will be printed on the console highlighting the issue with unsupported characters.
+When executing a vro:pull command on a legacy archetype, if the workflows paths contains special character(&), the command will fail but will provide descriptive error message.
 
 ### Fix SSH Session methods type
 

--- a/typescript/vropkg/src/parse/flat.ts
+++ b/typescript/vropkg/src/parse/flat.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 import * as winston from "winston";
 import * as a from "../packaging";
 import * as t from "../types";
-import { read, xml, xmlGet, xmlToCategory, xmlToTag, xmlToAction, xmlChildNamed, getCommentFromJavadoc, getWorkflowItems } from "./util";
+import { read, xml, xmlGet, xmlToCategory, xmlToTag, xmlToAction, xmlChildNamed, getCommentFromJavadoc, getWorkflowItems, validateWorkflowPath} from "./util";
 import { exist } from "../util";
 import { WINSTON_CONFIGURATION, FORM_ITEM_TEMPLATE, WORKFLOW_ITEM_INPUT_TYPE, DEFAULT_FORM_NAME, DEFAULT_FORM_FILE_NAME, VSO_RESOURCE_INF } from "../constants";
 
@@ -37,6 +37,7 @@ const parseFlatElement = async (elementInfoPath: string): Promise<t.VroNativeEle
 
     let infoXml = xml(read(elementInfoPath));
     let categoriesXml = xml(read(elementCategoryPath));
+    validateWorkflowPath(categoriesXml);
     let categoryPath = xmlToCategory(categoriesXml);
     let description = xmlGet(infoXml, "description");
     // input forms (applicable for vRO workflows only)

--- a/typescript/vropkg/src/parse/util.ts
+++ b/typescript/vropkg/src/parse/util.ts
@@ -32,9 +32,9 @@ export const stringToCategory = (category): string[] => category.split(/(?<!\/)\
     .map(path => { return path.replace(/\//g, "") })
     .filter(path => path != "");
 export const validateWorkflowPath = (xmlDocument) => {
-	const invalidElement = xmlDocument.children.find((e) => e.attr.name == null || e.attr.name =='undefined');
-	if (invalidElement && invalidElement.firstChild!=null){
-		console.warn(`Unsupported characters detected in the workflow path. The value "${invalidElement.firstChild.val}" contains characters that are not allowed. The folders with special characters will be ignored.`);
+	const invalidElement = xmlDocument.children.find((e) => e.attr.name === null || e.attr.name === undefined);
+	if (invalidElement && invalidElement.firstChild !== null){
+		throw new Error(`Unsupported characters detected in the workflow path. The value "${invalidElement.firstChild.val}" contains characters that are not allowed.`);
 	}
 };
 export const xmlToAction = (file: string, bundlePath: string, name: string, comment: string, description: string, tags: Array<string>): t.VroActionData => {

--- a/typescript/vropkg/src/parse/util.ts
+++ b/typescript/vropkg/src/parse/util.ts
@@ -31,7 +31,12 @@ export const xmlToTag = (tags): string[] => tags.children.filter(e => e.attr && 
 export const stringToCategory = (category): string[] => category.split(/(?<!\/)\./)
     .map(path => { return path.replace(/\//g, "") })
     .filter(path => path != "");
-
+export const validateWorkflowPath = (xmlDocument) => {
+	const invalidElement = xmlDocument.children.find((e) => e.attr.name == null || e.attr.name =='undefined');
+	if (invalidElement && invalidElement.firstChild!=null){
+		console.warn(`Unsupported characters detected in the workflow path. The value "${invalidElement.firstChild.val}" contains characters that are not allowed. The folders with special characters will be ignored.`);
+	}
+};
 export const xmlToAction = (file: string, bundlePath: string, name: string, comment: string, description: string, tags: Array<string>): t.VroActionData => {
     let type = "" + t.VroElementType.ScriptModule;
     if (!exist(file)) {

--- a/typescript/vropkg/src/serialize/tree.ts
+++ b/typescript/vropkg/src/serialize/tree.ts
@@ -100,9 +100,6 @@ const serializeTreeElement = async (context: any, element: t.VroNativeElement): 
     } else {
         xInfo.ele("comment").cdata(complexActionComment(element));
     }
-    if (element?.categoryPath) {
-		element.categoryPath = element?.categoryPath.filter(x => x!=null);
-	}
     const categoryPathKey = element.type == t.VroElementType.ScriptModule
         ? element?.categoryPath
         : element?.categoryPath.map(c => c.replace(/\./g, "/."))

--- a/typescript/vropkg/src/serialize/tree.ts
+++ b/typescript/vropkg/src/serialize/tree.ts
@@ -100,7 +100,9 @@ const serializeTreeElement = async (context: any, element: t.VroNativeElement): 
     } else {
         xInfo.ele("comment").cdata(complexActionComment(element));
     }
-
+    if (element?.categoryPath) {
+		element.categoryPath = element?.categoryPath.filter(x => x!=null);
+	}
     const categoryPathKey = element.type == t.VroElementType.ScriptModule
         ? element?.categoryPath
         : element?.categoryPath.map(c => c.replace(/\./g, "/."))


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
Fix issue #165.  Resolved the build error that occurs when executing the 'vro:pull' command on the legacy workflow archetype due to special characters(&) in the workflow path. 

Pull process will be failed with descriptive error message for legacy archetype projects which contains special characters ('&') in workflow paths.

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->

### Release Notes

Fix 165 / vro:pull command for legacy archetype fails when workflow folder path name contains character '&'.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
https://github.com/vmware/build-tools-for-vmware-aria/issues/165