### PR TITLE
Fix SSH Session 'error' and 'status' types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Enhancements
 * [vrotsc] `vrotsc` refactoring. Updated documentation and reworks. Check [this](https://github.com/vmware/build-tools-for-vmware-aria/pull/233) for detailed information
 
+### Fixes
+* [vro-types] Fix SSHSession 'error' and 'state' types
+
 ## v2.37.0 - 26 Jan 2024
 
 ### Enhancements

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -37,7 +37,7 @@
 [//]: # (#### Relevant Documentation:)
 
 
-## Upgrade procedure:
+## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 
 [//]: # (## Changelog:)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -10,11 +10,9 @@
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
 
 
-
 ## Deprecations
 [//]: # (### *Deprecation*)
 [//]: # (Explain what is deprecated and suggest alternatives)
-
 
 
 [//]: # (Features -> New Functionality)
@@ -23,7 +21,6 @@
 [//]: # (Describe the feature)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
 
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
@@ -38,7 +35,6 @@
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
 
 
 ## Upgrade procedure:

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -46,3 +46,13 @@
 
 [//]: # (## Changelog:)
 [//]: # (Pull request links)
+
+### Fix SSH Session methods type
+
+ #### Previous Behavior
+
+ When using SSH with typescript, the `error` and `state` methods has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `error` and `state` has type `String`.
+
+ #### Current Behavior
+
+ Method `error` and `state` should return type `String` instead of type `void`

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -49,10 +49,10 @@
 
 ### Fix SSH Session methods type
 
- #### Previous Behavior
+#### Previous Behavior
 
- When using SSH with typescript, the `error` and `state` methods has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `error` and `state` has type `String`.
+When using SSH with typescript, the `error` and `state` methods has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable `error` and `state` has type `String`.
 
- #### Current Behavior
+#### Current Behavior
 
- Method `error` and `state` should return type `String` instead of type `void`
+Method `error` and `state` should return type `String` instead of type `void`

--- a/vro-types/o11n-plugin-ssh/index.d.ts
+++ b/vro-types/o11n-plugin-ssh/index.d.ts
@@ -120,8 +120,8 @@ declare class SSHSession {
 	pty: void;
 	terminal: void;
 	output: string;
-	error: void;
-	state: void;
+	error: string;
+	state: string;
 	constructor()
 	/**
 	 * Create a new SSHSession


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->

### Release Notes
In the existing vRO API SSHSession, 'error' and 'status' have type string. In o11n-plugin-ssh it has type void.
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
