### PR TITLE
Fix SSH Session 'cmd', 'pty', 'terminal' types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 * [vro-types] Fix SSHSession 'error' and 'state' types
 * [typescript] 165 / vro:pull command for legacy archetype fails when workflow folder path name contains character '&'.
+* [vro-types] Fix SSHSession `cmd`, `pty`, `terminal` types
 
 ## v2.37.0 - 26 Jan 2024
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -104,11 +104,11 @@ The new archetype can be bootstrapped with:
 
 ### Fix SSH Session additional methods type
 
- #### Previous Behavior
+#### Previous Behavior
 
  When using SSH with typescript, the  `cmd`, `pty`, `terminal` methods has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable  `cmd`, `pty`, `terminal` has type `String`.
 
- #### Current Behavior
+#### Current Behavior
 
  Method  `cmd`, `pty`, `terminal` should return type `String` instead of type `void`
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -102,6 +102,16 @@ The new archetype can be bootstrapped with:
 #### Related issue
 <https://github.com/vmware/build-tools-for-vmware-aria/issues/180>
 
+### Fix SSH Session additional methods type
+
+ #### Previous Behavior
+
+ When using SSH with typescript, the  `cmd`, `pty`, `terminal` methods has the type `void`. But technically, it returns a string. VSCode highlight it as an error and the complication failed. The same method is working in JS (obviously). Example from the built-in Workflow. Variable  `cmd`, `pty`, `terminal` has type `String`.
+
+ #### Current Behavior
+
+ Method  `cmd`, `pty`, `terminal` should return type `String` instead of type `void`
+
 ## Upgrade procedure
 [//]: # (Explain in details if something needs to be done)
 

--- a/vro-types/o11n-plugin-ssh/index.d.ts
+++ b/vro-types/o11n-plugin-ssh/index.d.ts
@@ -116,9 +116,9 @@ declare class SSHCommand {
  */
 declare class SSHSession {
 	exitCode: number;
-	cmd: void;
-	pty: void;
-	terminal: void;
+	cmd: string;
+	pty: string;
+	terminal: string;
 	output: string;
 	error: string;
 	state: string;


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [ ] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->

### Release Notes

In the existing vRO API SSHSession, `cmd`, `pty`, `terminal` have type string. In o11n-plugin-ssh it has type void.

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
