### PR TITLE
Fixed an issue with CS Pipeline imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Add support for `vgpu` in `VcVirtualDeviceBackingInfo` class
 
 ### Fixes
-* [artifact-manager] IACCOE-809 : Fixed an issue for importing Aria Pipelines with dependencies on another pipelines for rollback. 
+* [artifact-manager] IACCOE-809 : Fixed an issue for importing Aria Pipelines with dependencies on another pipelines for rollback.
 
 ## v2.38.0 - 29 Mar 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Enhancements
 * Add support for `vgpu` in `VcVirtualDeviceBackingInfo` class
 
+### Fixes
+* [artifact-manager] IACCOE-809 : Fixed an issue for importing Aria Pipelines with dependencies on another pipelines for rollback. 
+
 ## v2.38.0 - 29 Mar 2024
 
 ### Enhancements

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/cs/CsPipelineStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/cs/CsPipelineStore.java
@@ -1,10 +1,10 @@
 package com.vmware.pscoe.iac.artifact.store.cs;
 
-/*
+/*-
  * #%L
  * artifact-manager
  * %%
- * Copyright (C) 2023 VMware
+ * Copyright (C) 2023 - 2024 VMware
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
@@ -37,9 +37,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
-public class CsPipelineStore extends AbstractCsStore {
+public final class CsPipelineStore extends AbstractCsStore {
+	/**
+	 * The pipelines root folder.
+	 */
 	private static final String DIR_PIPELINES = "pipelines";
+
+	/**
+	 * logger.
+	 */
 	private final Logger logger = LoggerFactory.getLogger(CsPipelineStore.class);
+
+	/**
+	 * projectPipelines.
+	 */
 	private List<JsonObject> projectPipelines;
 
 	List<JsonObject> getProjectPipelines() {
@@ -52,7 +63,7 @@ public class CsPipelineStore extends AbstractCsStore {
 
 	/**
 	 * Exporting the contents of all blueprints listed in the content.yaml file,
-	 * available for the configured project
+	 * available for the configured project.
 	 */
 	public void exportContent() {
 		List<String> pipelineNames = this.descriptor.getPipeline();
@@ -68,7 +79,7 @@ public class CsPipelineStore extends AbstractCsStore {
 	}
 
 	/**
-	 * Importing content into vRA target environment
+	 * Importing content into vRA target environment.
 	 * 
 	 * @param sourceDirectory sourceDirectory
 	 */

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/cs/package-info.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/cs/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Package that handles Aria Pipelines imports/exports.
+ *
+ */
+package com.vmware.pscoe.iac.artifact.store.cs;
+
+/*-
+ * #%L
+ * artifact-manager
+ * %%
+ * Copyright (C) 2024 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2024 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/cs/CsPipelineStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/cs/CsPipelineStoreTest.java
@@ -16,6 +16,8 @@ package com.vmware.pscoe.iac.artifact.store.cs;
  */
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,12 +29,14 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.vmware.pscoe.iac.artifact.configuration.ConfigurationCs;
 import com.vmware.pscoe.iac.artifact.helpers.AssertionsHelper;
@@ -43,11 +47,14 @@ import com.vmware.pscoe.iac.artifact.model.PackageType;
 import com.vmware.pscoe.iac.artifact.model.cs.CsPackageDescriptor;
 import com.vmware.pscoe.iac.artifact.rest.RestClientCs;
 
+import net.minidev.json.JSONObject;
+
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 public class CsPipelineStoreTest {
@@ -142,7 +149,7 @@ public class CsPipelineStoreTest {
 		JsonObject pipeline = new JsonObject();
 		pipeline.addProperty("name", "newPipeline");
 		pipeline.addProperty("state", "ENABLED");
-		//pipelines.add(pipeline);
+		// pipelines.add(pipeline);
 		createTempFile("newPipeline", pipeline);
 
 		pipeline = new JsonObject();
@@ -160,6 +167,55 @@ public class CsPipelineStoreTest {
 		// VERIFY
 		verify(restClient, times(1)).createPipeline(any());
 		verify(restClient, times(1)).updatePipeline(any(), any());
+		verify(restClient, times(3)).patchPipeline(any(), any());
+
+	}
+
+	@Test
+	void testImportPipelineWithRollbackDependencies() {
+		// GIVEN Three pipelines. One of them used as a rollback to the other two.
+		List<JsonObject> pipelines = new ArrayList<>(3);
+
+		JsonObject rollbackPipe = new JsonObject();
+		rollbackPipe.addProperty("name", "PipelineRollback");
+		rollbackPipe.addProperty("state", "ENABLED");
+		rollbackPipe.addProperty("id", "3C22AD16-95D9-4C20-B9FF-D035CF97AA88");
+
+		JsonObject pipe1 = new JsonObject();
+		pipe1.addProperty("name", "Pipeline1");
+		pipe1.addProperty("state", "ENABLED");
+		pipe1.addProperty("id", "740820E8-E249-4399-985F-DBA1C554DC38");
+
+		JsonObject pipe2 = new JsonObject();
+		pipe2.addProperty("name", "Pipeline2");
+		pipe2.addProperty("state", "ENABLED");
+		pipe2.addProperty("id", "FA3EEDE8-C6F5-4D59-8277-84B90B702464");
+
+		JsonArray rollbacks = new JsonArray();
+		rollbacks.add(rollbackPipe);
+		pipe1.add("rollbacks", rollbacks);
+		pipe2.add("rollbacks", rollbacks);
+
+		pipelines.add(pipe1);
+		pipelines.add(pipe2);
+		pipelines.add(rollbackPipe);
+
+		createTempFile("PipelineRollback", rollbackPipe);
+		createTempFile("Pipeline1", pipe1);
+		createTempFile("Pipeline2", pipe2);
+
+		when(restClient.getProjectPipelines()).thenReturn(pipelines);
+		when(restClient.getProjectName()).thenReturn("myProject");
+
+		// TEST
+		store.importContent(tempFolder.getRoot());
+
+		// VERIFY
+		InOrder inOrder = inOrder(restClient);
+		inOrder.verify(restClient).updatePipeline(eq("PipelineRollback"), any());
+		inOrder.verify(restClient).updatePipeline(eq("Pipeline2"), any());
+		inOrder.verify(restClient).updatePipeline(eq("Pipeline1"), any());
+
 		verify(restClient, times(3)).patchPipeline(any(), any());
 
 	}

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -22,6 +22,8 @@
 
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 ## Improvements
+### *Fixed an issue with Arira Pipelines import*
+You can now import pipelines with dependencies to other pipelines in their rollback section definition.
 
 ### Add missing attribute to VcVirtualDeviceBackingInfo class
 


### PR DESCRIPTION
### Description

[IACCOE-809] When importing Aria Pipelines definitions with dependencies to another Pipeline for a rollback the current import mechanism could break because of not importing the dependency pipelines first. This is fixed with this PR by adding a topological sort algorithm to the pipeline YAML files before import.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated CHANGELOG.md with a short summary of the changes introduced
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->
It was tested in a real environment.
