### PR TITLE
Update the Mockito Version to Support JDK 22

### DIFF
--- a/common/artifact-manager/pom.xml
+++ b/common/artifact-manager/pom.xml
@@ -157,7 +157,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>5.4.0</version>
+			<version>5.12.0</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- snakeyaml is included in  jackson-dataformat-yaml artifact-->


### PR DESCRIPTION
Update the Mockito Version to Support JDK 22

### Description

Update the Mockito library to be compatible with the latest Java version 22

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Run the test cases in the commons/artifact-manager

### Release Notes

Update the Mockito library to be compatible with the latest Java version 22
