### PR TITLE
[artifact-manager] [archetypes/vra] (#210) Cloud Template folder name and the name from details.json mismatch issue fixed in vRA

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.Objects;
 
 public class VraNgBlueprintStore extends AbstractVraNgStore {
 
@@ -241,10 +242,15 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 		VraNgBlueprint bp = loadBlueprintFromFilesystem(bpDir);
 		String bpID;
 
+		// Check the blueprint folder name(bpName) with details.json->name(bp.getName())
+		if (!Objects.equals(bp.getName(), bpName)) {
+			throw new IllegalStateException(String.format("Mismatch between blueprint folder name and details.json->name. (%s, %s)", bpName, bp.getName()));
+		}
+
 		// Check if the blueprint exists
 		VraNgBlueprint existingRecord = null;
-		if (bpsOnServerByName.containsKey(bpName)) {
-			existingRecord = bpsOnServerByName.get(bpName);
+		if (bpsOnServerByName.containsKey(bp.getName())) {
+			existingRecord = bpsOnServerByName.get(bp.getName());
 		}
 
 		if (existingRecord == null) {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
@@ -242,9 +242,9 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 		VraNgBlueprint bp = loadBlueprintFromFilesystem(bpDir);
 		String bpID;
 
-		// Check the blueprint folder name(bpName) with details.json->name(bp.getName())
+		// Check the blueprint folder name(bpName) with the name from details.json(bp.getName())
 		if (!Objects.equals(bp.getName(), bpName)) {
-			throw new IllegalStateException(String.format("Mismatch between blueprint folder name and details.json->name. (%s, %s)", bpName, bp.getName()));
+			throw new IllegalStateException(String.format("Mismatch between the blueprint folder name and the name from details.json. (%s, %s)", bpName, bp.getName()));
 		}
 
 		// Check if the blueprint exists

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStore.java
@@ -233,8 +233,9 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 	 * Handling import of a single blueprint - reading files from a directory, it's name would match
 	 * the blueprint name and contain files describing its details, content and versions.
 	 *
-	 * @param bpDir
-	 * @param bpsOnServerByName
+	 * @param bpDir blueprint folder
+	 * @param bpsOnServerByName existing blueprints from the server
+	 * @throws IllegalStateException if blueprint folder name mismatch with the name from details.json
 	 */
 	private void handleBlueprintImport(final File bpDir, final Map<String, VraNgBlueprint> bpsOnServerByName) {
 		String bpName = bpDir.getName();

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/filesystem/BlueprintFsMocks.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/helpers/filesystem/BlueprintFsMocks.java
@@ -59,8 +59,18 @@ public class BlueprintFsMocks extends VraNgFsMock {
 	 * @param    blueprint - The blueprint to store
 	 */
 	public void addBlueprint(final VraNgBlueprint blueprint) {
-		File blueprintFolder = Paths.get(this.getWorkdir().getAbsolutePath(),
-			blueprint.getName()).toFile();
+		addBlueprint(blueprint, blueprint.getName());
+	}
+
+	/**
+	 * JSON encodes a blueprint and adds it to the blueprint directory.
+	 * This will also create the content.yaml based on the blueprint and alternatively accepts a versions' data containing
+	 * information about the versions.
+	 * @param blueprint - Blueprint to store
+	 * @param folderName - Blueprint folder name
+	 */
+	public void addBlueprint(final VraNgBlueprint blueprint, String folderName) {
+		File blueprintFolder = Paths.get(this.getWorkdir().getAbsolutePath(), folderName).toFile();
 
 		if (!blueprintFolder.exists()) {
 			if (!blueprintFolder.mkdirs()) {

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgBlueprintStoreTest.java
@@ -307,4 +307,25 @@ public class VraNgBlueprintStoreTest {
 		// VERIFY
 		verify(restClient, times(1)).createBlueprint(any());
 	}
+
+	@Test
+	void testImportContentWithDiffBlueprintFolderName() {
+		// GIVEN
+		List<String> blueprintNames = new ArrayList<>();
+		blueprintNames.add("nginx-blueprint-1");
+
+		when(vraNgPackageDescriptor.getBlueprint()).thenReturn(blueprintNames);
+
+		// INSIDE THE details.json -> name
+		BlueprintMockBuilder builder = new BlueprintMockBuilder("nginx-blueprint");
+		VraNgBlueprint blueprint = builder.build();
+
+		fsMocks.blueprintFsMocks().addBlueprint(blueprint, "nginx-blueprint-1");
+
+		List<VraNgBlueprint> bluePrintsOnServer = new ArrayList<>();
+		when(restClient.getAllBlueprints()).thenReturn(bluePrintsOnServer);
+
+		// START TEST & VERIFY EXCEPTION
+		assertThrows(IllegalStateException.class, () -> store.importContent(tempFolder.getRoot()));
+	}
 }

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -194,12 +194,12 @@ The `enableConfigManager`, `maximumHardwareVersionKey` and `desiredSoftwareSpec`
 
 #### Previous Behavior
 
-- When Cloud-Template folder name and details.json->name mismatch,  folder name is used for validating if the record exists on the server and details.json->name is used for creating/updating the cloud template on server.
+- When the Cloud-Template folder name does not match the name from details.json, folder name is used for validating if the record exists on the server and the name from details.json is used for creating/updating the cloud template on server.
 
 #### Current Behavior
 
-- When Cloud-Template folder name and details.json->name mismatch, now an error throwing explaining the mismatch.
-- details.json->name is now used for both validating and creating/updating cloud template on the server.
+- When the Cloud-Template folder name does not match the name from details.json, now an error throwing explaining the mismatch.
+- The name from details.json is now used for both validating and creating/updating cloud template on the server.
 
 ## Upgrade Procedure
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -190,6 +190,17 @@ The `enableConfigManager`, `maximumHardwareVersionKey` and `desiredSoftwareSpec`
 
 <https://github.com/vmware/build-tools-for-vmware-aria/issues/297>
 
+### Cloud Template folder name and details.json->name mismatch issue fixed
+
+#### Previous Behavior
+
+- When Cloud-Template folder name and details.json->name mismatch,  folder name is used for validating if the record exists on the server and details.json->name is used for creating/updating the cloud template on server.
+
+#### Current Behavior
+
+- When Cloud-Template folder name and details.json->name mismatch, now an error throwing explaining the mismatch.
+- details.json->name is now used for both validating and creating/updating cloud template on the server.
+
 ## Upgrade Procedure
 
 [//]: # "Explain in details if something needs to be done"


### PR DESCRIPTION
### Description

Cloud Template folder name and details.json->name mismatch issue fixed.

_Previous Behavior_ 

- When Cloud-Template folder name and details.json->name mismatch,  folder name is used for validating if the record exists on the server and details.json->name is used for creating/updating the cloud template on server.

_Current Behavior_

- When Cloud-Template folder name and details.json->name mismatch, now an error throwing explaining the mismatch.  

- details.json->name is now used for both validating and creating/updating cloud template on the server.

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation type (enhancement, bug, dependencies) and version change (major, minor, patch)
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1.) Create vra 8 project using build-tools-for-vmware-aria.
2.) Create blueprint folder(Test-Blueprint-1) and content.yaml, details.json files accordingly.
3.) Add the blueprint folder name(Test-Blueprint-1) in project content.yaml.
4.) Change the details.json->name value into different from blueprint folder name. (Test-Blueprint-2)
5.) Push project to vra server.

### Release Notes

[artifact-manager] (#210) Cloud Template folder name and details.json->name mismatch issue fixed in vra.

### Related issues and PRs

Closed #210

### Additional Notes

Please note that, this fix is applying only when, we have a 'blueprint folder' named as in the project 'content.yaml'. 

Examples  

- Scenario 1 - Fix will be applied in this scenario.

#### content.yaml

```
blueprint:
  - Test-1
```

#### blueprints/Test-1/details.json

```json
{
  "name": "Test-2",
  "description": "",
  "requestScopeOrg": false
}
```

- Scenario 2 - Fix would not applied in following scenario. ( Since there is no 'Test-1' folder, blueprint will be skipped. )

#### content.yaml

```yml
blueprint:
  - Test-1

```

#### blueprints/Test-2/details.json

```json
{
  "name": "Test-1",
  "description": "",
  "requestScopeOrg": false
}
```

For the second scenario, this is the current behavior as well.
