### PR TITLE
[polyglotpkg] (#259) Packages can now be built correctly

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -47,7 +47,7 @@ Fixed an issue where the ABX archetype could not compile due to an old version o
 
 We were getting a build error when trying to compile the ABX archetype:
 
-```
+```log
 info:    Error ts(1110) /root/vro/polyglot_test_project/node_modules/@types/node/crypto.d.ts (3569,17): Type expected.
 info:    Error ts(1005) /root/vro/polyglot_test_project/node_modules/@types/node/events.d.ts (105,28): ',' expected.
 ...

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -39,6 +39,48 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### *ABX archetype build issue, cannot compile*
+
+Fixed an issue where the ABX archetype could not compile due to an old version of the `xmlbuilder2` package.
+
+#### Previous Behavior
+
+We were getting a build error when trying to compile the ABX archetype:
+
+```
+info:    Error ts(1110) /root/vro/polyglot_test_project/node_modules/@types/node/crypto.d.ts (3569,17): Type expected.
+info:    Error ts(1005) /root/vro/polyglot_test_project/node_modules/@types/node/events.d.ts (105,28): ',' expected.
+...
+info:    Error ts(1005) /root/vro/polyglot_test_project/node_modules/@types/node/util.d.ts (1763,26): ';' expected.
+info:    Error ts(1128) /root/vro/polyglot_test_project/node_modules/@types/node/util.d.ts (1765,1): Declaration or statement expected.
+info: Exit status: 1
+info: Compilation complete
+/root/vro/polyglot_test_project/node_modules/@vmware-pscoe/polyglotpkg/dist/strategies/nodejs.js:123
+            throw new Error('Found compilation errors');
+                  ^
+
+Error: Found compilation errors
+    at NodejsStrategy.compile (/root/vro/polyglot_test_project/node_modules/@vmware-pscoe/polyglotpkg/dist/strategies/nodejs.js:123:19)
+    at NodejsStrategy.<anonymous> (/root/vro/polyglot_test_project/node_modules/@vmware-pscoe/polyglotpkg/dist/strategies/nodejs.js:52:18)
+    at Generator.next (<anonymous>)
+    at fulfilled (/root/vro/polyglot_test_project/node_modules/@vmware-pscoe/polyglotpkg/dist/strategies/nodejs.js:5:58)
+[ERROR] Command execution failed.
+org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)
+    at org.apache.commons.exec.DefaultExecutor.executeInternal (DefaultExecutor.java:404)
+    at org.apache.commons.exec.DefaultExecutor.execute (DefaultExecutor.java:166)
+...
+    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
+    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
+    at java.lang.Thread.run (Thread.java:840)
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+```
+
+#### New Behavior
+
+The ABX archetype now compiles successfully.
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/typescript/polyglotpkg/package-lock.json
+++ b/typescript/polyglotpkg/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.40.1-SNAPSHOT",
       "license": "VMware Confidential",
       "dependencies": {
+        "@types/node": "^14.0.13",
         "adm-zip": "^0.4.14",
         "command-line-args": "^5.1.1",
         "fs-extra": "^9.0.1",
@@ -29,7 +30,6 @@
         "@types/fs-extra": "^9.0.1",
         "@types/lodash": "4.14.182",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^14.0.13",
         "@types/uuid": "^8.0.0",
         "@types/which": "^1.3.2",
         "mocha": "^10.2.0",
@@ -37,7 +37,7 @@
         "ts-node": "^8.10.2"
       },
       "engines": {
-        "node": ">=16.15.1",
+        "node": ">=16.15.1 <16.20.2",
         "npm": ">=6.14.0"
       },
       "optionalDependencies": {

--- a/typescript/polyglotpkg/package-lock.json
+++ b/typescript/polyglotpkg/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.40.1-SNAPSHOT",
       "license": "VMware Confidential",
       "dependencies": {
-        "@types/node": "^14.0.13",
         "adm-zip": "^0.4.14",
         "command-line-args": "^5.1.1",
         "fs-extra": "^9.0.1",
@@ -19,7 +18,7 @@
         "uuid": "^8.1.0",
         "which": "^2.0.2",
         "winston": "^3.2.1",
-        "xmlbuilder2": "^2.1.3"
+        "xmlbuilder2": "^3.1.1"
       },
       "bin": {
         "polyglotpkg": "bin/polyglotpkg"
@@ -30,6 +29,7 @@
         "@types/fs-extra": "^9.0.1",
         "@types/lodash": "4.14.182",
         "@types/mocha": "^10.0.1",
+        "@types/node": "^14.0.13",
         "@types/uuid": "^8.0.0",
         "@types/which": "^1.3.2",
         "mocha": "^10.2.0",
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@oozcitak/dom": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.8.tgz",
-      "integrity": "sha512-MoOnLBNsF+ok0HjpAvxYxR4piUhRDCEWK0ot3upwOOHYudJd30j6M+LNcE8RKpwfnclAX9T66nXXzkytd29XSw==",
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
       "dependencies": {
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/url": "1.0.4",
@@ -177,7 +177,8 @@
     "node_modules/@types/node": {
       "version": "14.18.53",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
-      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
+      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==",
+      "dev": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.2",
@@ -917,9 +918,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1638,18 +1639,17 @@
       "dev": true
     },
     "node_modules/xmlbuilder2": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.4.1.tgz",
-      "integrity": "sha512-vliUplZsk5vJnhxXN/mRcij/AE24NObTUm/Zo4vkLusgayO6s3Et5zLEA14XZnY1c3hX5o1ToR0m0BJOPy0UvQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
       "dependencies": {
-        "@oozcitak/dom": "1.15.8",
+        "@oozcitak/dom": "1.15.10",
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/util": "8.3.8",
-        "@types/node": "*",
-        "js-yaml": "3.14.0"
+        "js-yaml": "3.14.1"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/y18n": {

--- a/typescript/polyglotpkg/package.json
+++ b/typescript/polyglotpkg/package.json
@@ -48,11 +48,11 @@
     "uuid": "^8.1.0",
     "which": "^2.0.2",
     "winston": "^3.2.1",
-    "xmlbuilder2": "^2.1.3",
-    "@types/node": "^14.0.13"
+    "xmlbuilder2": "^3.1.1"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
+    "@types/node": "^14.0.13",
     "@types/adm-zip": "^0.4.33",
     "@types/command-line-args": "^5.0.0",
     "@types/fs-extra": "^9.0.1",

--- a/typescript/polyglotpkg/package.json
+++ b/typescript/polyglotpkg/package.json
@@ -28,7 +28,7 @@
     "package"
   ],
   "engines": {
-    "node": ">=16.15.1",
+    "node": ">=16.15.1 <16.20.2",
     "npm": ">=6.14.0"
   },
   "author": "VMware WWCoE",
@@ -48,7 +48,8 @@
     "uuid": "^8.1.0",
     "which": "^2.0.2",
     "winston": "^3.2.1",
-    "xmlbuilder2": "^2.1.3"
+    "xmlbuilder2": "^2.1.3",
+    "@types/node": "^14.0.13"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
@@ -56,7 +57,6 @@
     "@types/command-line-args": "^5.0.0",
     "@types/fs-extra": "^9.0.1",
     "@types/lodash": "4.14.182",
-    "@types/node": "^14.0.13",
     "@types/uuid": "^8.0.0",
     "@types/which": "^1.3.2",
     "run-script-os": "^1.1.6",

--- a/typescript/polyglotpkg/package.json
+++ b/typescript/polyglotpkg/package.json
@@ -28,7 +28,7 @@
     "package"
   ],
   "engines": {
-    "node": ">=16.15.1 <16.20.2",
+    "node": ">=16.15.1",
     "npm": ">=6.14.0"
   },
   "author": "VMware WWCoE",


### PR DESCRIPTION
### Description

The issue was that the `polyglotpkg` package had `types/node` set as a devDependency, which, under normal circumstances, would be fine, however, `xmlbuilder2`, one of our dependencies, has a dependency on `@types/node` set to "*". This caused the `xmlbuilder2` package to install the latest version of `@types/node`, which is incompatible with the version of `node` that we are using. We are using version 2.4.1 of `xmlbuilder2`, newest version `3.1.1` does not have this problem.

For more information here are the relevant `package-lock.json` entries:

```json
		"node_modules/xmlbuilder2": {
			"version": "2.4.1",
			"resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.4.1.tgz",
			"integrity": "sha512-vliUplZsk5vJnhxXN/mRcij/AE24NObTUm/Zo4vkLusgayO6s3Et5zLEA14XZnY1c3hX5o1ToR0m0BJOPy0UvQ==",
			"dependencies": {
				"@oozcitak/dom": "1.15.8",
				"@oozcitak/infra": "1.0.8",
				"@oozcitak/util": "8.3.8",
				"@types/node": "*",
				"js-yaml": "3.14.0"
			},
			"engines": {
				"node": ">=10.0"
			}
		}
```

```json

		"node_modules/@vmware-pscoe/polyglotpkg": {
			"version": "2.40.1-SNAPSHOT",
			"resolved": "file:../../../.m2/repository/com/vmware/pscoe/iac/polyglotpkg/2.40.1-SNAPSHOT/polyglotpkg-2.40.1-SNAPSHOT.tgz",
			"integrity": "sha512-WsAUQUPCzHcOuF2n8LkUzvzq7/7YTOpybLBP8ZhjN4qF8QrVxUZJfeY3h43Teo/Fxcme4SeoHsGIvh4qX9zbjA==",
			"license": "VMware Confidential",
			"dependencies": {
				"adm-zip": "^0.4.14",
				"command-line-args": "^5.1.1",
				"fs-extra": "^9.0.1",
				"globby": "^11.0.1",
				"lodash": "^4.17.15",
				"typescript": "^3.9.5",
				"uuid": "^8.1.0",
				"which": "^2.0.2",
				"winston": "^3.2.1",
				"xmlbuilder2": "^2.1.3"
			},
			"bin": {
				"polyglotpkg": "bin/polyglotpkg"
			},
			"engines": {
				"node": ">=16.15.1 <16.20.2",
				"npm": ">=6.14.0"
			},
			"optionalDependencies": {
				"fsevents": "~2.3.1"
			}
		},
```

The issue applied, is to migrate to version `3.1.1.` of `xmlbuilder2`. We could also have moved `@types/node` to our `dependencies`, both would have fixed the issue


### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue
