### PR TITLE
[ecmascript] (#311)Fix for Unknown error on VROES.import

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -172,6 +172,22 @@ org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit 
 
 The ABX archetype now compiles successfully.
 
+### *VROES.import from invalid package throws Unknown error*
+
+Fixed an issue with VROES.import() in ecmascript Module.
+
+#### Previous Behavior
+
+VROES import from an invalid module path resulted in Unknown error.
+The Unknown error could not be caught in a try/catch block and was not shown in the logs.
+
+#### New Behavior
+
+VROES import from a missing/invalid module path, or import of non-existing elements of a valid module,
+result in more detailed errors in the logs. No exceptions are thrown by default (as per the existing behaviour)
+but there is an option to alter the error handling behaviour via an optional parameter in import.from().
+
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/packages/ecmascript/README.md
+++ b/packages/ecmascript/README.md
@@ -62,3 +62,42 @@ Mixed imports
 import defaultExport, { MyClass, myFunction as myFunc } from "module-name";
 var { defaultExport, MyClass, myFunc} = ESModule.import("default", "MyClass", "myFunction").from("module-name");
 ```
+
+Import with relative and base path
+```js
+import defaultExport, { MyClass, myFunction as myFunc } from "module-name";
+// Note: ./ and ../ are supported only at the start of the relative path. Relative paths without base path will result in error
+var { myFunc} = ESModule.import("myFunction").from("../../relative/path", "module-name");
+var { MyClass} = ESModule.import("MyClass").from("./relative/path", "module-name");
+```
+
+Import with custom error handling (default behavior is to log an Error and return null)
+```js
+import defaultExport, { MyClass, myFunction as myFunc } from "module-name";
+// throw the error
+var { myFunc} = ESModule.import("myFunction").from(
+  "module-name",
+  null, // no base path needed when module path is not relative
+  function (errorMessage) { 
+    throw new Error(errorMessage);
+  }
+);
+// log the error as warning
+var { myFunc} = ESModule.import("myFunction").from(
+  "module-name",
+  null,
+  function (errorMessage) { 
+    System.warn(errorMessage);
+    return null; // required
+  }
+);
+// do nothing - e.g. to avoid cluttering the logs when trying several potential module paths
+var { myFunc} = ESModule.import("myFunction").from(
+  "module-name",
+  null,
+  function (errorMessage) {
+    
+    return null; // required
+  }
+);
+```

--- a/packages/ecmascript/src/module.test.ts
+++ b/packages/ecmascript/src/module.test.ts
@@ -13,74 +13,74 @@
  * #L%
  */
 describe("Module", () => {
-    var ESModule = System.getModule("com.vmware.pscoe.library.ecmascript").Module();
-    var exported;
-    var modules = {
-        "com.vmware.pscoe.library.class": {
-            "Class": function () {
-                return function Class() { };
-            }
-        },
-        "com.vmware.pscoe": {
-            "ExportClass": function () {
-                return exported;
-            }
-        },
-        "com.vmware.pscoe.test": {
-            "TestClass": function () {
-                return function TestClass() { };
-            }
-        }
-    };
-    let getModuleOriginal: any;
-   
-    beforeAll(() => {
-        getModuleOriginal = System.getModule;
-        System.getModule = function (moduleName: string) {
-            let moduleInfo = modules[moduleName];
-            if (moduleInfo && !moduleInfo.actionDescriptions) {
-                moduleInfo.name = moduleName;
-                moduleInfo.actionDescriptions = Object.keys(moduleInfo)
-                    .map(actionName => <any>{
-                        name: actionName,
-                    });
-            }
+	var ESModule = System.getModule("com.vmware.pscoe.library.ecmascript").Module();
+	var exported;
+	var modules = {
+		"com.vmware.pscoe.library.class": {
+			"Class": function () {
+				return function Class() { };
+			}
+		},
+		"com.vmware.pscoe": {
+			"ExportClass": function () {
+				return exported;
+			}
+		},
+		"com.vmware.pscoe.test": {
+			"TestClass": function () {
+				return function TestClass() { };
+			}
+		}
+	};
+	let getModuleOriginal: any;
 
-            return moduleInfo;
-        }
-    });
+	beforeAll(() => {
+		getModuleOriginal = System.getModule;
+		System.getModule = function (moduleName: string) {
+			let moduleInfo = modules[moduleName];
+			if (moduleInfo && !moduleInfo.actionDescriptions) {
+				moduleInfo.name = moduleName;
+				moduleInfo.actionDescriptions = Object.keys(moduleInfo)
+					.map(actionName => <any>{
+						name: actionName,
+					});
+			}
 
-    afterAll(() => {
-        System.getModule = getModuleOriginal
-    });
+			return moduleInfo;
+		}
+	});
 
-    it("import class", () => {
-        var Class = ESModule.import("default").from("com.vmware.pscoe.library.class.Class");
-        expect(Class).toBeDefined();
-    })
-    it("export class", () => {
-        var TestSubClass1 = function TestSubClass1(s) { };
-        var TestSubClass2 = function TestSubClass2(s) { };
-        var exp = ESModule.export().default(TestSubClass1).named("TestSubClass2", TestSubClass2).build();
-        expect(exp.default).toBe(TestSubClass1);
-        expect(exp["TestSubClass2"]).toBe(TestSubClass2);
-    })
-    it("import exported class", () => {
-        var t1 = function TestSubClass1(s) { };
-        var t2 = function TestSubClass2(s) { };
-        exported = ESModule.export().default(t1).named("TestSubClass2", t2).build();
-        var _a = ESModule.import("default", "TestSubClass2").from("com.vmware.pscoe.ExportClass"), TestSubClass1 = _a[0], TestSubClass2 = _a[1];
-        expect(TestSubClass1).toBe(t1);
-        expect(TestSubClass2).toBe(t2);
-    })
-    it("Compare imported classes", () => {
-        const global = System.getContext() as Record<string, any>;
-        expect(global).toBeDefined();
-        expect((global.__classes__ || {})["com.vmware.pscoe.test/TestClass"]).not.toBeDefined();
-        const TestClass = ESModule.import("default").from("com.vmware.pscoe.test.TestClass");
-        expect(TestClass).toBeDefined();
-        expect(global.__classes__).toBeDefined();
-        expect(global.__classes__["com.vmware.pscoe.test/TestClass"]).toBeDefined();
-        expect(global.__classes__["com.vmware.pscoe.test/TestClass"]).toBe(TestClass);
-    })
+	afterAll(() => {
+		System.getModule = getModuleOriginal
+	});
+
+	it("import class", () => {
+		var Class = ESModule.import("default").from("com.vmware.pscoe.library.class.Class");
+		expect(Class).toBeDefined();
+	})
+	it("export class", () => {
+		var TestSubClass1 = function TestSubClass1(s) { };
+		var TestSubClass2 = function TestSubClass2(s) { };
+		var exp = ESModule.export().default(TestSubClass1).named("TestSubClass2", TestSubClass2).build();
+		expect(exp.default).toBe(TestSubClass1);
+		expect(exp["TestSubClass2"]).toBe(TestSubClass2);
+	})
+	it("import exported class", () => {
+		var t1 = function TestSubClass1(s) { };
+		var t2 = function TestSubClass2(s) { };
+		exported = ESModule.export().default(t1).named("TestSubClass2", t2).build();
+		var _a = ESModule.import("default", "TestSubClass2").from("com.vmware.pscoe.ExportClass"), TestSubClass1 = _a[0], TestSubClass2 = _a[1];
+		expect(TestSubClass1).toBe(t1);
+		expect(TestSubClass2).toBe(t2);
+	})
+	it("Compare imported classes", () => {
+		const global = System.getContext() as Record<string, any>;
+		expect(global).toBeDefined();
+		expect((global.__classes__ || {})["com.vmware.pscoe.test/TestClass"]).not.toBeDefined();
+		const TestClass = ESModule.import("default").from("com.vmware.pscoe.test.TestClass");
+		expect(TestClass).toBeDefined();
+		expect(global.__classes__).toBeDefined();
+		expect(global.__classes__["com.vmware.pscoe.test/TestClass"]).toBeDefined();
+		expect(global.__classes__["com.vmware.pscoe.test/TestClass"]).toBe(TestClass);
+	})
 })


### PR DESCRIPTION
### Description

Issue summary:
VROES.import(...).from(invalidModulePath) threw an Unknown error. Cause was calling System.getModule() with blank path.

Changes:
Added validation for module path and specifiers in ecmascript/Module, affecting for VROES.import().from().
Additional parameter for handling the validation errors in Module.import(), Module.load() with default value - function to log the error and return null (avoids breaking changes).
Removed unused path parameter and from() method from export.
Documentation (comments, README, release note)
Unit tests.



### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested on a client environment with the same action as the issue and a library that searched through potential module paths.
