### PR TITLE
[ecmascript] (#353) Fix problem with Size in a Map Object when Setting a Value in it

### DIFF
--- a/packages/ecmascript/src/Map.ts
+++ b/packages/ecmascript/src/Map.ts
@@ -65,6 +65,12 @@ export default class Map<K extends (string | number), V> {
 	}
 
 	public set(key: any, value: any): any {
+		let exist = this.has(key);
+		if (exist) {
+			this.items[key] = value;
+			this.size++;
+			return this;
+		}
 		this.items[key] = value;
 		this.size++;
 

--- a/packages/ecmascript/src/Map.ts
+++ b/packages/ecmascript/src/Map.ts
@@ -66,12 +66,11 @@ export default class Map<K extends (string | number), V> {
 
 	public set(key: any, value: any): any {
 		let exist = this.has(key);
+		this.items[key] = value;
+
 		if (exist) {
-			this.items[key] = value;
-			this.size++;
 			return this;
 		}
-		this.items[key] = value;
 		this.size++;
 
 		return this;

--- a/packages/ecmascript/src/Map.ts
+++ b/packages/ecmascript/src/Map.ts
@@ -14,7 +14,7 @@
  */
 
 export default class Map<K extends (string | number), V> {
-	private size: number = 0;
+	public size: number = 0;
 	private items: { [name: string]: any } = {};
 
 	constructor(values?: ReadonlyArray<[K, V]> | null) {

--- a/packages/ecmascript/src/Map.ts
+++ b/packages/ecmascript/src/Map.ts
@@ -14,7 +14,7 @@
  */
 
 export default class Map<K extends (string | number), V> {
-	private size = 0;
+	private size: number = 0;
 	private items: { [name: string]: any } = {};
 
 	constructor(values?: ReadonlyArray<[K, V]> | null) {
@@ -26,7 +26,7 @@ export default class Map<K extends (string | number), V> {
 		}
 	}
 
-	entries(): [any, any][] {
+	public entries(): [any, any][] {
 		let entries = [];
 
 		for (let key in this.items) {
@@ -36,7 +36,7 @@ export default class Map<K extends (string | number), V> {
 		return entries;
 	}
 
-	keys(): any[] {
+	public keys(): any[] {
 		let keys = [];
 
 		for (let key in this.items) {
@@ -46,7 +46,7 @@ export default class Map<K extends (string | number), V> {
 		return keys;
 	}
 
-	values(): any[] {
+	public values(): any[] {
 		let values = [];
 
 		for (let key in this.items) {
@@ -56,26 +56,23 @@ export default class Map<K extends (string | number), V> {
 		return values;
 	}
 
-	has(key): boolean {
+	public has(key: any): boolean {
 		return this.items.hasOwnProperty(key);
 	}
 
-	get(key): any {
+	public get(key: any): any {
 		return this.items[key];
 	}
 
-	set(key, value): any {
-		let exist = this.items.hasOwnProperty(key);
-		if (exist) {
-			this.size++;
-		}
-
+	public set(key: any, value: any): any {
 		this.items[key] = value;
+		this.size++;
+
 		return this;
 	}
 
-	delete(key): boolean {
-		let exist = this.items.hasOwnProperty(key);
+	public delete(key: any): boolean {
+		let exist = this.has(key);
 		if (exist) {
 			this.size--;
 			delete this.items[key];
@@ -84,14 +81,14 @@ export default class Map<K extends (string | number), V> {
 		return exist;
 	}
 
-	clear(): void {
+	public clear(): void {
 		this.size = 0;
 		this.items = {};
 	}
 
-	forEach(callbackfn: (value, key, map: Map<any, any>) => void): void {
+	public forEach(callbackFunction: (value: any, key: any, map: Map<any, any>) => void): void {
 		for (let key in this.items) {
-			callbackfn(this.items[key], key, this);
+			callbackFunction(this.items[key], key, this);
 		}
 	}
 }

--- a/packages/ecmascript/src/Set.ts
+++ b/packages/ecmascript/src/Set.ts
@@ -54,7 +54,12 @@ export default class Set<T extends string | number> {
 	}
 
 	public add(value: any): any {
+		let exist = this.has(value);
 		this.items[value] = true;
+
+		if (exist) {
+			return this;
+		}
 		this.size++;
 
 		return this;

--- a/packages/ecmascript/src/Set.ts
+++ b/packages/ecmascript/src/Set.ts
@@ -55,6 +55,8 @@ export default class Set<T extends string | number> {
 
 	public add(value: any): any {
 		this.items[value] = true;
+		this.size++;
+
 		return this;
 	}
 

--- a/packages/ecmascript/src/Set.ts
+++ b/packages/ecmascript/src/Set.ts
@@ -13,7 +13,7 @@
  * #L%
  */
 export default class Set<T extends string | number> {
-	private size: number = 0;
+	public size: number = 0;
 	private items: { [name: string]: boolean } = {};
 
 	constructor(values?: ReadonlyArray<T> | null) {

--- a/packages/ecmascript/src/Set.ts
+++ b/packages/ecmascript/src/Set.ts
@@ -13,7 +13,7 @@
  * #L%
  */
 export default class Set<T extends string | number> {
-	private size = 0;
+	private size: number = 0;
 	private items: { [name: string]: boolean } = {};
 
 	constructor(values?: ReadonlyArray<T> | null) {
@@ -25,7 +25,7 @@ export default class Set<T extends string | number> {
 		}
 	}
 
-	entries(): [any, any][] {
+	public entries(): [any, any][] {
 		let entries = [];
 
 		for (let value in this.items) {
@@ -35,11 +35,11 @@ export default class Set<T extends string | number> {
 		return entries;
 	}
 
-	keys(): any[] {
+	public keys(): any[] {
 		return this.values();
 	}
 
-	values(): any[] {
+	public values(): any[] {
 		let values = [];
 
 		for (let value in this.items) {
@@ -49,17 +49,17 @@ export default class Set<T extends string | number> {
 		return values;
 	}
 
-	has(value): boolean {
+	public has(value: any): boolean {
 		return this.items.hasOwnProperty(value);
 	}
 
-	add(value): any {
+	public add(value: any): any {
 		this.items[value] = true;
 		return this;
 	}
 
-	delete(value: any): boolean {
-		let exist = this.items.hasOwnProperty(value);
+	public delete(value: any): boolean {
+		let exist = this.has(value);
 		if (exist) {
 			this.size--;
 			delete this.items[value];
@@ -68,14 +68,14 @@ export default class Set<T extends string | number> {
 		return exist;
 	}
 
-	clear(): void {
+	public clear(): void {
 		this.size = 0;
 		this.items = {};
 	}
 
-	forEach(callbackfn: (value, value2, set: Set<any>) => void): void {
+	public forEach(callbackFunction: (value: any, value2: any, set: Set<any>) => void): void {
 		for (let value in this.items) {
-			callbackfn(value, value, this);
+			callbackFunction(value, value, this);
 		}
 	}
 }


### PR DESCRIPTION
Fix problem with Size in a Map Object when Setting a Value in it

### Description

The size property should increase when adding key / values to a map object.

### Checklist

- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1. Push the ecmascript package to a live environment.
2. Create a dummy workflow with one scrip table task that has the following code in it:
```ts
var __global = System.getContext() || (function () { return this; }).call(null);
var VROES = __global.__VROES || (__global.__VROES = System.getModule("com.vmware.pscoe.library.ecmascript").VROES()), exports = {};
var Map = VROES.Map;

var myMap = new Map();
myMap.set(1,2);
System.log('myMap Size: '.concat(myMap.size));
```
3. Execute the workflow
4. The size printed should be `1`

![ecmascript_map_test_result_workflow](https://github.com/user-attachments/assets/6bd3676b-772d-4a5e-8999-3d4e4d7fcb11)

### Release Notes

The size property should increase when adding key / values to a map object.

### Related issues and PRs

Issue #353 
