### PR TITLE
[vropkg] (#365) Support for transforming `for each` statements when pulling

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -508,6 +508,86 @@ export class HandleNetworkConfigurationBackup {
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+
+### *`for each` statements are now being converted by `vropkg` when pulling*
+
+`for each` is valid syntax in the Java's Rhino engine, but not in normal JS.
+
+#### Previous Behavior
+
+When pulling a workflow with `for each` statements, the action would be pulled, but then would not be able to be pushed as the syntax is invalid.
+
+#### New Behavior
+
+`for each` statements are now being converted to `for` statements when pulling a workflow.
+
+Example:
+
+```js
+var test = ["ya", "da"]
+
+for each (var i in test) {
+    for each (var y in test) {
+        System.log(y)
+        for each(var z in test){System.log(z)}
+    }
+  System.log(i)
+}
+
+for each (
+var n in test
+) {
+    System.log(n)
+}
+
+for (var i in test) {
+  System.log(i)
+}
+
+for (var $index in test) {
+    var i = test[$index]
+  System.log(i)
+}
+```
+
+is converted to
+
+
+```js
+/**
+ * @return {string}
+ */
+(function() {
+  var test = ["ya", "da"]
+
+  for (var $index_i in test) {
+    var i = test[$index_i];
+    for (var $index_y in test) {
+      var y = test[$index_y];
+      System.log(y)
+      for (var $index_z in test) {
+        var z = test[$index_z];
+        System.log(z)
+      }
+    }
+    System.log(i)
+  }
+
+  for (var $index_n in test) {
+    var n = test[$index_n];
+    System.log(n)
+  }
+  for (var i in test) {
+    System.log(i)
+  }
+
+  for (var $index in test) {
+    var i = test[$index]
+    System.log(i)
+  }
+});
+```
+
 ### *ABX archetype build issue, cannot compile*
 
 Fixed an issue where the ABX archetype could not compile due to an old version of the `xmlbuilder2` package.

--- a/typescript/vropkg/src/parse/transformers.ts
+++ b/typescript/vropkg/src/parse/transformers.ts
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * vropkg
+ * %%
+ * Copyright (C) 2023 - 2024 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+/**
+ * Regex used to match 'for each' loops
+ *
+ * Works for the following cases:
+ *   - Single line
+ *   - Multiple lines
+ *   - Nested loops
+ *   - Multiple nested loops
+ *   - Multiple nested loops with multiple lines
+ *
+ * Does not work for:
+ *  - `for each (var n in Object.values(x)) {` or other complex expressions
+ */
+const FOR_EACH_REGEX = /for each\s*\(\s*var\s+(\w+)\s+in\s+(\w+)\s*\)\s*\{\s*([\s\S]*?)\s*\}/;
+
+/**
+ * Structure of the transformed code
+ *
+ * @NOTE: Indentation gets lost in the transformation and mutliple line for-each loops will be on a single line
+ *
+ * @param {string} iterator Iterator variable
+ * @param {string} collection Collection to iterate over
+ * @param {string} body Body of the loop
+ *
+ * @returns {string} Transformed code
+ */
+function getTransformationReplacer(iterator: string, collection: string, body: string): string {
+	return `for (var $index_${iterator} in ${collection}) {
+	var ${iterator} = ${collection}[$index_${iterator}];
+	${body}
+}`;
+}
+
+/**
+ * Transforms 'for each' loops to standard 'for' loops with variable declaration
+ *
+ * @param {string} source Source code to transform
+ * @returns {string} Transformed source code
+ */
+export function transformForEachToFor(source: string): string {
+	while (FOR_EACH_REGEX.test(source)) {
+		source = source.replace(
+			FOR_EACH_REGEX,
+			(match, iterator, collection, body) => getTransformationReplacer(iterator, collection, body)
+		);
+	}
+
+	return source;
+}

--- a/typescript/vropkg/src/parse/util.ts
+++ b/typescript/vropkg/src/parse/util.ts
@@ -21,6 +21,7 @@ import * as CRC from "crc-32";
 import { exist } from "../util";
 import * as path from "path";
 import { JSON_MINOR_IDENT } from "../constants";
+import { transformForEachToFor } from "./transformers";
 
 export const read = (file) => decode(fs.readFileSync(file));
 export const xml = (data) => new xmldoc.XmlDocument(data);
@@ -29,260 +30,268 @@ export const xmlChildNamed = (doc, name): string => doc.childNamed(name)?.val ||
 export const xmlToCategory = (categories): string[] => categories.children.map((e: xmldoc.XmlElement) => e.attr.name);
 export const xmlToTag = (tags): string[] => tags.children.filter(e => e.attr && e.attr.name).map((e: xmldoc.XmlElement) => e.attr.name);
 export const stringToCategory = (category): string[] => category.split(/(?<!\/)\./)
-    .map(path => { return path.replace(/\//g, "") })
-    .filter(path => path != "");
+	.map(path => { return path.replace(/\//g, ""); })
+	.filter(path => path != "");
 export const validateWorkflowPath = (xmlDocument) => {
 	const invalidElement = xmlDocument.children.find((e) => e.attr.name === null || e.attr.name === undefined);
-	if (invalidElement && invalidElement.firstChild !== null){
+	if (invalidElement && invalidElement.firstChild !== null) {
 		throw new Error(`Unsupported characters detected in the workflow path. The value "${invalidElement.firstChild.val}" contains characters that are not allowed.`);
 	}
 };
-export const xmlToAction = (file: string, bundlePath: string, name: string, comment: string, description: string, tags: Array<string>): t.VroActionData => {
-    let type = "" + t.VroElementType.ScriptModule;
-    if (!exist(file)) {
-        console.warn(`WARN  Cannot find corresponding data xml file "${file}" for metadata file for element of type "${type}". Skipping that element.`);
-        return null;
-    }
-    if (!fileCanRead(file)) {
-        console.warn(`WARN  Data xml file "${file}" that corresponds to the ${type} element metadata file "${file}"`
-            + `, does exist, but is not readable by current user ("${userInfo().username}"). Please update file mode permissions accordingly. Skipping this element.`);
-        return null;
-    }
-    let xmlContent = decode(fs.readFileSync(file));
-    let actionXml = new xmldoc.XmlDocument(xmlContent);
-    let scriptName = actionXml.attr["name"];
-    scriptName = !scriptName ? name : scriptName;
+export const xmlToAction = (file: string, bundlePath: string, name: string, comment: string, description: string, tags: Array<string>): t.VroActionData | null => {
+	let type = "" + t.VroElementType.ScriptModule;
+	if (!exist(file)) {
+		console.warn(`WARN  Cannot find corresponding data xml file "${file}" for metadata file for element of type "${type}". Skipping that element.`);
+		return null;
+	}
+	if (!fileCanRead(file)) {
+		console.warn(`WARN  Data xml file "${file}" that corresponds to the ${type} element metadata file "${file}"`
+			+ `, does exist, but is not readable by current user ("${userInfo().username}"). Please update file mode permissions accordingly. Skipping this element.`);
+		return null;
+	}
+	let xmlContent = decode(fs.readFileSync(file));
+	let actionXml = new xmldoc.XmlDocument(xmlContent);
+	let scriptName = actionXml.attr["name"];
+	scriptName = !scriptName ? name : scriptName;
 
-    let resultType = actionXml.attr["result-type"];
-    let apiVersion = actionXml.attr["api-version"] || "6.0.0";
-    let version = actionXml.attr["version"];
-    let timeout = actionXml.attr["timeout"];
-    let memoryLimit = actionXml.attr["memory-limit"];
+	let resultType = actionXml.attr["result-type"];
+	let apiVersion = actionXml.attr["api-version"] || "6.0.0";
+	let version = actionXml.attr["version"];
+	let timeout = actionXml.attr["timeout"];
+	let memoryLimit = actionXml.attr["memory-limit"];
 
-    let runtime = null;
-    let entryHandler = null;
-    let params: Array<t.VroActionParameter> = [];
-    let inline = null;
-    actionXml.children.forEach((element) => {
-        if (element.type == "element" && element?.name == "param") {
+	let runtime = null;
+	let entryHandler = null;
+	let params: Array<t.VroActionParameter> = [];
+	let inline = null;
+	actionXml.children.forEach((element) => {
+		if (element.type == "element" && element?.name == "param") {
 
-            let paramName = element.attr["n"];
-            let paramType = element.attr["t"];
-            let paramDesc = element.val; // VroNativeFolderElementParser.getDescriptionForParameterFromXml(actionXmlPath, paramName, element);
-            let param: t.VroActionParameter = {
-                name: paramName?.trim(),
-                type: paramType?.trim(),
-                description: paramDesc?.trim()
-            };
-            params.push(param);
-        } else if (element.type == "element" && element.name == "script") {
-            inline = getScriptInline(file, element, comment, this.lazy);
-        } else if (element.type == "element" && element.name == "runtime") {
-            runtime = element.val;
-        } else if (element.type == "element" && element.name == "entry-point") {
-            entryHandler = element.val;
-        }
-    });
-    if (scriptName != name) {
-        console.warn(`WARN  The name "${scriptName}" of the Scriptable module defined in file "${file}" is different than the name of the same module `
-            + `"${name}" defined in the corresponding metadata file "${file}". Please fix the name in the metadata file.`);
-    }
-    if (apiVersion != "6.0.0") {
-        console.warn(`WARN  The api version (${apiVersion}) specified in file "${file}" for ${type} ${scriptName}, `
-            + "might not be supported. Currently well supported api version is 6.0.0. Continuing to process as per 6.0.0.");
-    }
-    let returnType = { name: null, type: resultType, description: getReturnDescriptionFromComment(file, resultType, comment, false) };
+			let paramName = element.attr["n"];
+			let paramType = element.attr["t"];
+			let paramDesc = element.val; // VroNativeFolderElementParser.getDescriptionForParameterFromXml(actionXmlPath, paramName, element);
+			let param: t.VroActionParameter = {
+				name: paramName?.trim(),
+				type: paramType?.trim(),
+				description: paramDesc?.trim()
+			};
+			params.push(param);
+		} else if (element.type == "element" && element.name == "script") {
+			inline = getScriptInline(file, element, comment, this.lazy);
+		} else if (element.type == "element" && element.name == "runtime") {
+			runtime = element.val;
+		} else if (element.type == "element" && element.name == "entry-point") {
+			entryHandler = element.val;
+		}
+	});
+	if (scriptName != name) {
+		console.warn(`WARN  The name "${scriptName}" of the Scriptable module defined in file "${file}" is different than the name of the same module `
+			+ `"${name}" defined in the corresponding metadata file "${file}". Please fix the name in the metadata file.`);
+	}
+	if (apiVersion != "6.0.0") {
+		console.warn(`WARN  The api version (${apiVersion}) specified in file "${file}" for ${type} ${scriptName}, `
+			+ "might not be supported. Currently well supported api version is 6.0.0. Continuing to process as per 6.0.0.");
+	}
+	let returnType = { name: null, type: resultType, description: getReturnDescriptionFromComment(file, resultType, comment, false) };
 
-    let nativeElement: t.VroActionData =
-        {
-            version: version,
-            params: params,
-            returnType: returnType,
-            runtime: getScriptRuntime(runtime),
-            timeout,
-            memoryLimit,
-            inline: inline,
-            bundle: getScriptBundle(file, bundlePath, entryHandler, comment),
-        } as t.VroActionData;
-    return nativeElement;
+	let nativeElement: t.VroActionData =
+		{
+			version: version,
+			params: params,
+			returnType: returnType,
+			runtime: getScriptRuntime(runtime),
+			timeout,
+			memoryLimit,
+			inline: inline,
+			bundle: getScriptBundle(file, bundlePath, entryHandler, comment),
+		} as t.VroActionData;
+	return nativeElement;
 
-}
+};
 
 export function getScriptRuntime(runtime: string): t.VroScriptRuntime {
-    if (runtime == null) {
-        return { lang: t.Lang.javascript, version: "" };
-    }
-    runtime = runtime.trim();
-    let index = runtime.indexOf(":");
-    let langString = index == -1 ? runtime : runtime.substring(0, index);
-    let langVersion = index == -1 ? "" : index >= runtime.length - 1 ? "" : runtime.substring(index + 1);
-    langString = langString.toLowerCase().trim();
-    langVersion = langVersion.toLowerCase().trim();
-    let defaultVersion = "";
-    let lang: t.Lang = t.Lang[langString];
-    switch (lang) {
-        case t.Lang.javascript: defaultVersion = ""; break;
-        case t.Lang.node: defaultVersion = "12"; break;
-        case t.Lang.powercli: defaultVersion = "11-powershell-6.2"; break;
-        case t.Lang.python: defaultVersion = "3.7"; break;
-        default: throw new Error(`Unsupported runtime language "${langString}". Only supported languages are "javascript", "node", "powercli" and "python".`);
-    };
-    return { lang: lang, version: langVersion != "" ? langVersion : defaultVersion }
+	if (runtime == null) {
+		return { lang: t.Lang.javascript, version: "" };
+	}
+	runtime = runtime.trim();
+	let index = runtime.indexOf(":");
+	let langString = index == -1 ? runtime : runtime.substring(0, index);
+	let langVersion = index == -1 ? "" : index >= runtime.length - 1 ? "" : runtime.substring(index + 1);
+	langString = langString.toLowerCase().trim();
+	langVersion = langVersion.toLowerCase().trim();
+	let defaultVersion = "";
+	let lang: t.Lang = t.Lang[langString];
+	switch (lang) {
+		case t.Lang.javascript: defaultVersion = ""; break;
+		case t.Lang.node: defaultVersion = "12"; break;
+		case t.Lang.powercli: defaultVersion = "11-powershell-6.2"; break;
+		case t.Lang.python: defaultVersion = "3.7"; break;
+		default: throw new Error(`Unsupported runtime language "${langString}". Only supported languages are "javascript", "node", "powercli" and "python".`);
+	};
+	return { lang: lang, version: langVersion != "" ? langVersion : defaultVersion };
 }
 
 function getScriptInline(file: string, element: xmldoc.XmlElement, comment: string, lazy: boolean): t.VroScriptInline {
 
-    let scriptSource: string = element.val;
-    let scriptStartLine: number = element.line;
-    let scriptStartIndex: number = element.column;
-    let lines: Array<string> = scriptSource.split("\n");
-    let lastLine = lines[lines.length - 1];
-    let scriptEndLine: number = scriptStartLine + lines.length;
-    let scriptEndIndex: number = -1;
-    if (lines.length <= 1) {
-        scriptEndLine = scriptStartLine;
-        scriptEndIndex = scriptStartIndex + lastLine.length;
-    } else {
-        scriptEndLine = scriptStartLine + lines.length - 1;
-        scriptEndIndex = lastLine.length;
-    }
-    return {
-        actionSource: lazy ? null : scriptSource,
-        sourceFile: file,
-        sourceStartLine: scriptStartLine,
-        sourceStartIndex: scriptStartIndex,
-        sourceEndLine: scriptEndLine,
-        sourceEndIndex: scriptEndIndex,
-        getActionSource: function (action: t.VroActionData): string {
-            let jsFile = action.inline.sourceFile;
-            let startLine = action.inline.sourceStartLine;
-            let startIndex = action.inline.sourceStartIndex;
-            let endLine = action.inline.sourceEndLine;
-            let endIndex = action.inline.sourceEndIndex;
-            let fileContent = fs.readFileSync(jsFile)?.toString();
-            let actionSource = getActionBodyFromSourceIndexes(fileContent, startLine, startIndex, endLine, endIndex);
-            let trimmed = actionSource.trim();
-            const CDATA_START = "<![CDATA[";
-            const CDATA_END = "]]>";
-            if (trimmed.startsWith(CDATA_START) && trimmed.endsWith(CDATA_END)) {
-                return trimmed.substring(CDATA_START.length, trimmed.length - CDATA_END.length);
-            }
-            return actionSource;
-        },
-        javadoc: getJavadocFromComment(file, comment)
-    }
+	let scriptSource: string = element.val;
+	let scriptStartLine: number = element.line;
+	let scriptStartIndex: number = element.column;
+
+	// Transforms `for each` statements
+	scriptSource = transformForEachToFor(scriptSource);
+
+	let lines: Array<string> = scriptSource.split("\n");
+	let lastLine = lines[lines.length - 1];
+	let scriptEndLine: number = scriptStartLine + lines.length;
+	let scriptEndIndex: number = -1;
+	if (lines.length <= 1) {
+		scriptEndLine = scriptStartLine;
+		scriptEndIndex = scriptStartIndex + lastLine.length;
+	} else {
+		scriptEndLine = scriptStartLine + lines.length - 1;
+		scriptEndIndex = lastLine.length;
+	}
+	return {
+		actionSource: lazy ? null : scriptSource,
+		sourceFile: file,
+		sourceStartLine: scriptStartLine,
+		sourceStartIndex: scriptStartIndex,
+		sourceEndLine: scriptEndLine,
+		sourceEndIndex: scriptEndIndex,
+		getActionSource: function(action: t.VroActionData): string {
+			let jsFile = action.inline.sourceFile;
+			let startLine = action.inline.sourceStartLine;
+			let startIndex = action.inline.sourceStartIndex;
+			let endLine = action.inline.sourceEndLine;
+			let endIndex = action.inline.sourceEndIndex;
+			let fileContent = fs.readFileSync(jsFile)?.toString();
+
+			// Transforms `for each` statements
+			fileContent = transformForEachToFor(fileContent);
+
+			let actionSource = getActionBodyFromSourceIndexes(fileContent, startLine, startIndex, endLine, endIndex);
+			let trimmed = actionSource.trim();
+			const CDATA_START = "<![CDATA[";
+			const CDATA_END = "]]>";
+			if (trimmed.startsWith(CDATA_START) && trimmed.endsWith(CDATA_END)) {
+				return trimmed.substring(CDATA_START.length, trimmed.length - CDATA_END.length);
+			}
+			return actionSource;
+		},
+		javadoc: getJavadocFromComment(file, comment)
+	};
 }
 
 function getScriptBundle(file: string, bundlePath: string, entry: string, comment: string): t.VroScriptBundle {
-    if (exist(bundlePath)) {
-        if (entry == null) {
-            throw new Error(`Cannot find entry handler (entry-point) for script bundle "${bundlePath}". Please check for entry-point tag in the corresponding data file (metadata file): "${file}".`);
-        }
-        return {
-            contentPath: path.resolve(bundlePath),
-            projectPath: getBundlePathFromComment(comment),
-            entry: entry.trim(),
-        }
-    }
-    if (entry != null) {
-        throw new Error(`Entry point defined as "${entry}" in metadata file  "${file}", but a corresponding bundle zip does not exist as: "${bundlePath}".`);
-    }
-    return null;
+	if (exist(bundlePath)) {
+		if (entry == null) {
+			throw new Error(`Cannot find entry handler (entry-point) for script bundle "${bundlePath}". Please check for entry-point tag in the corresponding data file (metadata file): "${file}".`);
+		}
+		return {
+			contentPath: path.resolve(bundlePath),
+			projectPath: getBundlePathFromComment(comment),
+			entry: entry.trim(),
+		};
+	}
+	if (entry != null) {
+		throw new Error(`Entry point defined as "${entry}" in metadata file  "${file}", but a corresponding bundle zip does not exist as: "${bundlePath}".`);
+	}
+	return null;
 }
 
 function getActionBodyFromSourceIndexes(source: string, startLine: number, startIndex: number, endLine: number, endIndex: number): string {
-    if (!source) {
-        return "";
-    }
-    let lines: Array<string> = source.split("\n");
-    let filtered: Array<string> = [];
-    let len = lines.length;
-    for (let i = 0; i < len; i++) {
-        let line = lines.shift();
-        if (i < startLine || i > endLine) {
-            continue;
-        }
-        let filteredLine = "";
-        if (i == startLine && i == endLine) {
-            filteredLine = line.substring(startIndex, endIndex);
-        } else if (i == startLine) {
-            filteredLine = line.substring(startIndex);
-        } else if (i == endLine) {
-            filteredLine = line.substring(0, endIndex);
-        } else {
-            filteredLine = line;
-        }
-        filtered.push(filteredLine);
-    }
-    return filtered.join("\n");
+	if (!source) {
+		return "";
+	}
+	let lines: Array<string> = source.split("\n");
+	let filtered: Array<string> = [];
+	let len = lines.length;
+	for (let i = 0; i < len; i++) {
+		let line = lines.shift();
+		if (i < startLine || i > endLine) {
+			continue;
+		}
+		let filteredLine = "";
+		if (i == startLine && i == endLine) {
+			filteredLine = line.substring(startIndex, endIndex);
+		} else if (i == startLine) {
+			filteredLine = line.substring(startIndex);
+		} else if (i == endLine) {
+			filteredLine = line.substring(0, endIndex);
+		} else {
+			filteredLine = line;
+		}
+		filtered.push(filteredLine);
+	}
+	return filtered.join("\n");
 }
 
 function getJavadocFromComment(file: string, comment: string): any {
-    if (comment == null) {
-        return null;
-    }
-    try {
-        return JSON.parse(comment)?.javadoc;
-    } catch (e) {
-        return null;
-    }
+	if (comment == null) {
+		return null;
+	}
+	try {
+		return JSON.parse(comment)?.javadoc;
+	} catch (e) {
+		return null;
+	}
 }
 
 function getBundlePathFromComment(comment: string): any {
-    if (comment == null) {
-        return null;
-    }
-    try {
-        return JSON.parse(comment)?.bundle;
-    } catch (e) {
-        return null;
-    }
+	if (comment == null) {
+		return null;
+	}
+	try {
+		return JSON.parse(comment)?.bundle;
+	} catch (e) {
+		return null;
+	}
 }
 
 export const getCommentFromJavadoc = (comment: string, bundle: string, returnType: t.VroActionParameter, javadoc: any): string => {
-    let obj: any = {
-        comment: comment,
-        returnType: returnType,
-        bundle: bundle,
-        javadoc: javadoc,
-        crc: null
-    };
-    obj.crc = (CRC.str(JSON.stringify(obj)) & 0x7FFFFFFF).toString(16);
+	let obj: any = {
+		comment: comment,
+		returnType: returnType,
+		bundle: bundle,
+		javadoc: javadoc,
+		crc: null
+	};
+	obj.crc = (CRC.str(JSON.stringify(obj)) & 0x7FFFFFFF).toString(16);
 
-    return JSON.stringify(obj, null, JSON_MINOR_IDENT);
-}
+	return JSON.stringify(obj, null, JSON_MINOR_IDENT);
+};
 
 function getReturnDescriptionFromComment(file: string, expectedResultType: string, comment: string, dump: boolean): string {
-    try {
-        let obj: any = JSON.parse(comment);
-        let resultType = obj?.returnType?.type;
-        if (resultType != expectedResultType) {
-            return "";
-        }
-        let crc = obj?.crc;
-        obj.crc = null;
-        if (crc != (CRC.str(JSON.stringify(obj)) & 0x7FFFFFFF).toString(16)) {
-            return "";
-        }
-        let description = obj?.returnType?.description;
-        return description ?? "";
-    } catch (e) {
-        return "";
-    }
+	try {
+		let obj: any = JSON.parse(comment);
+		let resultType = obj?.returnType?.type;
+		if (resultType != expectedResultType) {
+			return "";
+		}
+		let crc = obj?.crc;
+		obj.crc = null;
+		if (crc != (CRC.str(JSON.stringify(obj)) & 0x7FFFFFFF).toString(16)) {
+			return "";
+		}
+		let description = obj?.returnType?.description;
+		return description ?? "";
+	} catch (e) {
+		return "";
+	}
 }
 
 function fileCanRead(file: string): boolean {
-    try {
-        fs.accessSync(file, fs.constants.R_OK);
-        return true;
-    } catch (e) {
-        return false;
-    }
+	try {
+		fs.accessSync(file, fs.constants.R_OK);
+		return true;
+	} catch (e) {
+		return false;
+	}
 }
 
 export function getWorkflowItems(workflowDataFile: string, type: string): string[] {
-    const wfItems: xmldoc.XmlElement[] = exist(workflowDataFile) ? xml(read(workflowDataFile)).childrenNamed("workflow-item") : [];
-    const inputWfItems = wfItems.filter(item => item.attr.type === type);
+	const wfItems: xmldoc.XmlElement[] = exist(workflowDataFile) ? xml(read(workflowDataFile)).childrenNamed("workflow-item") : [];
+	const inputWfItems = wfItems.filter(item => item.attr.type === type);
 
-    return inputWfItems.filter(item => item?.attr?.name !== null && item?.attr?.name !== undefined).map(item => item.attr.name);
+	return inputWfItems.filter(item => item?.attr?.name !== null && item?.attr?.name !== undefined).map(item => item.attr.name);
 }


### PR DESCRIPTION
### Description

`for each` is valid syntax in the Java's Rhino engine, but not in normal JS.

#### Previous Behavior

When pulling a workflow with `for each` statements, the action would be pulled, but then would not be able to be pushed as the syntax is invalid.

#### New Behavior

`for each` statements are now being converted to `for` statements when pulling a workflow.

Example:

```js
var test = ["ya", "da"]

for each (var i in test) {
    for each (var y in test) {
        System.log(y)
        for each(var z in test){System.log(z)}
    }
  System.log(i)
}

for each (
var n in test
) {
    System.log(n)
}

for (var i in test) {
  System.log(i)
}

for (var $index in test) {
    var i = test[$index]
  System.log(i)
}
```

is converted to


```js
/**
 * @return {string}
 */
(function() {
  var test = ["ya", "da"]

  for (var $index_i in test) {
    var i = test[$index_i];
    for (var $index_y in test) {
      var y = test[$index_y];
      System.log(y)
      for (var $index_z in test) {
        var z = test[$index_z];
        System.log(z)
      }
    }
    System.log(i)
  }

  for (var $index_n in test) {
    var n = test[$index_n];
    System.log(n)
  }
  for (var i in test) {
    System.log(i)
  }

  for (var $index in test) {
    var i = test[$index]
    System.log(i)
  }
});
```

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Manually tested... I could not figure out how the e2e tests work...
