### PR TITLE
[maven] (#368) Update Maven Assembly Plugin Version

### DIFF
--- a/maven/base-package/pom.xml
+++ b/maven/base-package/pom.xml
@@ -344,7 +344,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.vmware.pscoe.maven</groupId>

--- a/maven/npmconv/pom.xml
+++ b/maven/npmconv/pom.xml
@@ -80,7 +80,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.7.0</version>
                     <executions>
                         <execution>
                             <id>copy-vro-dependencies</id>

--- a/maven/plugins/actions/src/it/basic/pom.xml
+++ b/maven/plugins/actions/src/it/basic/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>

--- a/maven/plugins/actions/src/it/pull/pom.xml
+++ b/maven/plugins/actions/src/it/pull/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>

--- a/maven/plugins/polyglot/src/it/basic/pom.xml
+++ b/maven/plugins/polyglot/src/it/basic/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>copy-vro-dependencies</id>

--- a/maven/plugins/typescript/src/it/basic/pom.xml
+++ b/maven/plugins/typescript/src/it/basic/pom.xml
@@ -55,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>copy-vro-dependencies</id>

--- a/maven/plugins/vrealize/src/it/basic/pom.xml
+++ b/maven/plugins/vrealize/src/it/basic/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>

--- a/maven/plugins/xml/src/it/pull/pom.xml
+++ b/maven/plugins/xml/src/it/pull/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.0</version>
                 <executions>
                     <execution>
                         <id>unpack-keystore</id>

--- a/maven/polyglot/pom.xml
+++ b/maven/polyglot/pom.xml
@@ -28,7 +28,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
-						<version>3.6.0</version>
+						<version>3.7.0</version>
 						<executions>
 							<execution>
 								<id>unpack-keystore</id>

--- a/maven/repository/pom.xml
+++ b/maven/repository/pom.xml
@@ -356,7 +356,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.7.0</version>
 				<executions>
 					<execution>
 						<id>iac-maven-repository</id>

--- a/maven/repository/pom.xml
+++ b/maven/repository/pom.xml
@@ -321,7 +321,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.7.0</version>
 				<executions>
 					<execution>
 						<id>copy</id>


### PR DESCRIPTION
### Description

Update the maven assembly plugin to version 3.7.0 that does not depend on `com.github.luben:zstd-jni 1.5.5-2` library (considered vulnerable).

### Checklist

- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Building of the project would pull latest version of the maven assembly plugin

### Release Notes

Update the maven assembly plugin to version 3.7.0 that does not depend on `com.github.luben:zstd-jni 1.5.5-2` library (considered vulnerable).

### Related issues and PRs

This resolves #368
