### PR TITLE
[vrotsc] (#301) Improve error messages for Policy Template, Workflow and Configuration files with incorrect extensions

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -112,6 +112,21 @@ An error is thrown when an elements targets itself or is isolated (not targeted 
 <https://github.com/vmware/build-tools-for-vmware-aria/issues/383>
 <https://github.com/vmware/build-tools-for-vmware-aria/issues/318>
 
+### Better errors for Policy Template, Workflow and Configuration files with incorrect extensions
+
+#### Previous Behavior
+
+A non-descriptive error was thrown when a Policy Template, Workflow or Configuration file was missing either .ts or its respective file extension prefix (.pl, .wf, .conf).
+
+#### Current Behavior
+
+A more specific error is thrown when a file ends in .pl, .wf, .conf, with instructions to add the omitted extension (.ts / .xml / .yaml).
+A more specific error is thrown when a .ts file contains a PolicyTemplate, Workflow or Configuration decorator without the corresponding file extension prefix (.pl, .wf, .conf).
+
+#### Related issues
+
+<https://github.com/vmware/build-tools-for-vmware-aria/issues/301>
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -152,12 +152,12 @@ The following classes were added to `o11n-plugin-aria`:
 
 #### Previous Behavior
 
-A non-descriptive error was thrown when a Policy Template, Workflow or Configuration file was missing either .ts or its respective file extension prefix (.pl, .wf, .conf).
+A non-descriptive error was thrown when a typescript Policy Template, Workflow or Configuration file was missing either .ts or its respective file extension prefix (.pl, .wf, .conf).
 
 #### Current Behavior
 
-A more specific error is thrown when a file ends in .pl, .wf, .conf, with instructions to add the omitted extension (.ts / .xml / .yaml).
-A more specific error is thrown when a .ts file contains a PolicyTemplate, Workflow or Configuration decorator without the corresponding file extension prefix (.pl, .wf, .conf).
+A more specific error is thrown when a file ends in .pl, .wf, .conf and contains a corresponding typescript decorator (@PolicyTemplate, @Workflow, @Configuration), with instructions to add the omitted .ts extension.
+A more specific error is thrown when a .ts file contains a @PolicyTemplate, @Workflow or @Configuration decorator without the corresponding file extension prefix (.pl, .wf, .conf).
 
 #### Related issues
 

--- a/typescript/vrotsc/src/compiler/program.ts
+++ b/typescript/vrotsc/src/compiler/program.ts
@@ -90,7 +90,9 @@ export function createProgram(options: ProgramOptions): Program {
 				),
 		};
 
-		files.map(file => transformerFactoryMap[file.type](file, context)).forEach(transform => transform());
+		files.map(file => (transformerFactoryMap[file.type] && transformerFactoryMap[file.type](file, context))
+			|| (() => { throw new Error(`Cannot transform file '${file?.filePath}' - unsupported file type!`) }))
+			.forEach(transform => transform());
 
 		generateIndexTypes(context);
 
@@ -195,6 +197,15 @@ export function createProgram(options: ProgramOptions): Program {
 	function getFileType(filePath: string, fileSet: Record<string, boolean>): FileType {
 		filePath = filePath.toLowerCase();
 
+		if (filePath.endsWith(".wf")) {
+			throw new Error(`'.wf' is not a valid Workflow file extension. Use '.wf.ts' or '.wf.xml'.`)
+		}
+		if (filePath.endsWith(".pl")) {
+			throw new Error(`'.pl' is not a valid Policy Template file extension. Use '.pl.ts' or '.pl.xml'.`)
+		}
+		if (filePath.endsWith(".conf")) {
+			throw new Error(`'.conf' is not a valid Configuration Element file extension. Use '.conf.ts' or '.conf.yaml'.`)
+		}
 		if (filePath.endsWith(".wf.ts")) {
 			return FileType.Workflow;
 		}

--- a/typescript/vrotsc/src/compiler/program.ts
+++ b/typescript/vrotsc/src/compiler/program.ts
@@ -90,9 +90,7 @@ export function createProgram(options: ProgramOptions): Program {
 				),
 		};
 
-		files.map(file => (transformerFactoryMap[file.type] && transformerFactoryMap[file.type](file, context))
-			|| (() => { throw new Error(`Cannot transform file '${file?.filePath}' - unsupported file type!`) }))
-			.forEach(transform => transform());
+		files.map(file => transformerFactoryMap[file.type](file, context)).forEach(transform => transform());
 
 		generateIndexTypes(context);
 
@@ -197,15 +195,6 @@ export function createProgram(options: ProgramOptions): Program {
 	function getFileType(filePath: string, fileSet: Record<string, boolean>): FileType {
 		filePath = filePath.toLowerCase();
 
-		if (filePath.endsWith(".wf")) {
-			throw new Error(`'.wf' is not a valid Workflow file extension. Use '.wf.ts' or '.wf.xml'.`)
-		}
-		if (filePath.endsWith(".pl")) {
-			throw new Error(`'.pl' is not a valid Policy Template file extension. Use '.pl.ts' or '.pl.xml'.`)
-		}
-		if (filePath.endsWith(".conf")) {
-			throw new Error(`'.conf' is not a valid Configuration Element file extension. Use '.conf.ts' or '.conf.yaml'.`)
-		}
 		if (filePath.endsWith(".wf.ts")) {
 			return FileType.Workflow;
 		}

--- a/typescript/vrotsc/src/compiler/transformer/fileTransformers/resource.ts
+++ b/typescript/vrotsc/src/compiler/transformer/fileTransformers/resource.ts
@@ -6,9 +6,9 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
+ *
  * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
- * 
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -16,6 +16,7 @@ import { FileDescriptor, FileTransformationContext, FileType } from "../../../ty
 import { system } from "../../../system/system";
 import { generateElementId } from "../../../utilities/utilities";
 import { printElementInfo } from "../../elementInfo";
+import { checkResourceForMisplacedDecorators } from "../helpers/checkResourceForMisplacedDecorators";
 
 const yaml: typeof import("js-yaml") = require("js-yaml");
 
@@ -37,6 +38,7 @@ interface ResourceElementInfo {
 export function getResourceTransformer(file: FileDescriptor, context: FileTransformationContext) {
 	return function transform() {
 		const content = system.readFile(file.filePath);
+		checkResourceForMisplacedDecorators(file.filePath, content.toString());
 		const resourceInfo =
 			getYamlElementInfo(`${file.filePath}.element_info.yaml`) ||
 			getJsonElementInfo(`${file.filePath}.element_info.json`) ||

--- a/typescript/vrotsc/src/compiler/transformer/helpers/checkActionForMisplacedClassDecorators.ts
+++ b/typescript/vrotsc/src/compiler/transformer/helpers/checkActionForMisplacedClassDecorators.ts
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * vrotsc
+ * %%
+ * Copyright (C) 2023 - 2024 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ * 
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ * 
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+import { ClassDeclaration, getDecorators, CallExpression, SyntaxKind } from "typescript";
+
+/**
+ * Checks an action for class-level decorators, associated with an unintentionally omitted prefix to the ".ts" extension:
+ * - Configuration (.conf.ts)
+ * - PolicyTemplate (.pl.ts)
+ * - Workflow (.wf.ts)
+ * @param {ClassDeclaration} classNode - class node in the action
+ * @throws Error if such decorator is found to indicate possibly omitted extension prefix
+ * (otherwise Actions as functions are not expected to have class-level decorators).
+ */
+export function checkActionForMisplacedClassDecorators(classNode: ClassDeclaration) {
+	const decoratorToFileSuffixMap = {
+		"PolicyTemplate": "pl",
+		"Configuration": "conf",
+		"Workflow": "wf"
+	};
+	const misplacedDecorator = getDecorators(classNode)
+		?.map(decoratorNode => (decoratorNode.expression as CallExpression).expression as { kind?: SyntaxKind; text?: string; })
+		.find(expression => expression?.kind === SyntaxKind.Identifier && expression?.text in decoratorToFileSuffixMap)?.text;
+	if (misplacedDecorator) {
+		throw new Error(`Typescript ${misplacedDecorator} file names need to be in the format `
+			+ `'<fileName>.${decoratorToFileSuffixMap[misplacedDecorator]}.ts'!`
+		);
+	}
+}

--- a/typescript/vrotsc/src/compiler/transformer/helpers/checkResourceForMisplacedDecorators.ts
+++ b/typescript/vrotsc/src/compiler/transformer/helpers/checkResourceForMisplacedDecorators.ts
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * vrotsc
+ * %%
+ * Copyright (C) 2023 - 2024 VMware
+ * %%
+ * Build Tools for VMware Aria
+ * Copyright 2023 VMware, Inc.
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
+ * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+ * #L%
+ */
+
+/**
+ * Checks a Resource file for a specific decorator and matching extension, indicationg an unintentionally omitted ".ts" extension:
+ * @param {string} filePath -path of the resource file
+ * @param {string} content - content of the file as string
+ * @throws Error if the file with one of these extensions contains a matching TS class-level decorator in its contents:
+ * - .conf -> Configuration
+ * - .pl -> PolicyTemplate
+ * - .wf -> Workflow
+ */
+export function checkResourceForMisplacedDecorators(filePath: string, content: string) {
+	filePath = filePath?.toLowerCase() || "";
+	let errMsg: string;
+	if (filePath.endsWith(".wf") && content?.match(new RegExp("@Workflow\\s*\\(\\s*{", "gm"))) {
+		errMsg = `'.wf' is not a valid Workflow file extension. Use '.wf.ts' instead.`;
+	}
+	else if (filePath.endsWith(".pl") && content?.match(new RegExp("@PolicyTemplate\\s*\\(\\s*{", "gm"))) {
+		errMsg = `'.pl' is not a valid Policy Template file extension. Use '.pl.ts' instead.`;
+	}
+	else if (filePath.endsWith(".conf") && content?.match(new RegExp("@Configuration\\s*\\(\\s*{", "gm"))) {
+		errMsg = `'.conf' is not a valid Configuration Element file extension. Use '.conf.ts' instead.`;
+	}
+	if (errMsg) {
+		throw new Error(errMsg);
+	}
+}


### PR DESCRIPTION
### Description

Replaces the non-specific error of the type "SyntaxError: [9:15]: Unexpected token: '-'" thrown when a file has an unsupported extension (e.g. .wf):

- in the cases when a .ts Action file contains a Workflow, Configuration or PolicyTemplate decorator:
![confErr](https://github.com/user-attachments/assets/eae650ca-19d3-42c5-ae3e-9f8c8c6f6f2b)
![wfErr](https://github.com/user-attachments/assets/8e5762ec-658d-40d1-8ef5-eabba23d04fa)
![plErr](https://github.com/user-attachments/assets/f7664ffc-7854-4659-8b6c-f7071a1b3a39)

- in the cases when the file extension is .pl, .wf, .conf (omitted .ts/.xml/.yaml extension):
![wfErr2](https://github.com/user-attachments/assets/dd01a47f-83f4-4f67-9d67-b807cd27a999)
![plErr2](https://github.com/user-attachments/assets/ceda8855-ffd6-40a5-8392-5076ca8c5fef)
![confErr2](https://github.com/user-attachments/assets/dcc745d9-e5f0-4ef7-93d9-df965ae791a8)

- in the case of all other unsupported file extensions, the file is treated as Resource, retaining the existing behavior.

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested manually on a new TS archetype project.

### Related issues and PRs

Closes #301 