### PR TITLE
[ecmascript] (402) Remove unused function `Export.from` from class `Module`

### DIFF
--- a/packages/ecmascript/src/Module.ts
+++ b/packages/ecmascript/src/Module.ts
@@ -211,38 +211,6 @@ const IMPORT_BASE_REGEX = /^(?:[\w-]+\.)*[\w-]+$/g;
 		return this;
 	};
 
-	Export.prototype.from = function (moduleName: string, ...specifiers: (string | [string, string])[]) {
-		let importNames: string[] = [];
-		let exportNames: string[] = [];
-
-		specifiers.forEach(specifier => {
-			if (Array.isArray(specifier)) {
-				exportNames.push(specifier[0]);
-				importNames.push(specifier[1]);
-			}
-			else {
-				exportNames.push(specifier);
-				importNames.push(specifier);
-			}
-		});
-
-		let values = loadActionOrModule(moduleName);
-
-		for (let i = 0; i < importNames.length; i++) {
-			let importName = importNames[i];
-			if (importName == "*") {
-				for (let propName in values) {
-					this.elements[propName] = values && values[propName];
-				}
-			}
-			else {
-				this.elements[exportNames[i]] = values && values[importName];
-			}
-		}
-
-		return this;
-	};
-
 	Export.prototype.build = function () {
 		return this.elements;
 	};


### PR DESCRIPTION
### Description

Removed the function Module.export.from as discussed on roadmap meeting.
The function 'from' is not part of the interface ModuleExport and is not used anywhere within the project.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Pushed to test environment without issue.

### Related issues and PRs

[<!-- Link any related issues and pull requests here using #number or user/repo#number -->](https://github.com/vmware/build-tools-for-vmware-aria/issues/402)
Closes #402 