### PR TITLE
[ecmascript] (#417) Fix `exports` failure during TS Workflow execution

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -39,6 +39,16 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### Fixed bug with exports
+
+#### Previous Behavior
+
+Running a workflow resulted in ERROR (com.vmware.pscoe.library.ecmascript/Module) Error in (Dynamic Script Module name : Module#18) ReferenceError: "exports" is not defined.
+
+#### New Behavior
+
+The bug in Module.ts is fixed and an error is no longer thrown.
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/packages/ecmascript/src/Module.ts
+++ b/packages/ecmascript/src/Module.ts
@@ -12,18 +12,12 @@
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
-const GLOBAL = System.getContext() || (function () {
-	return this;
-}).call(null);
 
 /**
  * Function to handle errors when loading/importing an action or module.
  * @param {string | Error} err - error (message)
  */
 export type ModuleErrorHandler = (error: string | Error) => void;
-
-/** Default module error handling function. Logs a System Error. */
-export const DEFAULT_MODULE_ERROR_HANDLER: ModuleErrorHandler = (error) => System.error(error?.toString());
 
 export interface ModuleConstructor extends Function {
 	/**
@@ -116,6 +110,17 @@ export interface ModuleExport {
 export interface ModuleElementList {
 	[name: string]: any;
 }
+
+////////////////////////////// CONSTANTS //////////////////////////////
+// N.B.: DO NOT export constants or enums (ONLY types / interfaces) - will cause error on WF execution due to misplaced "exports"!
+
+/** Global context. */
+const GLOBAL = System.getContext() || (function () {
+	return this;
+}).call(null);
+
+/** Default module error handling function. Logs a System Error. */
+const DEFAULT_MODULE_ERROR_HANDLER: ModuleErrorHandler = (error) => System.error(error?.toString());
 
 /**
  * Key of the Module attribute that holds the last set error handler via {@link Module.setModuleErrorHandler}.


### PR DESCRIPTION
### Description

Removed "export" from a constant in Module.ts, which was causing the error.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Built successfully, tested imports on environment with the sample project.

### Related issues and PRs

https://github.com/vmware/build-tools-for-vmware-aria/issues/417

PR that introduced the issue:
https://github.com/vmware/build-tools-for-vmware-aria/pull/345
<!-- Link any related issues and pull requests here using #number or user/repo#number -->
