### PR TITLE
[vropkg] (#415) `for each` transformer now respects comments and will not work in them

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -46,6 +46,46 @@ The following runtimes have been added to the polyglot archetype:
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### `for each` transformer does not respect comments
+
+We have a transformer in `vropkg` as a way to automatically convert 'Aria Orchestrator' supported `for each` loops to normal `for` loops.
+
+#### Previous Behavior
+
+The transformer did not respect comments and would remove them.
+
+```js
+// for each (var i in [1, 2, 3]) { }
+/*
+
+for each (var i in [1, 2, 3]) { }
+
+*/
+
+/* for each (var i in [1, 2, 3]) { } */
+```
+
+Would all get transformed and the comments would be removed.
+
+#### New Behavior
+
+The transformer now respects comments and will not remove them.
+
+```js
+// for each (var i in [1, 2, 3]) { }
+/*
+
+for (var i in [1, 2, 3]) { }
+
+*/
+
+/* for (var i in [1, 2, 3]) { } */
+```
+
+The comments will be preserved and no transformation will be done.
+
+> Our overall recommendation would be to avoid writing `for each` loops in comments in the first place.
+
 ### Fixed bug with exports
 
 #### Previous Behavior

--- a/typescript/vropkg/src/parse/transformers.ts
+++ b/typescript/vropkg/src/parse/transformers.ts
@@ -21,11 +21,12 @@
  *   - Nested loops
  *   - Multiple nested loops
  *   - Multiple nested loops with multiple lines
+ *   - Comments
  *
  * Does not work for:
  *  - `for each (var n in Object.values(x)) {` or other complex expressions
  */
-const FOR_EACH_REGEX = /for each\s*\(\s*var\s+(\w+)\s+in\s+(\w+)\s*\)\s*\{\s*([\s\S]*?)\s*\}/;
+const FOR_EACH_REGEX = /^(?!\s*(\/\/|\/\*|\*\/|\*)).*for each\s*\(\s*var\s+(\w+)\s+in\s+(\w+)\s*\)\s*\{\s*([\s\S]*?)\s*\}/;
 
 /**
  * Structure of the transformed code


### PR DESCRIPTION
### Description

`for each` transformers will not transform the code inside of comments

### Checklist


Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

TBD

### Release Notes

TBD

### Related issues and PRs

Fixes: #415 