### PR TITLE
[maven,artifact-manager,installer] (#498) Remove `vrang.org.id` and `vrang_org_id` configuration properties

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVraNg.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVraNg.java
@@ -47,10 +47,6 @@ public class ConfigurationVraNg extends Configuration {
 	 */
 	public static final String PROJECT_NAME = "project.name";
 	/**
-	 * param ORGANIZATION_ID.
-	 */
-	public static final String ORGANIZATION_ID = "org.id";
-	/**
 	 * param ORGANIZATION_NAME.
 	 */
 	public static final String ORGANIZATION_NAME = "org.name";
@@ -139,13 +135,6 @@ public class ConfigurationVraNg extends Configuration {
 	 */
 	public String getProjectName() {
 		return this.properties.getProperty(PROJECT_NAME);
-	}
-
-	/**
-	 * @return String
-	 */
-	public String getOrgId() {
-		return this.properties.getProperty(ORGANIZATION_ID);
 	}
 
 	/**
@@ -244,8 +233,8 @@ public class ConfigurationVraNg extends Configuration {
 			message.append("Project name ");
 		}
 
-		if (StringUtils.isEmpty(getOrgId()) && StringUtils.isEmpty(getOrgName())) {
-			message.append("Organization id and Organization Name ");
+		if (StringUtils.isEmpty(getOrgName())) {
+			message.append("Organization Name ");
 		}
 
 		if (StringUtils.isEmpty(getRefreshToken()) && StringUtils.isEmpty(super.getUsername())) {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVraNg.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVraNg.java
@@ -253,7 +253,8 @@ public class ConfigurationVraNg extends Configuration {
 		String[] deprecatedFlags = new String[] {
 				"bp.ignore.versions",
 				"bp.release",
-				"project.id"
+				"project.id",
+				"org.id"
 		};
 
 		for (String flag : deprecatedFlags) {

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVroNg.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/configuration/ConfigurationVroNg.java
@@ -30,16 +30,11 @@ public final class ConfigurationVroNg extends ConfigurationVraNg implements Conf
 	}
 
 	// Important - when modify properties refer to comments in @Configuration
-	public static final String ORGANIZATION_ID = "org.id";
 	public static final String REFRESH_TOKEN = "refresh.token";
 
 	/**
 	 * vRA Package Import content conflict resolution mode
 	 */
-
-	public String getOrgId() {
-		return this.properties.getProperty(ORGANIZATION_ID);
-	}
 
 	public String getRefreshToken() {
 		return this.properties.getProperty(REFRESH_TOKEN);

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/utils/VraNgOrganizationUtil.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/utils/VraNgOrganizationUtil.java
@@ -21,24 +21,20 @@ import org.apache.commons.lang3.StringUtils;
 
 public class VraNgOrganizationUtil {
 
-	private VraNgOrganizationUtil() {}
+	private VraNgOrganizationUtil() {
+	}
 
 	public static VraNgOrganization getOrganization(RestClientVraNgPrimitive restClient, ConfigurationVraNg config) {
-		VraNgOrganization orgByName = null, orgById = null;
-		if (StringUtils.isNotEmpty(config.getOrgId())) {
-			orgById = restClient.getOrganizationById(config.getOrgId());
-		}
+		VraNgOrganization orgByName = null;
 		if (StringUtils.isNotEmpty(config.getOrgName())) {
 			orgByName = restClient.getOrganizationByName(config.getOrgName());
 		}
-		if(orgByName == null && orgById == null) {
-			throw new RuntimeException(String.format("Couldn't find organization by the provided criteria - ID '%s' or Name '%s'.",
-					config.getOrgId(), config.getOrgName()));
-		}
-		if(orgByName != null && orgById != null && !orgByName.getId().equalsIgnoreCase(orgById.getId())) {
-			throw new RuntimeException("Organization ID and Organization Name provided from the configuration refer to different Organizations.");
+
+		if (orgByName == null) {
+			throw new RuntimeException(String.format("Couldn't find organization by the provided criteria - Name '%s'.",
+					config.getOrgName()));
 		}
 
-		return orgById != null ? orgById : orgByName;
+		return orgByName;
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/utils/VraNgOrganizationUtil.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/utils/VraNgOrganizationUtil.java
@@ -19,7 +19,7 @@ import com.vmware.pscoe.iac.artifact.model.vrang.VraNgOrganization;
 import com.vmware.pscoe.iac.artifact.rest.RestClientVraNgPrimitive;
 import org.apache.commons.lang3.StringUtils;
 
-public class VraNgOrganizationUtil {
+public final class VraNgOrganizationUtil {
 
 	private VraNgOrganizationUtil() {
 	}

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgApprovalPolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgApprovalPolicyStoreTest.java
@@ -53,7 +53,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.never;
 
-public class VraNgApprovalPolicyStoreTest  {
+public class VraNgApprovalPolicyStoreTest {
 	/**
 	 * Temp Folder.
 	 */
@@ -96,7 +96,6 @@ public class VraNgApprovalPolicyStoreTest  {
 	 */
 	private final Logger logger = LoggerFactory.getLogger(VraNgApprovalPolicyStoreTest.class);
 
-
 	/**
 	 * Init function called before each test.
 	 */
@@ -120,7 +119,6 @@ public class VraNgApprovalPolicyStoreTest  {
 		org.setName("VIDM-L-01A");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
@@ -144,16 +142,16 @@ public class VraNgApprovalPolicyStoreTest  {
 	@Test
 	void testExportContentWithNoApprovalPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithNoApprovalPolicies");
-		//GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(new VraNgPolicy());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
 		File approvalPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 
-		//VERIFY
+		// VERIFY
 		verify(restClient, never()).getApprovalPolicies();
 		verify(restClient, never()).getApprovalPolicy(anyString());
 
@@ -164,28 +162,28 @@ public class VraNgApprovalPolicyStoreTest  {
 	void testExportContentWithAllApprovalPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllApprovalPolicies");
 		VraNgApprovalPolicy policy1 = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgApprovalPolicy policy2 = new VraNgApprovalPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"AP02",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"AP02",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		List<VraNgApprovalPolicy> policies = Arrays.asList(policy1, policy2);
 
@@ -200,7 +198,7 @@ public class VraNgApprovalPolicyStoreTest  {
 
 		// VERIFY
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 		assertEquals(2, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
 
@@ -209,16 +207,16 @@ public class VraNgApprovalPolicyStoreTest  {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificApprovalPolicies");
 
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -229,7 +227,7 @@ public class VraNgApprovalPolicyStoreTest  {
 		store.exportContent();
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
@@ -239,16 +237,16 @@ public class VraNgApprovalPolicyStoreTest  {
 	void testImportContentWithUpdateLogic() {
 		System.out.println("testImportContentWithUpdateLogic");
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -256,7 +254,7 @@ public class VraNgApprovalPolicyStoreTest  {
 		fsMocks.getApprovalPolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), approvalPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), approvalPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "AP01.json" });
 
@@ -270,34 +268,33 @@ public class VraNgApprovalPolicyStoreTest  {
 		verify(restClient, times(1)).createApprovalPolicy(any());
 	}
 
-
 	@Test
 	void testImportContentWithCreateLogic() {
 		System.out.println("testImportContentWithCreateLogic");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgApprovalPolicy policyFromServer = new VraNgApprovalPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"AP02",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"AP02",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -305,7 +302,7 @@ public class VraNgApprovalPolicyStoreTest  {
 		fsMocks.getApprovalPolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), approvalPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), approvalPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "AP01.json" });
 
@@ -337,28 +334,28 @@ public class VraNgApprovalPolicyStoreTest  {
 	void testExportContentWithSpecificApprovalPoliciesAndDuplicateFiles() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificApprovalPoliciesAndDuplicateFiles");
 		VraNgApprovalPolicy policyInFile = new VraNgApprovalPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -366,8 +363,7 @@ public class VraNgApprovalPolicyStoreTest  {
 		when(restClient.getApprovalPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 
 		fsMocks.getApprovalPolicyFsMocks().addPolicy(policyInFile);
 		policyInFile.setName("AP01_1");
@@ -382,7 +378,8 @@ public class VraNgApprovalPolicyStoreTest  {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "AP01.json", "AP01_1.json", "AP01_2.json", "AP01_3.json", "AP01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "AP01.json", "AP01_1.json", "AP01_2.json", "AP01_3.json", "AP01_4.json" });
 	}
 
 	@Test
@@ -390,16 +387,16 @@ public class VraNgApprovalPolicyStoreTest  {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -407,88 +404,87 @@ public class VraNgApprovalPolicyStoreTest  {
 		when(restClient.getApprovalPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 
 		fsMocks.getApprovalPolicyFsMocks().addPolicy(policy);
 		// TEST
 		store.exportContent();
 
 		// VERIFY
-		//export should overwrite policy, not create a new file.
+		// export should overwrite policy, not create a new file.
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
 
 	@Test
-	void testExportContentWithSpecificApprovalPoliciesAndDuplicateNames(){
+	void testExportContentWithSpecificApprovalPoliciesAndDuplicateNames() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificApprovalPoliciesAndDuplicateNames");
 		VraNgApprovalPolicy policyInFile = new VraNgApprovalPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgApprovalPolicy policy = new VraNgApprovalPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgApprovalPolicy policy1 = new VraNgApprovalPolicy(
-			"df60ff9e-4027-11d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST1",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST1",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgApprovalPolicy policy2 = new VraNgApprovalPolicy(
-			"df60ff9e-4027-12d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST2",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST2",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgApprovalPolicy policy3 = new VraNgApprovalPolicy(
-			"df60ff9e-4027-13d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST3",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST3",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgApprovalPolicy policy4 = new VraNgApprovalPolicy(
-			"df60ff9e-4027-14d1-a2b5-5229b3cee282",
-			"AP01",
-			"com.vmware.policy.approval",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST4",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"AP01",
+				"com.vmware.policy.approval",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST4",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, Collections.singletonList("AP01"), null);
 		// // GIVEN
@@ -500,17 +496,16 @@ public class VraNgApprovalPolicyStoreTest  {
 		when(restClient.getApprovalPolicy("df60ff9e-4027-13d1-a2b5-5229b3cee282")).thenReturn(policy3);
 		when(restClient.getApprovalPolicy("df60ff9e-4027-14d1-a2b5-5229b3cee282")).thenReturn(policy4);
 
-
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, approvalPolicy).toFile();
 
 		// TEST
 		store.exportContent();
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "AP01.json", "AP01_1.json", "AP01_2.json", "AP01_3.json", "AP01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "AP01.json", "AP01_1.json", "AP01_2.json", "AP01_3.json", "AP01_4.json" });
 	}
-
 
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgContentSharingPolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgContentSharingPolicyStoreTest.java
@@ -132,7 +132,6 @@ public class VraNgContentSharingPolicyStoreTest {
 		this.scope2 = String.format("projectId%s", nextProject++);
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn(organization.getId());
 		when(config.getOrgName()).thenReturn(organization.getName());
 		when(restClient.getOrganizationById(this.organization.getId())).thenReturn(this.organization);
 		when(restClient.getOrganizationByName(this.organization.getName())).thenReturn(this.organization);
@@ -165,7 +164,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		// TEST
 		store.exportContent();
 
-		File contentSharingPolicyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths
+				.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
 
 		// VERIFY
 		verify(restClient, never()).getContentSharingPolicies();
@@ -178,10 +178,14 @@ public class VraNgContentSharingPolicyStoreTest {
 	void testExportContentWithAllContentSharingPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllContentSharingPolicies");
 
-		VraNgContentSharingPolicy csPolicy1 = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe87", "cs",
-				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy csPolicy2 = new VraNgContentSharingPolicy("94824034-ef7b-4728-a6c2-fb440aff590c", "testing",
-				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1, this.organization.getName());
+		VraNgContentSharingPolicy csPolicy1 = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe87",
+				"cs",
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1,
+				this.organization.getName());
+		VraNgContentSharingPolicy csPolicy2 = new VraNgContentSharingPolicy("94824034-ef7b-4728-a6c2-fb440aff590c",
+				"testing",
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1,
+				this.organization.getName());
 
 		List<VraNgContentSharingPolicy> policies = Arrays.asList(csPolicy1, csPolicy2);
 
@@ -195,7 +199,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		store.exportContent();
 
 		// VERIFY
-		File contentSharingPolicyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths
+				.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
 		assertEquals(2, contentSharingPolicyFolder.listFiles().length);
 	}
 
@@ -203,7 +208,8 @@ public class VraNgContentSharingPolicyStoreTest {
 	void testExportContentWithSpecificContentSharingPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithSpecificContentSharingPolicies");
 
-		VraNgContentSharingPolicy csPolicy = new VraNgContentSharingPolicy("1", "cs", "com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST",
+		VraNgContentSharingPolicy csPolicy = new VraNgContentSharingPolicy("1", "cs",
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST",
 				new VraNgDefinition(), this.scope1, this.organization.getName());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Arrays.asList("cs"), null, null, null, null, null);
 		// // GIVEN
@@ -214,7 +220,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		// TEST
 		store.exportContent();
 
-		File contentSharingPolicyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths
+				.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, contentSharingPolicyFolder.listFiles().length);
@@ -225,13 +232,15 @@ public class VraNgContentSharingPolicyStoreTest {
 		System.out.println("testImportContentUpdate");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Arrays.asList("cs"), null, null, null, null, null);
 		VraNgContentSharingPolicy csPolicy = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe87", "cs",
-				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1, this.organization.getName());
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1,
+				this.organization.getName());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
 
 		fsMocks.contentSharingFsMocks().addContentSharingPolicy(csPolicy);
-		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy)
+				.toFile();
 		AssertionsHelper.assertFolderContainsFiles(contentSharingPolicyFolder, new String[] { "cs.json" });
 
 		when(restClient.getContentSharingPolicies()).thenReturn(Arrays.asList(csPolicy));
@@ -248,18 +257,22 @@ public class VraNgContentSharingPolicyStoreTest {
 	void testImportContentCreate() {
 		System.out.println("testImportContentCreate");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Arrays.asList("test"), null, null, null, null, null);
-		VraNgContentSharingPolicy csPolicy = new VraNgContentSharingPolicy("1", "test", "com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST",
+		VraNgContentSharingPolicy csPolicy = new VraNgContentSharingPolicy("1", "test",
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST",
 				new VraNgDefinition(), this.scope1, this.organization.getName());
 
-		VraNgContentSharingPolicy csPolicyFromServer = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe87", "cs",
-				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1, this.organization.getName());
+		VraNgContentSharingPolicy csPolicyFromServer = new VraNgContentSharingPolicy(
+				"679daee9-d63d-4ce2-9ee1-d4336861fe87", "cs",
+				"com.vmware.policy.catalog.entitlement", "1", "1", "HARD", "TEST", new VraNgDefinition(), this.scope1,
+				this.organization.getName());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
 
 		fsMocks.contentSharingFsMocks().addContentSharingPolicy(csPolicy);
 
-		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy)
+				.toFile();
 		AssertionsHelper.assertFolderContainsFiles(contentSharingPolicyFolder, new String[] { "test.json" });
 
 		when(restClient.getContentSharingPolicies()).thenReturn(Arrays.asList());
@@ -336,7 +349,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgContentSharingPolicy policy = new VraNgContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST", new VraNgDefinition(),
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Collections.singletonList("CS01"), null, null, null, null, null);
 		// // GIVEN
@@ -344,7 +358,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		when(restClient.getContentSharingPolicies()).thenReturn(Collections.singletonList(policy));
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
-		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy)
+				.toFile();
 
 		fsMocks.contentSharingFsMocks().addContentSharingPolicy(policy);
 		// TEST
@@ -358,12 +373,15 @@ public class VraNgContentSharingPolicyStoreTest {
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateFiles() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateFiles");
-		VraNgContentSharingPolicy policyInFile = new VraNgContentSharingPolicy("d160119e-4027-48d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "SOFT", "TEST", new VraNgDefinition(),
+		VraNgContentSharingPolicy policyInFile = new VraNgContentSharingPolicy("d160119e-4027-48d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "SOFT",
+				"TEST", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
 
 		VraNgContentSharingPolicy policy = new VraNgContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST", new VraNgDefinition(),
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Collections.singletonList("CS01"), null, null, null, null, null);
 		// // GIVEN
@@ -371,7 +389,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		when(restClient.getContentSharingPolicies()).thenReturn(Collections.singletonList(policy));
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
-		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy)
+				.toFile();
 
 		fsMocks.contentSharingFsMocks().addContentSharingPolicy(policyInFile);
 		policyInFile.setName("CS01_1");
@@ -386,7 +405,8 @@ public class VraNgContentSharingPolicyStoreTest {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "CS01.json", "CS01_1.json", "CS01_2.json", "CS01_3.json", "CS01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "CS01.json", "CS01_1.json", "CS01_2.json", "CS01_3.json", "CS01_4.json" });
 	}
 
 	@Test
@@ -394,28 +414,40 @@ public class VraNgContentSharingPolicyStoreTest {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateNames");
 
 		VraNgContentSharingPolicy policy = new VraNgContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST", new VraNgDefinition(),
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy policy1 = new VraNgContentSharingPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST1", new VraNgDefinition(),
+		VraNgContentSharingPolicy policy1 = new VraNgContentSharingPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST1", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy policy2 = new VraNgContentSharingPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST2", new VraNgDefinition(),
+		VraNgContentSharingPolicy policy2 = new VraNgContentSharingPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST2", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy policy3 = new VraNgContentSharingPolicy("df60ff9e-4027-13d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST3", new VraNgDefinition(),
+		VraNgContentSharingPolicy policy3 = new VraNgContentSharingPolicy("df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST3", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy policy4 = new VraNgContentSharingPolicy("df60ff9e-4027-14d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST4", new VraNgDefinition(),
+		VraNgContentSharingPolicy policy4 = new VraNgContentSharingPolicy("df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST4", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
-		VraNgContentSharingPolicy policy5 = new VraNgContentSharingPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282", "CS01",
-				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD", "TEST5", new VraNgDefinition(),
+		VraNgContentSharingPolicy policy5 = new VraNgContentSharingPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282",
+				"CS01",
+				"com.vmware.policy.catalog.entitlement", "b899c648-bf84-4d35-a61c-db212ecb4c1e", "VIDM-L-01A", "HARD",
+				"TEST5", new VraNgDefinition(),
 				this.scope1, this.organization.getName());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(Collections.singletonList("CS01"), null, null, null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getContentSharingPolicies()).thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
+		when(restClient.getContentSharingPolicies())
+				.thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282")).thenReturn(policy1);
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282")).thenReturn(policy2);
@@ -423,7 +455,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-14d1-a2b5-5229b3cee282")).thenReturn(policy4);
 		when(restClient.getContentSharingPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282")).thenReturn(policy5);
 
-		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy).toFile();
+		File policyFolder = Paths.get(tempFolder.getRoot().getPath(), dirContentSharingPolicies, contentSharingPolicy)
+				.toFile();
 
 		// TEST
 		store.exportContent();
@@ -431,7 +464,8 @@ public class VraNgContentSharingPolicyStoreTest {
 		// VERIFY
 		assertEquals(6, Objects.requireNonNull(policyFolder.listFiles()).length);
 		AssertionsHelper.assertFolderContainsFiles(policyFolder,
-				new String[] { "CS01.json", "CS01_1.json", "CS01_2.json", "CS01_3.json", "CS01_4.json", "CS01_5.json" });
+				new String[] { "CS01.json", "CS01_1.json", "CS01_2.json", "CS01_3.json", "CS01_4.json",
+						"CS01_5.json" });
 	}
 
 	private VraNgContentSharingPolicy prepareTestObjects(String scope, String organization) {
@@ -453,24 +487,32 @@ public class VraNgContentSharingPolicyStoreTest {
 		vraNgItem.setType("CATALOG_ITEM_IDENTIFIER");
 		entitledUser.setItems(Arrays.asList(new VraNgItem[] { vraNgItem }));
 
-		VraNgContentSharingPolicy csPolicyFromFile = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86", "test",
-				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST", contentSourcesDefinition, scope, organization);
+		VraNgContentSharingPolicy csPolicyFromFile = new VraNgContentSharingPolicy(
+				"679daee9-d63d-4ce2-9ee1-d4336861fe86", "test",
+				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST",
+				contentSourcesDefinition, scope, organization);
 
-		VraNgContentSharingPolicy csPolicyFromServer2 = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86", "test",
-				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST", contentSourcesDefinition, scope, organization);
+		VraNgContentSharingPolicy csPolicyFromServer2 = new VraNgContentSharingPolicy(
+				"679daee9-d63d-4ce2-9ee1-d4336861fe86", "test",
+				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST",
+				contentSourcesDefinition, scope, organization);
 
-		VraNgContentSharingPolicy toBeCreated = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86", "test",
-				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST", contentItemsDefinition, scope, organization);
+		VraNgContentSharingPolicy toBeCreated = new VraNgContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86",
+				"test",
+				"com.vmware.policy.catalog.entitlement", "1", this.organization.getId(), "HARD", "TEST",
+				contentItemsDefinition, scope, organization);
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
 
 		fsMocks.contentSharingFsMocks().addContentSharingPolicy(csPolicyFromFile);
-		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy).toFile();
+		File contentSharingPolicyFolder = Paths.get(fsMocks.getTempFolderProjectPath().getPath(), contentSharingPolicy)
+				.toFile();
 		AssertionsHelper.assertFolderContainsFiles(contentSharingPolicyFolder, new String[] { "test.json" });
 
 		when(restClient.getContentSharingPolicyIdByName("test")).thenReturn("679daee9-d63d-4ce2-9ee1-d4336861fe86");
 		when(restClient.getContentSharingPolicies()).thenReturn(Arrays.asList(csPolicyFromServer2));
-		when(restClient.getContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86")).thenReturn(csPolicyFromServer2);
+		when(restClient.getContentSharingPolicy("679daee9-d63d-4ce2-9ee1-d4336861fe86"))
+				.thenReturn(csPolicyFromServer2);
 		when(restClient.getProjectIdByName(Mockito.anyString())).thenReturn("1");
 
 		return toBeCreated;

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgCustomResourceStoreTest.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-
 import com.vmware.pscoe.iac.artifact.configuration.ConfigurationVraNg;
 import com.vmware.pscoe.iac.artifact.helpers.AssertionsHelper;
 import com.vmware.pscoe.iac.artifact.helpers.FsMocks;
@@ -71,9 +70,9 @@ public class VraNgCustomResourceStoreTest {
 	protected FsMocks fsMocks;
 	protected VraNgOrganization org;
 
-	protected static String PROJECT_ID	= "projectId";
-	protected static String ORG_ID		= "orgId";
-	protected static String ORG_NAME	= "testOrg";
+	protected static String PROJECT_ID = "projectId";
+	protected static String ORG_ID = "orgId";
+	protected static String ORG_NAME = "testOrg";
 
 	@BeforeEach
 	void init() {
@@ -83,19 +82,20 @@ public class VraNgCustomResourceStoreTest {
 			throw new RuntimeException("Could not create a temp folder");
 		}
 
-		fsMocks 				= new FsMocks(tempFolder.getRoot());
-		store 					= new VraNgCustomResourceStore();
-		restClient 				= Mockito.mock(RestClientVraNg.class);
-		pkg 					= PackageFactory.getInstance(PackageType.VRANG, tempFolder.getRoot());
-		config 					= Mockito.mock(ConfigurationVraNg.class);
-		vraNgPackageDescriptor 	= Mockito.mock(VraNgPackageDescriptor.class);
-		org					 	= Mockito.mock(VraNgOrganization.class);
+		fsMocks = new FsMocks(tempFolder.getRoot());
+		store = new VraNgCustomResourceStore();
+		restClient = Mockito.mock(RestClientVraNg.class);
+		pkg = PackageFactory.getInstance(PackageType.VRANG, tempFolder.getRoot());
+		config = Mockito.mock(ConfigurationVraNg.class);
+		vraNgPackageDescriptor = Mockito.mock(VraNgPackageDescriptor.class);
+		org = Mockito.mock(VraNgOrganization.class);
 
-		when( config.getOrgId() ).thenReturn( ORG_ID );
-		when( restClient.getOrganizationById(any()) ).thenReturn( org );
-		when( org.getId() ).thenReturn( ORG_ID );
-		when( org.getName() ).thenReturn( ORG_NAME );
-		when( org.getRefLink() ).thenReturn( "reflink" );
+		when(restClient.getOrganizationById(any())).thenReturn(org);
+		when(restClient.getOrganizationByName(any())).thenReturn(org);
+		when(config.getOrgName()).thenReturn(ORG_NAME);
+		when(org.getId()).thenReturn(ORG_ID);
+		when(org.getName()).thenReturn(ORG_NAME);
+		when(org.getRefLink()).thenReturn("reflink");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
 		System.out.println("==========================================================");
@@ -113,7 +113,7 @@ public class VraNgCustomResourceStoreTest {
 	}
 
 	@Test
-	void testImportCustomResourcesWhenIdNotExistsInVroAndExistsInJson() throws IOException{
+	void testImportCustomResourcesWhenIdNotExistsInVroAndExistsInJson() throws IOException {
 		// GIVEN
 		List<String> list = new ArrayList<String>();
 		list.add("Avi Load Balancer L3DSR");
@@ -129,30 +129,31 @@ public class VraNgCustomResourceStoreTest {
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
 
-		// 'comparator' will be used for comparison between expected value 
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
 		mockBuilder = new CustomResourceMockBuilder();
-		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
+		String comparator = mockBuilder.withoutIdInRawData().setOrgId(ORG_ID).removeFormDefinitionIds().build()
+				.getJson().toString();
 
-		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
-		when( restClient.getVraWorkflowIntegration( any()) ).thenReturn( vro );
-		when( restClient.getAllCustomResources() ).thenReturn( new HashMap<String, VraNgCustomResource>() );
-		doNothing().when( restClient ).importCustomResource( anyString(), anyString() );
-		doNothing().when( restClient ).deleteCustomResource( anyString(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(new HashMap<String, VraNgCustomResource>());
+		doNothing().when(restClient).importCustomResource(anyString(), anyString());
+		doNothing().when(restClient).deleteCustomResource(anyString(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
-		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
+		ArgumentCaptor<String> cr = ArgumentCaptor.forClass(String.class);
 
 		// VERIFY
-		verify( restClient, times( 3 ) ).getProjectId();
-		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
-		verify( restClient, never() ).deleteCustomResource( any(), anyString() );
+		verify(restClient, times(3)).getProjectId();
+		verify(restClient, times(1)).getVraWorkflowIntegration(any());
+		verify(restClient, times(1)).getAllCustomResources();
+		verify(restClient, times(1)).importCustomResource(any(), cr.capture());
+		verify(restClient, never()).deleteCustomResource(any(), anyString());
 
-		assertEquals( comparator, cr.getValue() );
+		assertEquals(comparator, cr.getValue());
 	}
 
 	@Test
@@ -173,45 +174,47 @@ public class VraNgCustomResourceStoreTest {
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
 
-		// 'comparator' will be used for comparison between expected value 
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
-		mockBuilder	= new CustomResourceMockBuilder();
-		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
+		mockBuilder = new CustomResourceMockBuilder();
+		String comparator = mockBuilder.withoutIdInRawData().setOrgId(ORG_ID).removeFormDefinitionIds().build()
+				.getJson().toString();
 
-		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
-		when( restClient.getAllCustomResources() ).thenReturn( new HashMap<String, VraNgCustomResource>() );
-		doNothing().when( restClient ).importCustomResource( anyString(), anyString() );
-		doNothing().when( restClient ).deleteCustomResource( anyString(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(new HashMap<String, VraNgCustomResource>());
+		doNothing().when(restClient).importCustomResource(anyString(), anyString());
+		doNothing().when(restClient).deleteCustomResource(anyString(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
-		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
+		ArgumentCaptor<String> cr = ArgumentCaptor.forClass(String.class);
 
 		// VERIFY
-		verify( restClient, times( 3 ) ).getProjectId();
-		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
-		verify( restClient, never() ).deleteCustomResource( any(), anyString() );
+		verify(restClient, times(3)).getProjectId();
+		verify(restClient, times(1)).getVraWorkflowIntegration(any());
+		verify(restClient, times(1)).getAllCustomResources();
+		verify(restClient, times(1)).importCustomResource(any(), cr.capture());
+		verify(restClient, never()).deleteCustomResource(any(), anyString());
 
-		assertEquals( comparator, cr.getValue() );
+		assertEquals(comparator, cr.getValue());
 	}
 
 	@ParameterizedTest
 	@ValueSource(strings = {
-							"AmpersandCharacter&",
-							"DollarCharacter$",
-							"_UnderscoreInfront",
-							"UnderscoreBehind_",
-							".DotInfront",
-							"DotBehind.",
-							" SpaceInfront",
-							"SpaceBehind ",
-							"Space InMiddle"
+			"AmpersandCharacter&",
+			"DollarCharacter$",
+			"_UnderscoreInfront",
+			"UnderscoreBehind_",
+			".DotInfront",
+			"DotBehind.",
+			" SpaceInfront",
+			"SpaceBehind ",
+			"Space InMiddle"
 	})
-	void testImportCustomResourcesWhenAdditionalActionNamesDoNotPassValidation(String wrongAdditionalActionName)  throws IOException{
+	void testImportCustomResourcesWhenAdditionalActionNamesDoNotPassValidation(String wrongAdditionalActionName)
+			throws IOException {
 		// GIVEN
 		List<String> list = new ArrayList<String>();
 		list.add("Avi Load Balancer L3DSR");
@@ -219,19 +222,21 @@ public class VraNgCustomResourceStoreTest {
 
 		// Create mock Custom Resource - should contain property 'id'
 		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
-		JsonArray additionalActions = JsonParser.parseString(mockBuilder.build().getJson()).getAsJsonObject().get("additionalActions").getAsJsonArray();
+		JsonArray additionalActions = JsonParser.parseString(mockBuilder.build().getJson()).getAsJsonObject()
+				.get("additionalActions").getAsJsonArray();
 		additionalActions.get(0).getAsJsonObject().addProperty("name", wrongAdditionalActionName);
-		VraNgCustomResource mockResource = mockBuilder.setAdditionalActions(additionalActions).setOrgId("WRONG").build();
+		VraNgCustomResource mockResource = mockBuilder.setAdditionalActions(additionalActions).setOrgId("WRONG")
+				.build();
 
 		// Create mock return value of getAllCustomResources().
 		// These represent the retrieved Custom Resources from the environment
 		// and are expected to contain property 'id'.
 		JsonElement mockResourceElement = JsonParser.parseString(mockResource.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
+		map.put(id, mockResource);
 
 		// Create mock vRO Integration
 		VraNgIntegration vro = new VraNgIntegration();
@@ -240,21 +245,20 @@ public class VraNgCustomResourceStoreTest {
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
 
-		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
-		when( config.getOrgId() ).thenReturn( ORG_ID );
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
-		when( restClient.getAllCustomResources() ).thenReturn( map );
-		doNothing().when( restClient ).importCustomResource( any(), anyString() );
-		doNothing().when( restClient ).deleteCustomResource( any(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(map);
+		doNothing().when(restClient).importCustomResource(any(), anyString());
+		doNothing().when(restClient).deleteCustomResource(any(), anyString());
 
 		// START TEST
-		assertThrows( RuntimeException.class, () -> {
+		assertThrows(RuntimeException.class, () -> {
 			store.importContent(tempFolder.getRoot());
 		});
 	}
 
 	@Test
-	void testImportCustomResourcesWhenIdExistsInVroAndInJson()  throws IOException{
+	void testImportCustomResourcesWhenIdExistsInVroAndInJson() throws IOException {
 		// GIVEN
 		List<String> list = new ArrayList<String>();
 		list.add("Avi Load Balancer L3DSR");
@@ -264,51 +268,52 @@ public class VraNgCustomResourceStoreTest {
 		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResource = mockBuilder.setOrgId("WRONG").build();
 
-		// Create mock return value of getAllCustomResources(). 
-		// These represent the retrieved Custom Resources from the environment 
+		// Create mock return value of getAllCustomResources().
+		// These represent the retrieved Custom Resources from the environment
 		// and are expected to contain property 'id'.
 		JsonElement mockResourceElement = JsonParser.parseString(mockResource.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
-		
+		map.put(id, mockResource);
+
 		// Create mock vRO Integration
 		VraNgIntegration vro = new VraNgIntegration();
 		vro.setEndpointConfigurationLink("dummy");
 		vro.setName("dummy_name");
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
-		
-		// 'comparator' will be used for comparison between expected value 
+
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
 		mockBuilder = new CustomResourceMockBuilder();
-		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson();
+		String comparator = mockBuilder.withoutIdInRawData().setOrgId(ORG_ID).removeFormDefinitionIds().build()
+				.getJson();
 
-		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
-		when( restClient.getAllCustomResources() ).thenReturn( map );
-		doNothing().when( restClient ).importCustomResource( any(), anyString() );
-		doNothing().when( restClient ).deleteCustomResource( any(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(map);
+		doNothing().when(restClient).importCustomResource(any(), anyString());
+		doNothing().when(restClient).deleteCustomResource(any(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
-		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
+		ArgumentCaptor<String> cr = ArgumentCaptor.forClass(String.class);
 
 		// VERIFY
-		verify( restClient, times( 3 ) ).getProjectId();
-		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
-		verify( restClient, times( 1 ) ).deleteCustomResource( any(), anyString() );
+		verify(restClient, times(3)).getProjectId();
+		verify(restClient, times(1)).getVraWorkflowIntegration(any());
+		verify(restClient, times(1)).getAllCustomResources();
+		verify(restClient, times(1)).importCustomResource(any(), cr.capture());
+		verify(restClient, times(1)).deleteCustomResource(any(), anyString());
 
-		assertEquals( comparator, cr.getValue() );
+		assertEquals(comparator, cr.getValue());
 	}
 
 	@Test
-	void testImportCustomResourcesWhenIdExistsInVroAndHasDeployments()  throws IOException{
+	void testImportCustomResourcesWhenIdExistsInVroAndHasDeployments() throws IOException {
 		// GIVEN
 		List<String> list = new ArrayList<String>();
 		list.add("Avi Load Balancer L3DSR");
@@ -318,44 +323,46 @@ public class VraNgCustomResourceStoreTest {
 		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResource = mockBuilder.setOrgId("WRONG").build();
 
-		// Create mock return value of getAllCustomResources(). 
-		// These represent the retrieved Custom Resources from the environment 
+		// Create mock return value of getAllCustomResources().
+		// These represent the retrieved Custom Resources from the environment
 		// and are expected to contain property 'id'.
 		JsonElement mockResourceElement = JsonParser.parseString(mockResource.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
-		
+		map.put(id, mockResource);
+
 		// Create mock vRO Integration
 		VraNgIntegration vro = new VraNgIntegration();
 		vro.setEndpointConfigurationLink("dummy");
 		vro.setName("dummy_name");
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
-		
-		// 'comparator' will be used for comparison between expected value 
+
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
 		mockBuilder = new CustomResourceMockBuilder();
-		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
+		String comparator = mockBuilder.withoutIdInRawData().setOrgId(ORG_ID).removeFormDefinitionIds().build()
+				.getJson().toString();
 
-		when( restClient.getProjectId() ).thenReturn( PROJECT_ID );
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn( vro );
-		when( restClient.getAllCustomResources() ).thenReturn( map );
-		doNothing().when( restClient ).importCustomResource( any(), anyString() );
-		doThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Resource type cannot be deleted as there are active resources attached to it"))
-			.when( restClient ).deleteCustomResource( any(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(map);
+		doNothing().when(restClient).importCustomResource(any(), anyString());
+		doThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST,
+				"Resource type cannot be deleted as there are active resources attached to it"))
+				.when(restClient).deleteCustomResource(any(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, times( 3 ) ).getProjectId();
-		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		verify( restClient, times(1) ).importCustomResource( any(), anyString() );
-		verify( restClient, times( 1 ) ).deleteCustomResource( any(), anyString() );
+		verify(restClient, times(3)).getProjectId();
+		verify(restClient, times(1)).getVraWorkflowIntegration(any());
+		verify(restClient, times(1)).getAllCustomResources();
+		verify(restClient, times(1)).importCustomResource(any(), anyString());
+		verify(restClient, times(1)).deleteCustomResource(any(), anyString());
 	}
 
 	@Test
@@ -369,18 +376,17 @@ public class VraNgCustomResourceStoreTest {
 		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResource = mockBuilder.setOrgId("WRONG").withoutIdInRawData().build();
 
-
-		// Create mock return value of getAllCustomResources(). 
-		// These represent the retrieved Custom Resources from the environment 
+		// Create mock return value of getAllCustomResources().
+		// These represent the retrieved Custom Resources from the environment
 		// and are expected to contain property 'id'.
 		mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResourceWithId = mockBuilder.setOrgId("WRONG").build();
 		JsonElement mockResourceElement = JsonParser.parseString(mockResourceWithId.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
+		map.put(id, mockResource);
 
 		// Create mock vRO Integration
 		VraNgIntegration vro = new VraNgIntegration();
@@ -388,35 +394,36 @@ public class VraNgCustomResourceStoreTest {
 		vro.setName("dummy_name");
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
-		
-		// 'comparator' will be used for comparison between expected value 
+
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
 		mockBuilder = new CustomResourceMockBuilder();
-		String comparator = mockBuilder.withoutIdInRawData().setOrgId( ORG_ID ).removeFormDefinitionIds().build().getJson().toString();
+		String comparator = mockBuilder.withoutIdInRawData().setOrgId(ORG_ID).removeFormDefinitionIds().build()
+				.getJson().toString();
 
-		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn(vro);
-		when( restClient.getAllCustomResources() ).thenReturn(map);
-		doNothing().when( restClient ).importCustomResource( any(), anyString());
-		doNothing().when( restClient ).deleteCustomResource( any(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(map);
+		doNothing().when(restClient).importCustomResource(any(), anyString());
+		doNothing().when(restClient).deleteCustomResource(any(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
-		ArgumentCaptor<String> cr = ArgumentCaptor.forClass( String.class );
+		ArgumentCaptor<String> cr = ArgumentCaptor.forClass(String.class);
 
 		// VERIFY
-		verify( restClient, times( 3 ) ).getProjectId();
-		verify( restClient, times( 1 ) ).getVraWorkflowIntegration( any() );
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		verify( restClient, times( 1 ) ).importCustomResource( any(), cr.capture() );
-		verify( restClient, times( 1 ) ).deleteCustomResource( any(), anyString() );
+		verify(restClient, times(3)).getProjectId();
+		verify(restClient, times(1)).getVraWorkflowIntegration(any());
+		verify(restClient, times(1)).getAllCustomResources();
+		verify(restClient, times(1)).importCustomResource(any(), cr.capture());
+		verify(restClient, times(1)).deleteCustomResource(any(), anyString());
 
-		assertEquals( comparator, cr.getValue() );
+		assertEquals(comparator, cr.getValue());
 	}
 
 	@Test
-	void testImportCustomResourcesWhenNotInConfiguration () throws IOException {
+	void testImportCustomResourcesWhenNotInConfiguration() throws IOException {
 		// GIVEN
 		// Create mock Custom Resource - should not contain property 'id'
 		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
@@ -426,17 +433,17 @@ public class VraNgCustomResourceStoreTest {
 		list.add("name");
 		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(list);
 
-		// Create mock return value of getAllCustomResources(). 
-		// These represent the retrieved Custom Resources from the environment 
+		// Create mock return value of getAllCustomResources().
+		// These represent the retrieved Custom Resources from the environment
 		// and are expected to contain property 'id'.
 		mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResourceWithId = mockBuilder.setOrgId("WRONG").build();
 		JsonElement mockResourceElement = JsonParser.parseString(mockResourceWithId.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
+		map.put(id, mockResource);
 
 		// Create mock vRO Integration
 		VraNgIntegration vro = new VraNgIntegration();
@@ -444,45 +451,46 @@ public class VraNgCustomResourceStoreTest {
 		vro.setName("dummy_name");
 
 		fsMocks.customResourceFsMocks().addCustomResource(mockResource);
-		
-		// 'comparator' will be used for comparison between expected value 
+
+		// 'comparator' will be used for comparison between expected value
 		// and passed value in importCustomResource()
 		mockBuilder = new CustomResourceMockBuilder();
-		String comparator = mockBuilder.setOrgId( ORG_ID ).removeFormDefinitionIds().withoutIdInRawData().build().getJson().toString();
+		String comparator = mockBuilder.setOrgId(ORG_ID).removeFormDefinitionIds().withoutIdInRawData().build()
+				.getJson().toString();
 
-		when( restClient.getProjectId() ).thenReturn(PROJECT_ID);
-		when( restClient.getVraWorkflowIntegration(any()) ).thenReturn(vro);
-		when( restClient.getAllCustomResources() ).thenReturn(map);
-		doNothing().when( restClient ).importCustomResource( any(), anyString());
-		doNothing().when( restClient ).deleteCustomResource( any(), anyString() );
+		when(restClient.getProjectId()).thenReturn(PROJECT_ID);
+		when(restClient.getVraWorkflowIntegration(any())).thenReturn(vro);
+		when(restClient.getAllCustomResources()).thenReturn(map);
+		doNothing().when(restClient).importCustomResource(any(), anyString());
+		doNothing().when(restClient).deleteCustomResource(any(), anyString());
 
 		// START TEST
 		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, never() ).importCustomResource( any(), anyString() );
+		verify(restClient, never()).importCustomResource(any(), anyString());
 	}
 
 	@Test
 	void testExportCustomResourcesRemovesIdOnSave() throws IOException {
 		// GIVEN
-		// Create mock Custom Resource 
-		CustomResourceMockBuilder	mockBuilder = new CustomResourceMockBuilder();
+		// Create mock Custom Resource
+		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
 		VraNgCustomResource mockResource = mockBuilder.setOrgId("orgId").build();
 		JsonElement mockResourceElement = JsonParser.parseString(mockResource.getJson());
 		JsonObject object = mockResourceElement.getAsJsonObject();
 		String name = mockResource.getName();
-		String id = object.get( "id" ).toString();
+		String id = object.get("id").toString();
 		String fileName = name.concat(".json");
 
 		mockBuilder = new CustomResourceMockBuilder();
 		String expectedFileContent = mockBuilder.setOrgId("orgId").withoutIdInRawData().build().getJson();
 
 		List<String> list = new ArrayList<String>();
-		list.add( name );
+		list.add(name);
 
 		HashMap<String, VraNgCustomResource> map = new HashMap<String, VraNgCustomResource>();
-		map.put( id, mockResource );
+		map.put(id, mockResource);
 
 		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(list);
 		when(restClient.getAllCustomResources()).thenReturn(map);
@@ -491,36 +499,35 @@ public class VraNgCustomResourceStoreTest {
 		store.exportContent();
 
 		// VERIFY
-		verify( vraNgPackageDescriptor, times( 1 ) ).getCustomResource();
-		verify( restClient, times( 1 ) ).getAllCustomResources();
-		assertEquals( 1, Objects.requireNonNull(fsMocks.getTempFolderProjectPath().listFiles()).length );
-		assertEquals( expectedFileContent, getFileContent( fsMocks.getTempFolderProjectPath(), fileName ));
-		
-		String[] expectedFiles	= { fileName };
-		AssertionsHelper.assertFolderContainsFiles( fsMocks.getTempFolderProjectPath(), expectedFiles );
-	
+		verify(vraNgPackageDescriptor, times(1)).getCustomResource();
+		verify(restClient, times(1)).getAllCustomResources();
+		assertEquals(1, Objects.requireNonNull(fsMocks.getTempFolderProjectPath().listFiles()).length);
+		assertEquals(expectedFileContent, getFileContent(fsMocks.getTempFolderProjectPath(), fileName));
+
+		String[] expectedFiles = { fileName };
+		AssertionsHelper.assertFolderContainsFiles(fsMocks.getTempFolderProjectPath(), expectedFiles);
+
 	}
 
-	
 	/**
 	 * Return content of a specific item in the given folder.
 	 * Throws if missing
 	 *
-	 * @param	folder -> the folder to search in
-	 * @param	itemName - The item name to search for
+	 * @param folder   -> the folder to search in
+	 * @param itemName - The item name to search for
 	 *
-	 * @return	File content as String
+	 * @return File content as String
 	 */
-	private String getFileContent( File folder, String itemName ) {
+	private String getFileContent(File folder, String itemName) {
 		File file = fsMocks.findItemByNameInFolder(folder, itemName);
-		try{			
-			String content = FileUtils.readFileToString( file, "UTF-8" );
-			if(content != null){
+		try {
+			String content = FileUtils.readFileToString(file, "UTF-8");
+			if (content != null) {
 				Gson gson = new GsonBuilder().setLenient().setPrettyPrinting().serializeNulls().create();
 				JsonObject customResourceJsonElement = gson.fromJson(content, JsonObject.class);
 				return customResourceJsonElement.toString();
 			}
-		}catch (IOException e) {
+		} catch (IOException e) {
 			throw new RuntimeException("Error reading from file: " + file.getPath(), e);
 		}
 		return "";
@@ -528,79 +535,82 @@ public class VraNgCustomResourceStoreTest {
 
 	@Test
 	void testExportContentWithNoCustomResources() {
-		//GIVEN 
-		when( vraNgPackageDescriptor.getCustomResource()).thenReturn(new ArrayList<String>());
+		// GIVEN
+		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(new ArrayList<String>());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
-		//VERIFY
-		verify( restClient, never() ).getAllCustomResources();
-		assertEquals( 0, tempFolder.getRoot().listFiles().length );
+		// VERIFY
+		verify(restClient, never()).getAllCustomResources();
+		assertEquals(0, tempFolder.getRoot().listFiles().length);
 	}
-	
 
 	@Test
 	void testExportContentWithAllCustomResources() throws IOException {
-		//GIVEN 
+		// GIVEN
 		Map<String, VraNgCustomResource> customResources = new HashMap<>();
-		CustomResourceMockBuilder	mockBuilder = new CustomResourceMockBuilder();
+		CustomResourceMockBuilder mockBuilder = new CustomResourceMockBuilder();
 
-		customResources.put( "Avi Load Balancer L3DSR", mockBuilder.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
+		customResources.put("Avi Load Balancer L3DSR",
+				mockBuilder.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
 
-		when( vraNgPackageDescriptor.getCustomResource()).thenReturn(null);
-		when( restClient.getAllCustomResources()).thenReturn( customResources );
+		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(null);
+		when(restClient.getAllCustomResources()).thenReturn(customResources);
 
-		//TEST
+		// TEST
 		store.exportContent();
 
-		String[] expectedCustomResource	= { "Avi Load Balancer L3DSR.json" };
+		String[] expectedCustomResource = { "Avi Load Balancer L3DSR.json" };
 
 		// VERIFY
-		AssertionsHelper.assertFolderContainsFiles( fsMocks.getTempFolderProjectPath(), expectedCustomResource );
+		AssertionsHelper.assertFolderContainsFiles(fsMocks.getTempFolderProjectPath(), expectedCustomResource);
 	}
 
-
 	@Test
-	void testExportContentWithSpecificCustomResources() throws IOException{
-		//GIVEN 
+	void testExportContentWithSpecificCustomResources() throws IOException {
+		// GIVEN
 		Map<String, VraNgCustomResource> customResources = new HashMap<>();
 		CustomResourceMockBuilder mockBuider = new CustomResourceMockBuilder();
 
-		customResources.put( "Avi Load Balancer L3DSR", mockBuider.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
-		customResources.put( "Ngnix Load Balancer", mockBuider.setDisplayNameInRawData("Ngnix Load Balancer L3DSR").build());
+		customResources.put("Avi Load Balancer L3DSR",
+				mockBuider.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
+		customResources.put("Ngnix Load Balancer",
+				mockBuider.setDisplayNameInRawData("Ngnix Load Balancer L3DSR").build());
 
 		List<String> customResourceNames = new ArrayList<>();
 		customResourceNames.add("Avi Load Balancer L3DSR");
 
-		when( vraNgPackageDescriptor.getCustomResource()).thenReturn(customResourceNames);
-		when( restClient.getAllCustomResources()).thenReturn( customResources );
+		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(customResourceNames);
+		when(restClient.getAllCustomResources()).thenReturn(customResources);
 
-		//TEST
+		// TEST
 		store.exportContent();
 
-		String[] expectedCustomResource	= { "Avi Load Balancer L3DSR.json" };
+		String[] expectedCustomResource = { "Avi Load Balancer L3DSR.json" };
 
 		// VERIFY
-		AssertionsHelper.assertFolderContainsFiles( fsMocks.getTempFolderProjectPath(), expectedCustomResource );
+		AssertionsHelper.assertFolderContainsFiles(fsMocks.getTempFolderProjectPath(), expectedCustomResource);
 	}
 
 	@Test
-	void testExportContentForNonExistingCustomResource() throws IOException{
-		//GIVEN 
+	void testExportContentForNonExistingCustomResource() throws IOException {
+		// GIVEN
 		Map<String, VraNgCustomResource> customResources = new HashMap<>();
 		CustomResourceMockBuilder mockBuider = new CustomResourceMockBuilder();
 
-		customResources.put( "Avi Load Balancer L3DSR", mockBuider.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
-		customResources.put( "Ngnix Load Balancer", mockBuider.setDisplayNameInRawData("Ngnix Load Balancer L3DSR").build());
+		customResources.put("Avi Load Balancer L3DSR",
+				mockBuider.setDisplayNameInRawData("Avi Load Balancer L3DSR").build());
+		customResources.put("Ngnix Load Balancer",
+				mockBuider.setDisplayNameInRawData("Ngnix Load Balancer L3DSR").build());
 
 		List<String> customResourceNames = new ArrayList<>();
 		customResourceNames.add("Not There");
 
-		when( vraNgPackageDescriptor.getCustomResource()).thenReturn(customResourceNames);
-		when( restClient.getAllCustomResources()).thenReturn( customResources );
+		when(vraNgPackageDescriptor.getCustomResource()).thenReturn(customResourceNames);
+		when(restClient.getAllCustomResources()).thenReturn(customResources);
 
-		//TEST
+		// TEST
 		assertThrows(IllegalStateException.class, () -> store.exportContent());
 	}
 

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgDay2ActionsPolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgDay2ActionsPolicyStoreTest.java
@@ -106,7 +106,6 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		org.setName("VIDM-L-01A");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
@@ -130,16 +129,16 @@ public class VraNgDay2ActionsPolicyStoreTest {
 	@Test
 	void testExportContentWithNoDay2ActionsPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithNoDay2ActionsPolicies");
-		//GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(new VraNgPolicy());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
 		File day2ActionsPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 
-		//VERIFY
+		// VERIFY
 		verify(restClient, never()).getDay2ActionsPolicies();
 		verify(restClient, never()).getDay2ActionsPolicy(anyString());
 
@@ -150,28 +149,28 @@ public class VraNgDay2ActionsPolicyStoreTest {
 	void testExportContentWithAllDay2ActionsPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllDay2ActionsPolicies");
 		VraNgDay2ActionsPolicy policy1 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDay2ActionsPolicy policy2 = new VraNgDay2ActionsPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"D2A02",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"D2A02",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		List<VraNgDay2ActionsPolicy> policies = Arrays.asList(policy1, policy2);
 
@@ -186,7 +185,7 @@ public class VraNgDay2ActionsPolicyStoreTest {
 
 		// VERIFY
 		File day2ActionsPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 		assertEquals(2, Objects.requireNonNull(day2ActionsPolicyFolder.listFiles()).length);
 	}
 
@@ -195,16 +194,16 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		System.out.println(this.getClass() + "testExportContentWithSpecificDay2ActionsPolicies");
 
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Collections.singletonList("D2A01"), null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -215,7 +214,7 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		store.exportContent();
 
 		File day2ActionsPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, Objects.requireNonNull(day2ActionsPolicyFolder.listFiles()).length);
@@ -225,16 +224,16 @@ public class VraNgDay2ActionsPolicyStoreTest {
 	void testImportContentWithUpdateLogic() {
 		System.out.println("testImportContentWithUpdateLogic");
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Collections.singletonList("D2A01"), null, null, null);
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -242,7 +241,7 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		fsMocks.getDay2ActionsPolicyFsMocks().addPolicy(policy);
 
 		File day2ActionsPolicyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), day2ActionsPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), day2ActionsPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(day2ActionsPolicyFolder, new String[] { "D2A01.json" });
 
@@ -256,34 +255,33 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		verify(restClient, times(1)).createDay2ActionsPolicy(any());
 	}
 
-
 	@Test
 	void testImportContentWithCreateLogic() {
 		System.out.println("testImportContentWithCreateLogic");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Arrays.asList("D2A01"), null, null, null);
 
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policyFromServer = new VraNgDay2ActionsPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"D2A02",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"D2A02",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -291,7 +289,7 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		fsMocks.getDay2ActionsPolicyFsMocks().addPolicy(policy);
 
 		File day2ActionsPolicyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), day2ActionsPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), day2ActionsPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(day2ActionsPolicyFolder, new String[] { "D2A01.json" });
 
@@ -318,21 +316,22 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		verify(restClient, never()).getDay2ActionsPolicy(anyString());
 		verify(restClient, never()).createDay2ActionsPolicy(any());
 	}
+
 	@Test
 	void testExportContentWithPolicyAlreadyInFile() {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Collections.singletonList("D2A01"), null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -340,43 +339,43 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 
 		fsMocks.getDay2ActionsPolicyFsMocks().addPolicy(policy);
 		// TEST
 		store.exportContent();
 
 		// VERIFY
-		//export should overwrite policy, not create a new file.
+		// export should overwrite policy, not create a new file.
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
+
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateFiles() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateFiles");
 		VraNgDay2ActionsPolicy policyInFile = new VraNgDay2ActionsPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Collections.singletonList("D2A01"), null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -384,8 +383,7 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 
 		fsMocks.getDay2ActionsPolicyFsMocks().addPolicy(policyInFile);
 		policyInFile.setName("D2A01_1");
@@ -400,96 +398,97 @@ public class VraNgDay2ActionsPolicyStoreTest {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "D2A01.json", "D2A01_1.json", "D2A01_2.json", "D2A01_3.json", "D2A01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "D2A01.json", "D2A01_1.json", "D2A01_2.json", "D2A01_3.json", "D2A01_4.json" });
 	}
-
 
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateNames() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateNames");
 		VraNgDay2ActionsPolicy policyInFile = new VraNgDay2ActionsPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDay2ActionsPolicy policy = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policy1 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-11d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST1",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST1",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policy2 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-12d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST2",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST2",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policy3 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-13d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST3",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST3",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policy4 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-14d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST4",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST4",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDay2ActionsPolicy policy5 = new VraNgDay2ActionsPolicy(
-			"df60ff9e-4027-15d1-a2b5-5229b3cee282",
-			"D2A01",
-			"com.vmware.policy.deployment.action",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST5",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-15d1-a2b5-5229b3cee282",
+				"D2A01",
+				"com.vmware.policy.deployment.action",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST5",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, Arrays.asList("D2A01"), null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getDay2ActionsPolicies()).thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
+		when(restClient.getDay2ActionsPolicies())
+				.thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282")).thenReturn(policy1);
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282")).thenReturn(policy2);
@@ -498,16 +497,15 @@ public class VraNgDay2ActionsPolicyStoreTest {
 		when(restClient.getDay2ActionsPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282")).thenReturn(policy5);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, day2ActionsPolicy).toFile();
 
 		// TEST
 		store.exportContent();
 
 		// VERIFY
 		assertEquals(6, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "D2A01.json", "D2A01_1.json", "D2A01_2.json", "D2A01_3.json", "D2A01_4.json", "D2A01_5.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "D2A01.json", "D2A01_1.json",
+				"D2A01_2.json", "D2A01_3.json", "D2A01_4.json", "D2A01_5.json" });
 	}
 
-
 }
-

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgDeploymentLimitPolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgDeploymentLimitPolicyStoreTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.never;
 
-public class VraNgDeploymentLimitPolicyStoreTest  {
+public class VraNgDeploymentLimitPolicyStoreTest {
 	/**
 	 * Temp Folder.
 	 */
@@ -106,7 +106,6 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		org.setName("VIDM-L-01A");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
@@ -130,16 +129,16 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 	@Test
 	void testExportContentWithNoDeploymentLimitPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithNoDeploymentLimitPolicies");
-		//GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(new VraNgPolicy());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
 		File deploymentLimitPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 
-		//VERIFY
+		// VERIFY
 		verify(restClient, never()).getDeploymentLimitPolicies();
 		verify(restClient, never()).getDeploymentLimitPolicy(anyString());
 
@@ -150,28 +149,28 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 	void testExportContentWithAllDeploymentLimitPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllDeploymentLimitPolicies");
 		VraNgDeploymentLimitPolicy policy1 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDeploymentLimitPolicy policy2 = new VraNgDeploymentLimitPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"DL02",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"DL02",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		List<VraNgDeploymentLimitPolicy> policies = Arrays.asList(policy1, policy2);
 
@@ -186,7 +185,7 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 
 		// VERIFY
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 		assertEquals(2, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
 
@@ -195,16 +194,16 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		System.out.println(this.getClass() + "testExportContentWithSpecificDeploymentLimitPolicies");
 
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -215,7 +214,7 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		store.exportContent();
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
@@ -225,16 +224,16 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 	void testImportContentWithUpdateLogic() {
 		System.out.println("testImportContentWithUpdateLogic");
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -242,7 +241,7 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		fsMocks.getDeploymentLimitPolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), deploymentLimitPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), deploymentLimitPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "DL01.json" });
 
@@ -256,34 +255,33 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		verify(restClient, times(1)).createDeploymentLimitPolicy(any());
 	}
 
-
 	@Test
 	void testImportContentWithCreateLogic() {
 		System.out.println("testImportContentWithCreateLogic");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policyFromServer = new VraNgDeploymentLimitPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"DL02",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"DL02",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -291,7 +289,7 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		fsMocks.getDeploymentLimitPolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), deploymentLimitPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), deploymentLimitPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "DL01.json" });
 
@@ -318,32 +316,33 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		verify(restClient, never()).getDeploymentLimitPolicy(anyString());
 		verify(restClient, never()).createDeploymentLimitPolicy(any());
 	}
+
 	@Test
 	void testExportContentWithSpecificDeploymentLimitPoliciesAndDuplicateFiles() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificDeploymentLimitPoliciesAndDuplicateFiles");
 		VraNgDeploymentLimitPolicy policyInFile = new VraNgDeploymentLimitPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -351,8 +350,7 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 
 		fsMocks.getDeploymentLimitPolicyFsMocks().addPolicy(policyInFile);
 		policyInFile.setName("DL01_1");
@@ -367,7 +365,8 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "DL01.json", "DL01_1.json", "DL01_2.json", "DL01_3.json", "DL01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "DL01.json", "DL01_1.json", "DL01_2.json", "DL01_3.json", "DL01_4.json" });
 	}
 
 	@Test
@@ -375,16 +374,16 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -392,15 +391,14 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 
 		fsMocks.getDeploymentLimitPolicyFsMocks().addPolicy(policy);
 		// TEST
 		store.exportContent();
 
 		// VERIFY
-		//export should overwrite policy, not create a new file.
+		// export should overwrite policy, not create a new file.
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
 
@@ -408,88 +406,89 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 	void testExportContentWithSpecificPoliciesAndDuplicateNames() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateNames");
 		VraNgDeploymentLimitPolicy policyInFile = new VraNgDeploymentLimitPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgDeploymentLimitPolicy policy = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policy1 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-11d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST1",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST1",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policy2 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-12d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST2",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST2",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policy3 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-13d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST3",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST3",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policy4 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-14d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST4",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST4",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgDeploymentLimitPolicy policy5 = new VraNgDeploymentLimitPolicy(
-			"df60ff9e-4027-15d1-a2b5-5229b3cee282",
-			"DL01",
-			"com.vmware.policy.deployment.limit",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST5",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-15d1-a2b5-5229b3cee282",
+				"DL01",
+				"com.vmware.policy.deployment.limit",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST5",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, null, null, Collections.singletonList("DL01"));
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getDeploymentLimitPolicies()).thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
+		when(restClient.getDeploymentLimitPolicies())
+				.thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282")).thenReturn(policy1);
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282")).thenReturn(policy2);
@@ -498,13 +497,14 @@ public class VraNgDeploymentLimitPolicyStoreTest  {
 		when(restClient.getDeploymentLimitPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282")).thenReturn(policy5);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, deploymentLimitPolicy).toFile();
 
 		// TEST
 		store.exportContent();
 
 		// VERIFY
 		assertEquals(6, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "DL01.json", "DL01_1.json", "DL01_2.json", "DL01_3.json", "DL01_4.json", "DL01_5.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "DL01.json", "DL01_1.json",
+				"DL01_2.json", "DL01_3.json", "DL01_4.json", "DL01_5.json" });
 	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgLeasePolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgLeasePolicyStoreTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.never;
 
-public class VraNgLeasePolicyStoreTest  {
+public class VraNgLeasePolicyStoreTest {
 	/**
 	 * Temp Folder.
 	 */
@@ -106,7 +106,6 @@ public class VraNgLeasePolicyStoreTest  {
 		org.setName("VIDM-L-01A");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
@@ -130,16 +129,16 @@ public class VraNgLeasePolicyStoreTest  {
 	@Test
 	void testExportContentWithNoLeasePolicies() {
 		System.out.println(this.getClass() + "testExportContentWithNoLeasePolicies");
-		//GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(new VraNgPolicy());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
 		File leasePolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 
-		//VERIFY
+		// VERIFY
 		verify(restClient, never()).getLeasePolicies();
 		verify(restClient, never()).getLeasePolicy(anyString());
 
@@ -150,28 +149,28 @@ public class VraNgLeasePolicyStoreTest  {
 	void testExportContentWithAllLeasePolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllLeasePolicies");
 		VraNgLeasePolicy policy1 = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgLeasePolicy policy2 = new VraNgLeasePolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"LP02",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"LP02",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		List<VraNgLeasePolicy> policies = Arrays.asList(policy1, policy2);
 
@@ -186,7 +185,7 @@ public class VraNgLeasePolicyStoreTest  {
 
 		// VERIFY
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 		assertEquals(2, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
 
@@ -195,16 +194,16 @@ public class VraNgLeasePolicyStoreTest  {
 		System.out.println(this.getClass() + "testExportContentWithSpecificLeasePolicies");
 
 		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -215,7 +214,7 @@ public class VraNgLeasePolicyStoreTest  {
 		store.exportContent();
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
@@ -225,17 +224,17 @@ public class VraNgLeasePolicyStoreTest  {
 	void testImportContentWithUpdateLogic() {
 		System.out.println("testImportContentWithUpdateLogic");
 		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
 
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -243,7 +242,7 @@ public class VraNgLeasePolicyStoreTest  {
 		fsMocks.getLeasePolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), leasePolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), leasePolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "LP01.json" });
 
@@ -257,34 +256,33 @@ public class VraNgLeasePolicyStoreTest  {
 		verify(restClient, times(1)).createLeasePolicy(any());
 	}
 
-
 	@Test
 	void testImportContentWithCreateLogic() {
 		System.out.println("testImportContentWithCreateLogic");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
 
 		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policyFromServer = new VraNgLeasePolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"LP02",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"LP02",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -292,7 +290,7 @@ public class VraNgLeasePolicyStoreTest  {
 		fsMocks.getLeasePolicyFsMocks().addPolicy(policy);
 
 		File policyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), leasePolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), leasePolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "LP01.json" });
 
@@ -319,65 +317,22 @@ public class VraNgLeasePolicyStoreTest  {
 		verify(restClient, never()).getLeasePolicy(anyString());
 		verify(restClient, never()).createLeasePolicy(any());
 	}
+
 	@Test
 	void testExportContentWithPolicyAlreadyInFile() {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
-		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null , Collections.singletonList("LP01"), null, null);
-		// // GIVEN
-		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getLeasePolicies()).thenReturn(Collections.singletonList(policy));
-		when(restClient.getLeasePolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
-
-		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
-
-
-		fsMocks.getLeasePolicyFsMocks().addPolicy(policy);
-		// TEST
-		store.exportContent();
-
-		// VERIFY
-		//export should overwrite policy, not create a new file.
-		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
-	}
-	@Test
-	void testExportContentWithSpecificPoliciesAndDuplicateFiles() {
-		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateFiles");
-		VraNgLeasePolicy policyInFile = new VraNgLeasePolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
-
-		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -385,8 +340,51 @@ public class VraNgLeasePolicyStoreTest  {
 		when(restClient.getLeasePolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 
+		fsMocks.getLeasePolicyFsMocks().addPolicy(policy);
+		// TEST
+		store.exportContent();
+
+		// VERIFY
+		// export should overwrite policy, not create a new file.
+		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
+	}
+
+	@Test
+	void testExportContentWithSpecificPoliciesAndDuplicateFiles() {
+		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateFiles");
+		VraNgLeasePolicy policyInFile = new VraNgLeasePolicy(
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
+
+		VraNgLeasePolicy policy = new VraNgLeasePolicy(
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
+		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
+		// // GIVEN
+		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
+		when(restClient.getLeasePolicies()).thenReturn(Collections.singletonList(policy));
+		when(restClient.getLeasePolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
+
+		File policyFolder = Paths
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 
 		fsMocks.getLeasePolicyFsMocks().addPolicy(policyInFile);
 		policyInFile.setName("LP01_1");
@@ -401,94 +399,97 @@ public class VraNgLeasePolicyStoreTest  {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "LP01.json", "LP01_1.json", "LP01_2.json", "LP01_3.json", "LP01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "LP01.json", "LP01_1.json", "LP01_2.json", "LP01_3.json", "LP01_4.json" });
 	}
+
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateNames() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateNames");
 		VraNgLeasePolicy policyInFile = new VraNgLeasePolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgLeasePolicy policy = new VraNgLeasePolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policy1 = new VraNgLeasePolicy(
-			"df60ff9e-4027-11d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST1",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST1",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policy2 = new VraNgLeasePolicy(
-			"df60ff9e-4027-12d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST2",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST2",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policy3 = new VraNgLeasePolicy(
-			"df60ff9e-4027-13d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST3",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST3",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policy4 = new VraNgLeasePolicy(
-			"df60ff9e-4027-14d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST4",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST4",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 		VraNgLeasePolicy policy5 = new VraNgLeasePolicy(
-			"df60ff9e-4027-15d1-a2b5-5229b3cee282",
-			"LP01",
-			"com.vmware.policy.deployment.lease",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST5",
-			new JsonObject(),
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-15d1-a2b5-5229b3cee282",
+				"LP01",
+				"com.vmware.policy.deployment.lease",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST5",
+				new JsonObject(),
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, null, null, Collections.singletonList("LP01"), null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getLeasePolicies()).thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
+		when(restClient.getLeasePolicies())
+				.thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
 		when(restClient.getLeasePolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 		when(restClient.getLeasePolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282")).thenReturn(policy1);
 		when(restClient.getLeasePolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282")).thenReturn(policy2);
@@ -497,13 +498,14 @@ public class VraNgLeasePolicyStoreTest  {
 		when(restClient.getLeasePolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282")).thenReturn(policy5);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, leasePolicy).toFile();
 
 		// TEST
 		store.exportContent();
 
 		// VERIFY
 		assertEquals(6, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "LP01.json", "LP01_1.json", "LP01_2.json", "LP01_3.json", "LP01_4.json", "LP01_5.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "LP01.json", "LP01_1.json",
+				"LP01_2.json", "LP01_3.json", "LP01_4.json", "LP01_5.json" });
 	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgPropertyGroupStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgPropertyGroupStoreTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 public class VraNgPropertyGroupStoreTest {
 	@Rule
-	public TemporaryFolder tempFolder	= new TemporaryFolder();
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	protected VraNgPropertyGroupStore store;
 	protected RestClientVraNg restClient;
@@ -57,185 +57,184 @@ public class VraNgPropertyGroupStoreTest {
 	void init() {
 		try {
 			tempFolder.create();
-		}
-		catch ( IOException e ) {
-			throw new RuntimeException( "Could not create a temp folder" );
+		} catch (IOException e) {
+			throw new RuntimeException("Could not create a temp folder");
 		}
 
-		fsMocks					= new FsMocks( tempFolder.getRoot() );
-		store					= new VraNgPropertyGroupStore();
-		restClient				= Mockito.mock( RestClientVraNg.class );
-		pkg						= PackageFactory.getInstance( PackageType.VRANG, tempFolder.getRoot() );
-		config					= Mockito.mock( ConfigurationVraNg.class );
-		vraNgPackageDescriptor	= Mockito.mock( VraNgPackageDescriptor.class );
+		fsMocks = new FsMocks(tempFolder.getRoot());
+		store = new VraNgPropertyGroupStore();
+		restClient = Mockito.mock(RestClientVraNg.class);
+		pkg = PackageFactory.getInstance(PackageType.VRANG, tempFolder.getRoot());
+		config = Mockito.mock(ConfigurationVraNg.class);
+		vraNgPackageDescriptor = Mockito.mock(VraNgPackageDescriptor.class);
 
 		VraNgOrganization org = new VraNgOrganization();
 		org.setId("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		org.setName("VIDM-L-01A");
 
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
 
-		System.out.println( "==========================================================" );
-		System.out.println( "START" );
-		System.out.println( "==========================================================" );
+		System.out.println("==========================================================");
+		System.out.println("START");
+		System.out.println("==========================================================");
 	}
 
 	@AfterEach
 	void tearDown() {
 		tempFolder.delete();
 
-		System.out.println( "==========================================================" );
-		System.out.println( "END" );
-		System.out.println( "==========================================================" );
+		System.out.println("==========================================================");
+		System.out.println("END");
+		System.out.println("==========================================================");
 	}
 
 	@Test
-	void testExportContentWithAllPropertyGroups() throws IOException{
+	void testExportContentWithAllPropertyGroups() throws IOException {
 		// GIVEN
 		this.initStoreWithPropertyGroups(new ArrayList<String>(Arrays.asList("memory", "compute")));
-		
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn( null );
+
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(null);
 		// TEST
 		store.exportContent();
 
-		String[] expectedPropertyGroups	= { "memory.json", "compute.json" };
+		String[] expectedPropertyGroups = { "memory.json", "compute.json" };
 
 		// VERIFY
-		AssertionsHelper.assertFolderContainsFiles( fsMocks.getTempFolderProjectPath(), expectedPropertyGroups );
+		AssertionsHelper.assertFolderContainsFiles(fsMocks.getTempFolderProjectPath(), expectedPropertyGroups);
 	}
 
 	@Test
 	void testExportContentWithAllPropertyGroupsButFilteringIsNone() throws IOException {
 		// GIVEN
 		this.initStoreWithPropertyGroups(new ArrayList<String>(Arrays.asList("memory")));
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn( new ArrayList<>() );
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(new ArrayList<>());
 
 		// TEST
 		store.exportContent();
 
-		String[] expectedPropertyGroups	= {};
+		String[] expectedPropertyGroups = {};
 
-		assertEquals( 0, tempFolder.getRoot().listFiles().length );
+		assertEquals(0, tempFolder.getRoot().listFiles().length);
 	}
 
 	@Test
 	void testExportContentWithSpecificPropertyGroups() throws IOException {
 		// GIVEN
 		this.initStoreWithPropertyGroups(new ArrayList<String>(Arrays.asList("memory", "compute")));
-		
-		List<String> propertyGroupNames			= new ArrayList<>();
-		propertyGroupNames.add( "memory" );
-		List<VraNgPropertyGroup> propertyGroups	= new ArrayList<>();
+
+		List<String> propertyGroupNames = new ArrayList<>();
+		propertyGroupNames.add("memory");
+		List<VraNgPropertyGroup> propertyGroups = new ArrayList<>();
 
 		PropertyGroupMockBuilder memoryBuilder = new PropertyGroupMockBuilder();
-		propertyGroups.add( memoryBuilder.setName( "memory" ).build() );
+		propertyGroups.add(memoryBuilder.setName("memory").build());
 
 		PropertyGroupMockBuilder computeBuilder = new PropertyGroupMockBuilder();
-		propertyGroups.add( computeBuilder.setName( "compute" ).build() );
+		propertyGroups.add(computeBuilder.setName("compute").build());
 
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn( propertyGroupNames );
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(propertyGroupNames);
 
 		// TEST
 		store.exportContent();
 
-		String[] expectedPropertyGroups	= { "memory.json" };
+		String[] expectedPropertyGroups = { "memory.json" };
 
 		// VERIFY
-		AssertionsHelper.assertFolderContainsFiles( fsMocks.getTempFolderProjectPath(), expectedPropertyGroups );
+		AssertionsHelper.assertFolderContainsFiles(fsMocks.getTempFolderProjectPath(), expectedPropertyGroups);
 	}
 
 	@Test
-	void testImportContentWithAllPropertyGroups() throws IOException{
+	void testImportContentWithAllPropertyGroups() throws IOException {
 		// GIVEN
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn(null);
-	
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(null);
+
 		this.initStoreWithPropertyGroups(new ArrayList<String>(Arrays.asList("memory", "compute")));
 
 		PropertyGroupMockBuilder memoryBuilder = new PropertyGroupMockBuilder();
-		fsMocks.propertyGroupFsMocks().addPropertyGroup( memoryBuilder.setName( "memory" ).build() );
+		fsMocks.propertyGroupFsMocks().addPropertyGroup(memoryBuilder.setName("memory").build());
 
 		PropertyGroupMockBuilder computeBuilder = new PropertyGroupMockBuilder();
-		fsMocks.propertyGroupFsMocks().addPropertyGroup( computeBuilder.setName( "compute" ).build() );
+		fsMocks.propertyGroupFsMocks().addPropertyGroup(computeBuilder.setName("compute").build());
 
 		// TEST
-		store.importContent( tempFolder.getRoot() );
+		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, times( 1 ) ).getPropertyGroups();
-		verify( restClient, times( 2 ) ).updatePropertyGroup( any() );
+		verify(restClient, times(1)).getPropertyGroups();
+		verify(restClient, times(2)).updatePropertyGroup(any());
 	}
 
 	@Test
-	void testImportContentWithExistingPropertyGroup() throws IOException{
+	void testImportContentWithExistingPropertyGroup() throws IOException {
 		// GIVEN
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn(null);
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(null);
 
-		List<VraNgPropertyGroup> pgs = this.initStoreWithPropertyGroups(new ArrayList<String>(Collections.singletonList("memory")));
+		List<VraNgPropertyGroup> pgs = this
+				.initStoreWithPropertyGroups(new ArrayList<String>(Collections.singletonList("memory")));
 
 		PropertyGroupMockBuilder memoryBuilder = new PropertyGroupMockBuilder();
 		fsMocks.propertyGroupFsMocks().addPropertyGroup(
-			memoryBuilder.setPropertyInRawData("description", "SANITY_CHECK").setName( "memory" ).setId( "testImportContentWithExistingPropertyGroup" ).build()
-		);
+				memoryBuilder.setPropertyInRawData("description", "SANITY_CHECK").setName("memory")
+						.setId("testImportContentWithExistingPropertyGroup").build());
 
-		ArgumentCaptor<VraNgPropertyGroup> pgArgumentCaptor = ArgumentCaptor.forClass( VraNgPropertyGroup.class );
+		ArgumentCaptor<VraNgPropertyGroup> pgArgumentCaptor = ArgumentCaptor.forClass(VraNgPropertyGroup.class);
 
 		// TEST
-		store.importContent( tempFolder.getRoot() );
+		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, times( 1 ) ).getPropertyGroups();
-		verify( restClient, times( 1 ) ).updatePropertyGroup( pgArgumentCaptor.capture() );
-		verify( restClient, never() ).createPropertyGroup( any() );
+		verify(restClient, times(1)).getPropertyGroups();
+		verify(restClient, times(1)).updatePropertyGroup(pgArgumentCaptor.capture());
+		verify(restClient, never()).createPropertyGroup(any());
 
 		System.out.println(pgArgumentCaptor.getValue().getRawData());
-		assertEquals( "mockedId", pgArgumentCaptor.getValue().getId() );
+		assertEquals("mockedId", pgArgumentCaptor.getValue().getId());
 		assertTrue(pgArgumentCaptor.getValue().getRawData().contains("SANITY_CHECK"));
 	}
 
 	@Test
-	void testImportContentWithNonExistingPropertyGroups() throws IOException{
+	void testImportContentWithNonExistingPropertyGroups() throws IOException {
 		// GIVEN
 		List<String> names = new ArrayList<>();
 		names.add("nonexisting");
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn(names);
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(names);
 
 		this.initStoreWithPropertyGroups(new ArrayList<String>());
 
 		PropertyGroupMockBuilder computeBuilder = new PropertyGroupMockBuilder();
-		fsMocks.propertyGroupFsMocks().addPropertyGroup( computeBuilder.setName( "nonexisting" ).build() );
+		fsMocks.propertyGroupFsMocks().addPropertyGroup(computeBuilder.setName("nonexisting").build());
 
 		// TEST
-		store.importContent( tempFolder.getRoot() );
+		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, times( 1 ) ).getPropertyGroups();
-		verify( restClient, times( 1 ) ).createPropertyGroup( any() );
+		verify(restClient, times(1)).getPropertyGroups();
+		verify(restClient, times(1)).createPropertyGroup(any());
 	}
 
 	@Test
-	void testImportContentWithConfig() throws IOException{
+	void testImportContentWithConfig() throws IOException {
 		// GIVEN
 		List<String> names = new ArrayList<>();
 		names.add("memory");
-		when( vraNgPackageDescriptor.getPropertyGroup() ).thenReturn(names);
-	
+		when(vraNgPackageDescriptor.getPropertyGroup()).thenReturn(names);
+
 		this.initStoreWithPropertyGroups(new ArrayList<String>(Arrays.asList("memory", "compute")));
 
 		PropertyGroupMockBuilder memoryBuilder = new PropertyGroupMockBuilder();
-		fsMocks.propertyGroupFsMocks().addPropertyGroup( memoryBuilder.setName( "memory" ).build() );
+		fsMocks.propertyGroupFsMocks().addPropertyGroup(memoryBuilder.setName("memory").build());
 
 		PropertyGroupMockBuilder computeBuilder = new PropertyGroupMockBuilder();
-		fsMocks.propertyGroupFsMocks().addPropertyGroup( computeBuilder.setName( "compute" ).build() );
+		fsMocks.propertyGroupFsMocks().addPropertyGroup(computeBuilder.setName("compute").build());
 
 		// TEST
-		store.importContent( tempFolder.getRoot() );
+		store.importContent(tempFolder.getRoot());
 
 		// VERIFY
-		verify( restClient, times( 1 ) ).getPropertyGroups();
-		verify( restClient, times( 1 ) ).updatePropertyGroup( any() );
+		verify(restClient, times(1)).getPropertyGroups();
+		verify(restClient, times(1)).updatePropertyGroup(any());
 	}
 
 	@Test
@@ -252,16 +251,17 @@ public class VraNgPropertyGroupStoreTest {
 		assertThrows(IllegalStateException.class, () -> store.exportContent());
 	}
 
-	private List<VraNgPropertyGroup> initStoreWithPropertyGroups(ArrayList<String> propertyGroupNames) throws IOException{
-		List<VraNgPropertyGroup> propertyGroups	= new ArrayList<>();
+	private List<VraNgPropertyGroup> initStoreWithPropertyGroups(ArrayList<String> propertyGroupNames)
+			throws IOException {
+		List<VraNgPropertyGroup> propertyGroups = new ArrayList<>();
 		for (String pgName : propertyGroupNames) {
 			PropertyGroupMockBuilder computeBuilder = new PropertyGroupMockBuilder();
-			propertyGroups.add( computeBuilder.setName( pgName ).build() );
+			propertyGroups.add(computeBuilder.setName(pgName).build());
 		}
 
-		when( restClient.getPropertyGroups() ).thenReturn( propertyGroups );
+		when(restClient.getPropertyGroups()).thenReturn(propertyGroups);
 
-		store.init( restClient, pkg, config, vraNgPackageDescriptor );
+		store.init(restClient, pkg, config, vraNgPackageDescriptor);
 
 		return propertyGroups;
 	}

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgResourceQuotaPolicyStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgResourceQuotaPolicyStoreTest.java
@@ -103,7 +103,6 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		org.setName("VIDM-L-01A");
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
-		when(config.getOrgId()).thenReturn("b2c558c8-f20c-4da6-9bc3-d7561f64df16");
 		when(config.getOrgName()).thenReturn("VIDM-L-01A");
 		when(restClient.getOrganizationById("b2c558c8-f20c-4da6-9bc3-d7561f64df16")).thenReturn(org);
 		when(restClient.getOrganizationByName("VIDM-L-01A")).thenReturn(org);
@@ -127,16 +126,16 @@ public class VraNgResourceQuotaPolicyStoreTest {
 	@Test
 	void testExportContentWithNoResourceQuotaPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithNoResourceQuotaPolicies");
-		//GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(new VraNgPolicy());
 
-		//TEST
+		// TEST
 		store.exportContent();
 
 		File resourceQuotaPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 
-		//VERIFY
+		// VERIFY
 		verify(restClient, never()).getResourceQuotaPolicies();
 		verify(restClient, never()).getResourceQuotaPolicy(anyString());
 
@@ -147,26 +146,26 @@ public class VraNgResourceQuotaPolicyStoreTest {
 	void testExportContentWithAllResourceQuotaPolicies() {
 		System.out.println(this.getClass() + "testExportContentWithAllResourceQuotaPolicies");
 		VraNgResourceQuotaPolicy rqPolicy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgResourceQuotaPolicy rqPolicy2 = new VraNgResourceQuotaPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"RQ02",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"RQ02",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 
 		List<VraNgResourceQuotaPolicy> policies = Arrays.asList(rqPolicy, rqPolicy2);
 
@@ -181,7 +180,7 @@ public class VraNgResourceQuotaPolicyStoreTest {
 
 		// VERIFY
 		File resourceQuotaPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 		assertEquals(2, Objects.requireNonNull(resourceQuotaPolicyFolder.listFiles()).length);
 	}
 
@@ -190,15 +189,15 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		System.out.println(this.getClass() + "testExportContentWithSpecificResourceQuotaPolicies");
 
 		VraNgResourceQuotaPolicy rqPolicy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -209,7 +208,7 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		store.exportContent();
 
 		File resourceQuotaPolicyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 
 		// VERIFY
 		assertEquals(1, Objects.requireNonNull(resourceQuotaPolicyFolder.listFiles()).length);
@@ -219,15 +218,15 @@ public class VraNgResourceQuotaPolicyStoreTest {
 	void testImportContentWithUpdateLogic() {
 		System.out.println("testImportContentWithUpdateLogic");
 		VraNgResourceQuotaPolicy rqPolicy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -235,7 +234,7 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		fsMocks.resourceQuotaPolicyFsMocks().addResourceQuotaPolicy(rqPolicy);
 
 		File resourceQuotaPolicyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), resourceQuotaPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), resourceQuotaPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(resourceQuotaPolicyFolder, new String[] { "RQ01.json" });
 
@@ -249,40 +248,39 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		verify(restClient, times(1)).createResourceQuotaPolicy(any());
 	}
 
-
-@Test
+	@Test
 	void testImportContentWithCreateLogic() {
 		System.out.println("testImportContentWithCreateLogic");
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 
 		VraNgResourceQuotaPolicy rqPolicy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy rqPolicyFromServer = new VraNgResourceQuotaPolicy(
-			"2cf93725-38e9-4cb9-888a-a40994754c31",
-			"RQ02",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"2cf93725-38e9-4cb9-888a-a40994754c31",
+				"RQ02",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"b2c558c8-f20c-4da6-9bc3-d7561f64df16",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 
-	// GIVEN
+		// GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
 
 		fsMocks.resourceQuotaPolicyFsMocks().addResourceQuotaPolicy(rqPolicy);
 
 		File resourceQuotaPolicyFolder = Paths
-			.get(fsMocks.getTempFolderProjectPath().getPath(), resourceQuotaPolicy).toFile();
+				.get(fsMocks.getTempFolderProjectPath().getPath(), resourceQuotaPolicy).toFile();
 
 		AssertionsHelper.assertFolderContainsFiles(resourceQuotaPolicyFolder, new String[] { "RQ01.json" });
 
@@ -296,33 +294,34 @@ public class VraNgResourceQuotaPolicyStoreTest {
 		verify(restClient, times(1)).createResourceQuotaPolicy(any());
 	}
 
-@Test
-void testImportContentWithNoFile() {
-	System.out.println(this.getClass() + "testImportContentWithNoFile");
+	@Test
+	void testImportContentWithNoFile() {
+		System.out.println(this.getClass() + "testImportContentWithNoFile");
 
-	// START TEST
-	store.importContent(tempFolder.getRoot());
+		// START TEST
+		store.importContent(tempFolder.getRoot());
 
-	// VERIFY
-	verify(vraNgPackageDescriptor, never()).getPolicy();
-	verify(restClient, never()).getResourceQuotaPolicies();
-	verify(restClient, never()).getResourceQuotaPolicy(anyString());
-	verify(restClient, never()).createResourceQuotaPolicy(any());
-}
+		// VERIFY
+		verify(vraNgPackageDescriptor, never()).getPolicy();
+		verify(restClient, never()).getResourceQuotaPolicies();
+		verify(restClient, never()).getResourceQuotaPolicy(anyString());
+		verify(restClient, never()).createResourceQuotaPolicy(any());
+	}
+
 	@Test
 	void testExportContentWithPolicyAlreadyInFile() {
 		System.out.println(this.getClass() + ".testExportContentWithPolicyAlreadyInFile");
 
 		VraNgResourceQuotaPolicy policy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -330,41 +329,41 @@ void testImportContentWithNoFile() {
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 
 		fsMocks.resourceQuotaPolicyFsMocks().addResourceQuotaPolicy(policy);
 		// TEST
 		store.exportContent();
 
 		// VERIFY
-		//export should overwrite policy, not create a new file.
+		// export should overwrite policy, not create a new file.
 		assertEquals(1, Objects.requireNonNull(policyFolder.listFiles()).length);
 	}
+
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateFiles() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateFiles");
 		VraNgResourceQuotaPolicy policyInFile = new VraNgResourceQuotaPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgResourceQuotaPolicy policy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
@@ -372,8 +371,7 @@ void testImportContentWithNoFile() {
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
-
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 
 		fsMocks.resourceQuotaPolicyFsMocks().addResourceQuotaPolicy(policyInFile);
 		policyInFile.setName("RQ01_1");
@@ -388,87 +386,90 @@ void testImportContentWithNoFile() {
 
 		// VERIFY
 		assertEquals(5, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "RQ01.json", "RQ01_1.json", "RQ01_2.json", "RQ01_3.json", "RQ01_4.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder,
+				new String[] { "RQ01.json", "RQ01_1.json", "RQ01_2.json", "RQ01_3.json", "RQ01_4.json" });
 	}
+
 	@Test
 	void testExportContentWithSpecificPoliciesAndDuplicateNames() {
 		System.out.println(this.getClass() + ".testExportContentWithSpecificPoliciesAndDuplicateNames");
 		VraNgResourceQuotaPolicy policyInFile = new VraNgResourceQuotaPolicy(
-			"d160119e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"SOFT",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"d160119e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"SOFT",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgResourceQuotaPolicy policy = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-48d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-48d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy policy1 = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-11d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST1",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-11d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST1",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy policy2 = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-12d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST2",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-12d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST2",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy policy3 = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-13d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST3",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-13d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST3",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy policy4 = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-14d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST4",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-14d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST4",
+				new JsonObject(),
+				new JsonObject());
 		VraNgResourceQuotaPolicy policy5 = new VraNgResourceQuotaPolicy(
-			"df60ff9e-4027-15d1-a2b5-5229b3cee282",
-			"RQ01",
-			"com.vmware.policy.resource.quota",
-			"b899c648-bf84-4d35-a61c-db212ecb4c1e",
-			"VIDM-L-01A",
-			"HARD",
-			"TEST5",
-			new JsonObject(),
-			new JsonObject());
+				"df60ff9e-4027-15d1-a2b5-5229b3cee282",
+				"RQ01",
+				"com.vmware.policy.resource.quota",
+				"b899c648-bf84-4d35-a61c-db212ecb4c1e",
+				"VIDM-L-01A",
+				"HARD",
+				"TEST5",
+				new JsonObject(),
+				new JsonObject());
 
 		VraNgPolicy vraNgPolicy = new VraNgPolicy(null, Collections.singletonList("RQ01"), null, null, null, null);
 		// // GIVEN
 		when(vraNgPackageDescriptor.getPolicy()).thenReturn(vraNgPolicy);
-		when(restClient.getResourceQuotaPolicies()).thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
+		when(restClient.getResourceQuotaPolicies())
+				.thenReturn(Arrays.asList(policy, policy1, policy2, policy3, policy4, policy5));
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-48d1-a2b5-5229b3cee282")).thenReturn(policy);
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-11d1-a2b5-5229b3cee282")).thenReturn(policy1);
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-12d1-a2b5-5229b3cee282")).thenReturn(policy2);
@@ -477,13 +478,14 @@ void testImportContentWithNoFile() {
 		when(restClient.getResourceQuotaPolicy("df60ff9e-4027-15d1-a2b5-5229b3cee282")).thenReturn(policy5);
 
 		File policyFolder = Paths
-			.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
+				.get(tempFolder.getRoot().getPath(), dirPolicies, resourceQuotaPolicy).toFile();
 
 		// TEST
 		store.exportContent();
 
 		// VERIFY
 		assertEquals(6, Objects.requireNonNull(policyFolder.listFiles()).length);
-		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "RQ01.json", "RQ01_1.json", "RQ01_2.json", "RQ01_3.json", "RQ01_4.json", "RQ01_5.json" });
+		AssertionsHelper.assertFolderContainsFiles(policyFolder, new String[] { "RQ01.json", "RQ01_1.json",
+				"RQ01_2.json", "RQ01_3.json", "RQ01_4.json", "RQ01_5.json" });
 	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgSubscriptionStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/store/vrang/VraNgSubscriptionStoreTest.java
@@ -70,6 +70,8 @@ public class VraNgSubscriptionStoreTest {
 	protected FsMocks fsMocks;
 	protected Gson gson;
 
+	protected static String ORG_NAME = "testOrg";
+
 	@BeforeEach
 	void init() {
 		try {
@@ -89,11 +91,11 @@ public class VraNgSubscriptionStoreTest {
 		// mock all rest calls in init
 		VraNgOrganization mockedOrg = new VraNgOrganization();
 		mockedOrg.setId("mockOrg");
-		when(config.getOrgId()).thenReturn("mockOrg");
 		when(restClient.getProjectId()).thenReturn("mockedProjectId");
 		when(restClient.getProjects()).thenReturn(new ArrayList<VraNgProject>());
 		when(restClient.getOrganizationById(anyString())).thenReturn(mockedOrg);
 		when(restClient.getOrganizationByName(anyString())).thenReturn(mockedOrg);
+		when(config.getOrgName()).thenReturn(ORG_NAME);
 
 		store.init(restClient, pkg, config, vraNgPackageDescriptor);
 		System.out.println("==========================================================");

--- a/docs/versions/latest/Components/Archetypes/vRA 8.x/General/Getting Started.md
+++ b/docs/versions/latest/Components/Archetypes/vRA 8.x/General/Getting Started.md
@@ -109,7 +109,6 @@ The following need to be added to the profile that you intend to use:
     <vrang.password>someSecurePassword</vrang.password>
     <vrang.tenant>{tenant}</vrang.tenant>
     <vrang.project.name>{project+name}</vrang.project.name>
-    <vrang.org.id>{organization+id}</vrang.org.id>
     <vrang.org.name>{org+name}</vrang.org.name>
     <vrang.refresh.token>{refresh+token}</vrang.refresh.token>
     <vrang.bp.unrelease.versions>true|false</vrang.bp.unrelease.versions>
@@ -128,4 +127,4 @@ credentials.
 
 #### Organizations
 
-The `vrang.org.id` needs to be passed, as vRA-ng targets only a single organization. However we can extract the `org.id` from the `org.name`. Meaning that in the end if `org.name` is present, you don't need to pass the `org.id`, however if `org.id` is passed, it will be taken with priority.
+`vrang.org.name` needs to be specified. The `vra-ng` project is scoped to a single organization.

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -16,6 +16,12 @@ Moving forward, `vrang.project.id` will not be accepted as part of the configura
 
 `project.name` is more flexible as it will automatically find out the `project.id`.
 
+### *`vrang.org.id` has been removed in favor of `vrang.org.name`*
+
+Moving forward, `vrang.org.id` will not be accepted as part of the configuration. Instead, use `vrang.org.name`.
+
+`org.name` is more flexible as it will automatically find out the `org.id`.
+
 ### *Polyglot projects will not try to fix mistakes due to issues with the manifest*
 
 Before, the `polyglot.json` could be defined like this:
@@ -132,3 +138,9 @@ Search your projects that use `@PolicyTemplate` decorator. The `templateVersion`
 1. Open your `settings.xml`.
 2. Search for `vrang.project.id`.
 3. If found, replace it with the name of the project as seen in Aria
+
+### *Migrate away from `vrang.org.id`*
+
+1. Open your `settings.xml`.
+2. Search for `vrang.org.id`.
+3. If found, replace it with the name of the organization as seen in Aria

--- a/maven/base-package/cs-package/pom.xml
+++ b/maven/base-package/cs-package/pom.xml
@@ -38,7 +38,6 @@
 						<password>${vrang.password}</password>
 						<serverId>${vrang.serverId}</serverId>
 						<project.name>${vrang.project.name}</project.name>
-						<org.id>${vrang.org.id}</org.id>
 						<org.name>${vrang.org.name}</org.name>
 						<refresh.token>${vrang.refresh.token}</refresh.token>
 						<proxy>${vrang.proxy}</proxy>

--- a/maven/base-package/pom.xml
+++ b/maven/base-package/pom.xml
@@ -264,7 +264,6 @@
 						<password>${vrang.password}</password>
 						<serverId>${vrang.serverId}</serverId>
 						<project.name>${vrang.project.name}</project.name>
-						<org.id>${vrang.org.id}</org.id>
 						<org.name>${vrang.org.name}</org.name>
 						<refresh.token>${vrang.refresh.token}</refresh.token>
 						<bp.release>${vrang.bp.release}</bp.release>

--- a/maven/base-package/serverless/pom.xml
+++ b/maven/base-package/serverless/pom.xml
@@ -227,7 +227,6 @@
 							<password>${vrang.password}</password>
 							<serverId>${vrang.serverId}</serverId>
 							<project.name>${vrang.project.name}</project.name>
-							<org.id>${vrang.org.id}</org.id>
 							<org.name>${vrang.org.name}</org.name>
 							<refresh.token>${vrang.refresh.token}</refresh.token>
 							<proxy>${vrang.proxy}</proxy>

--- a/maven/base-package/vra-ng-package/pom.xml
+++ b/maven/base-package/vra-ng-package/pom.xml
@@ -38,7 +38,6 @@
 						<password>${vrang.password}</password>
 						<serverId>${vrang.serverId}</serverId>
 						<project.name>${vrang.project.name}</project.name>
-						<org.id>${vrang.org.id}</org.id>
 						<org.name>${vrang.org.name}</org.name>
 						<refresh.token>${vrang.refresh.token}</refresh.token>
 						<bp.release>${vrang.bp.release}</bp.release>

--- a/maven/polyglot/pom.xml
+++ b/maven/polyglot/pom.xml
@@ -266,7 +266,6 @@
 							<password>${vrang.password}</password>
 							<serverId>${vrang.serverId}</serverId>
 							<project.name>${vrang.project.name}</project.name>
-							<org.id>${vrang.org.id}</org.id>
 							<org.name>${vrang.org.name}</org.name>
 							<refresh.token>${vrang.refresh.token}</refresh.token>
 							<bp.release>${vrang.bp.release}</bp.release>

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -126,12 +126,6 @@ enum Option {
 			"vrang_data.collection.delay.seconds",
 			ConfigurationVraNg.DATA_COLLECTION_DELAY_SECONDS),
 	/**
-	 * VRANG org Id.
-	 */
-	VRANG_ORGANIZATION_ID(
-			"vrang_org_id",
-			ConfigurationVraNg.ORGANIZATION_ID),
-	/**
 	 * VRANG org name.
 	 */
 	VRANG_ORGANIZATION_NAME(
@@ -1269,9 +1263,7 @@ public final class Installer {
 		Validate.ProjectAndOrg validated = Validate.project(input, input.get(Option.VRANG_PROJECT_NAME),
 				input.getText());
 		userInput(input, Option.VRANG_ORGANIZATION_NAME,
-				"  Organization Name (Optional if you supplied organization ID)", validated.org);
-		userInput(input, Option.VRANG_ORGANIZATION_ID, "  Organization ID (Optional if you supplied organization Name)",
-				validated.orgId);
+				"  Organization Name", validated.org);
 		userInput(input, Option.VRANG_PROXY_REQUIRED, "  Use proxy server for vRA? (Optional)", false);
 		if (input.allTrue(Option.VRANG_PROXY_REQUIRED)) {
 			userInput(input, Option.VRANG_PROXY, "    VRA proxy server");


### PR DESCRIPTION
### Description

`vrang.org.id` has been removed in favor of `vrang.org.name`

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Unit tests are green