### PR TITLE
[installer] (#467) Add Support for YAML Input Format when Running Workflows via the Installer

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -22,7 +22,7 @@
 
 This is a build improvement. Now security vulnerabilities will be reported to Github Security. Note that this will just report on the security vulnerabilities, but not fail the build. It's up to the maintainers to act upon the reported information.
 
-### *Add Support for YAML Input and Output in Workflow Run with Installer *
+### *Add Support for YAML Input and Output in Workflow Run with Installer*
 
 Add support for YAML data in the workflow inputs / outputs during workflow run triggered by the installer.
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -3,31 +3,26 @@
 [//]: # (Nothing here is optional. If a step must not be performed, it must be said so)
 [//]: # (Do not fill the version, it will be done automatically)
 [//]: # (Quick Intro to what is the focus of this release)
-
 ## Breaking Changes
-
 [//]: # (### *Breaking Change*)
 [//]: # (Describe the breaking change AND explain how to resolve it)
 [//]: # (You can utilize internal links /e.g. link to the upgrade procedure, link to the improvement|deprecation that introduced this/)
-
 ## Deprecations
-
 [//]: # (### *Deprecation*)
 [//]: # (Explain what is deprecated and suggest alternatives)
-
 [//]: # (Features -> New Functionality)
-
 ## Features
-
 [//]: # (### *Feature Name*)
 [//]: # (Describe the feature)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
 [//]: # (Improvements -> Bugfixes/hotfixes or general improvements)
 
-## Improvements
+### *Add Support for YAML Input and Output in Workflow Run with Installer *
 
+Add support for YAML data in the workflow inputs / outputs during workflow run within installer.
+
+## Improvements
 [//]: # (### *Improvement Name* )
 [//]: # (Talk ONLY regarding the improvement)
 [//]: # (Optional But higlhy recommended)
@@ -38,7 +33,5 @@
 [//]: # (Explain how it behaves now, regarding to the change)
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
-
 ## Upgrade procedure
-
 [//]: # (Explain in details if something needs to be done)

--- a/package-installer/pom.xml
+++ b/package-installer/pom.xml
@@ -34,6 +34,16 @@
 			<version>1.1.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+ 			<version>2.3</version>
+		</dependency>
+ 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.18.1</version>
+		</dependency>
+		<dependency>
 			<groupId>com.vmware.pscoe.iac</groupId>
 			<artifactId>artifact-manager</artifactId>
 			<version>${revision}</version>

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -1461,7 +1461,7 @@ public final class Installer {
             yaml.load(yamlString);
             return true;
         } catch (ParserException e) {
-            LOGGER.debug("Failed to parse the YAML string from file '{}' : {}", fileName, e.getLocalizedMessage());
+            LOGGER.debug("Encountered an error while parsing workflow input file '{}' as YAML. File will be processed as JSON. Error: {}", fileName, e.getLocalizedMessage());
             return false;
         }
     }

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -35,7 +35,12 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.beryx.textio.TextIO;
 import org.beryx.textio.TextIoFactory;
-
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.parser.ParserException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -1380,68 +1385,124 @@ public final class Installer {
 		return packages.stream().map(file -> PackageFactory.getInstance(type, file)).collect(Collectors.toList());
 	}
 
-	private static void runWorkflow(final Input input) throws ConfigurationException {
-		input.getText().getTextTerminal().println("Executing vRealize Orchestrator Workflow ...");
+    private static void runWorkflow(final Input input) throws ConfigurationException {
+        input.getText().getTextTerminal().println("Executing vRealize Orchestrator Workflow ...");
 
-		Gson gson = new GsonBuilder().setLenient().setPrettyPrinting().serializeNulls().create();
-		String wfID = input.get(Option.VRO_RUN_WORKFLOW_ID);
-		String wfInputFilePath = input.get(Option.VRO_RUN_WORKFLOW_INPUT_FILE_PATH);
-		String wfOutputFilePath = input.get(Option.VRO_RUN_WORKFLOW_OUTPUT_FILE);
-		String wfErrFilePath = input.get(Option.VRO_RUN_WORKFLOW_ERR_FILE);
-		wfErrFilePath = StringUtils.isEmpty(wfErrFilePath) && !StringUtils.isEmpty(wfOutputFilePath)
-				? wfOutputFilePath + ".err"
-				: "workflow.err";
-		String wfTimeout = input.get(Option.VRO_RUN_WORKFLOW_TIMEOUT);
+        Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
+        String wfID = input.get(Option.VRO_RUN_WORKFLOW_ID);
+        String wfInputFilePath = input.get(Option.VRO_RUN_WORKFLOW_INPUT_FILE_PATH);
+        String wfOutputFilePath = input.get(Option.VRO_RUN_WORKFLOW_OUTPUT_FILE);
+        String wfErrFilePath = input.get(Option.VRO_RUN_WORKFLOW_ERR_FILE);
+        wfErrFilePath = StringUtils.isEmpty(wfErrFilePath) && !StringUtils.isEmpty(wfOutputFilePath)
+                ? wfOutputFilePath + ".err"
+                : "workflow.err";
+        String wfTimeout = input.get(Option.VRO_RUN_WORKFLOW_TIMEOUT);
 
-		Properties wfInput = new Properties();
-		try {
-			String wfInputJSON = new String(Files.readAllBytes(Paths.get(wfInputFilePath)));
-			for (Map.Entry<String, JsonElement> entry : gson.fromJson(wfInputJSON, JsonObject.class).entrySet()) {
-				wfInput.put(entry.getKey(), StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
-			}
-			List<String> prefixes = new ArrayList<>();
-			if (input.allTrue(Option.VRO_EMBEDDED)) {
-				prefixes.add(ConfigurationPrefix.VRO.getValue());
-				prefixes.add(ConfigurationPrefix.VRANG.getValue());
-			} else {
-				prefixes.add(ConfigurationPrefix.VRO.getValue());
-			}
-			RestClientVro client = RestClientFactory
-					.getClientVro(ConfigurationVro.fromProperties(input.getMappings(prefixes.toArray(new String[0]))));
-			WorkflowExecution workflowExecutionResult = new VroWorkflowExecutor(client).executeWorkflow(wfID, wfInput,
-					Integer.parseInt(wfTimeout));
+        Properties wfInput = new Properties();
+        try {
+            String wfInputString = new String(Files.readAllBytes(Paths.get(wfInputFilePath)));
+            if (Installer.isValidYaml(wfInputString)) {
+                wfInputString = Installer.convertYamlToJson(wfInputFilePath, wfInputString);
+            }
 
-			JsonObject wfOutputJson = new JsonObject();
-			for (String key : workflowExecutionResult.getOutput().stringPropertyNames()) {
-				String value = StringEscapeUtils.unescapeJson(workflowExecutionResult.getOutput().getProperty(key));
-				wfOutputJson.add(key, gson.fromJson(value, JsonObject.class));
-			}
-			// write the workflow output
-			Files.write(Paths.get(wfOutputFilePath), gson.toJson(wfOutputJson).getBytes(), StandardOpenOption.CREATE);
-			// write the workflow error in a workflow error file (if any)
-			if (!StringUtils.isEmpty(workflowExecutionResult.getError())) {
-				Files.write(Paths.get(wfErrFilePath), workflowExecutionResult.getError().getBytes(),
-						StandardOpenOption.CREATE);
-			}
-		} catch (IOException e) {
-			throw new RuntimeException(
-					"Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-		} catch (JsonSyntaxException e) {
-			throw new RuntimeException("Unable to parse input / output file data: " + e.getClass().getName() + " : "
-					+ e.getLocalizedMessage(), e);
-		} catch (WorkflowExecutionException e) {
-			try {
-				Files.write(Paths.get(wfErrFilePath), e.getMessage().getBytes(), StandardOpenOption.CREATE);
-			} catch (IOException e1) {
-				throw new RuntimeException(
-						"Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(),
-						e);
-			}
-			throw new RuntimeException(
-					"Workflow execution failed: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-		} catch (Exception e) {
-			throw new RuntimeException("General error during workflow execution: " + e.getClass().getName() + " : "
-					+ e.getLocalizedMessage(), e);
-		}
-	}
+            for (Map.Entry<String, JsonElement> entry : gson.fromJson(wfInputString, JsonObject.class).entrySet()) {
+                wfInput.put(entry.getKey(),StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
+            }
+            List<String> prefixes = new ArrayList<>();
+            if (input.allTrue(Option.VRO_EMBEDDED)) {
+                prefixes.add(ConfigurationPrefix.VRO.getValue());
+                prefixes.add(ConfigurationPrefix.VRANG.getValue());
+            } else {
+                prefixes.add(ConfigurationPrefix.VRO.getValue());
+            }
+            RestClientVro client = RestClientFactory.getClientVro(ConfigurationVro.fromProperties(input.getMappings(prefixes.toArray(new String[0]))));
+            WorkflowExecution workflowExecutionResult = new VroWorkflowExecutor(client).executeWorkflow(wfID, wfInput, Integer.parseInt(wfTimeout));
+
+            JsonObject wfOutputJson = new JsonObject();
+            for (String key : workflowExecutionResult.getOutput().stringPropertyNames()) {
+                String value = StringEscapeUtils.unescapeJson(workflowExecutionResult.getOutput().getProperty(key));
+                wfOutputJson.add(key, gson.fromJson(value, JsonObject.class));
+            }
+            // write the workflow output
+            String outputString = gson.toJson(wfOutputJson);
+            if (Installer.endsWithIgnoreCase(wfOutputFilePath, "yaml")) {
+                outputString = Installer.convertJsonObjectToYaml(wfOutputFilePath, wfOutputJson);
+            }
+
+            Files.write(Paths.get(wfOutputFilePath), outputString.getBytes(), StandardOpenOption.CREATE);
+            // write the workflow error in a workflow error file (if any)
+            if (!StringUtils.isEmpty(workflowExecutionResult.getError())) {
+                Files.write(Paths.get(wfErrFilePath), workflowExecutionResult.getError().getBytes(), StandardOpenOption.CREATE);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+        } catch (JsonSyntaxException e) {
+            throw new RuntimeException("Unable to parse input / output file data: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+        } catch (WorkflowExecutionException e) {
+            try {
+                Files.write(Paths.get(wfErrFilePath), e.getMessage().getBytes(), StandardOpenOption.CREATE);
+            } catch (IOException e1) {
+                throw new RuntimeException("Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+            }
+            throw new RuntimeException("Workflow execution failed: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+        } catch (Exception e) {
+            throw new RuntimeException("General error during workflow execution: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+        }
+    }
+	
+    private static boolean isValidYaml(String yamlString) {
+        Yaml yaml = new Yaml();
+        try {
+            yaml.load(yamlString);
+            return true;
+        } catch (ParserException e) {
+            return false;
+        }
+    }
+
+    private static String convertYamlToJson(String fileName, String yamlString) {
+        Yaml yaml = new Yaml();
+        ObjectMapper jsonMapper = new ObjectMapper();
+        jsonMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        try {
+            // Parse YAML
+            Map<String, Object> yamlMap = yaml.load(yamlString);
+            // Convert to JSON
+            return jsonMapper.writeValueAsString(yamlMap);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(String.format("Unable to convert YAML file '%s' to JSON: '%s'", fileName, e.getLocalizedMessage()));
+        }
+    }
+
+    private static String convertJsonObjectToYaml(String fileName, JsonObject jsonObject) {
+        if (jsonObject.isEmpty()) {
+            return "--";
+        }
+        ObjectMapper jsonMapper = new ObjectMapper();
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        Yaml yaml = new Yaml(options);
+
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> jsonMap = jsonMapper.readValue(jsonObject.toString(), Map.class);
+            return yaml.dump(jsonMap);
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to convert JSON object to YAML file '%s': '%s'", fileName, e.getLocalizedMessage()));
+        }
+    }
+    
+    private static boolean endsWithIgnoreCase(String str, String suffix) {
+        if (str == null || suffix == null) {
+            return false;
+        }
+        if (suffix.length() > str.length()) {
+            return false;
+        }
+        String lowerStr = str.toLowerCase();
+        String lowerSuffix = suffix.toLowerCase();
+
+        return lowerStr.endsWith(lowerSuffix);
+    }    
 }

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -35,6 +35,8 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.beryx.textio.TextIO;
 import org.beryx.textio.TextIoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.parser.ParserException;
@@ -811,6 +813,11 @@ public final class Installer {
 	 */
 	private static final int EXIT_WF_EXEC_FAILED_CODE = -1;
 
+    /**
+     * Instance of the logger used in the installer.
+     */
+	private static final Logger LOGGER = LoggerFactory.getLogger(Installer.class);
+
 	private Installer() {
 	}
 
@@ -1375,10 +1382,8 @@ public final class Installer {
 			return new ArrayList<>();
 		}
 		if (!containerDir.isDirectory()) {
-			throw new RuntimeException(
-					String.format("Cannot find any packages at %s .", containerDir.getAbsolutePath()));
+			throw new RuntimeException(String.format("Cannot find any packages at %s .", containerDir.getAbsolutePath()));
 		}
-
 		List<File> packages = new ArrayList<>();
 		packages.addAll(FileUtils.listFiles(containerDir, new String[] { type.getPackageExtention() }, true));
 
@@ -1401,7 +1406,7 @@ public final class Installer {
         Properties wfInput = new Properties();
         try {
             String wfInputString = new String(Files.readAllBytes(Paths.get(wfInputFilePath)));
-            if (Installer.isValidYaml(wfInputString)) {
+            if (Installer.isValidYaml(wfInputFilePath, wfInputString)) {
                 wfInputString = Installer.convertYamlToJson(wfInputFilePath, wfInputString);
             }
 
@@ -1450,12 +1455,13 @@ public final class Installer {
         }
     }
 	
-    private static boolean isValidYaml(String yamlString) {
+    private static boolean isValidYaml(String fileName, String yamlString) {
         Yaml yaml = new Yaml();
         try {
             yaml.load(yamlString);
             return true;
         } catch (ParserException e) {
+            LOGGER.debug("Failed to parse the YAML string from file '{}' : {}", fileName, e.getLocalizedMessage());
             return false;
         }
     }

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -1406,7 +1406,7 @@ public final class Installer {
             }
 
             for (Map.Entry<String, JsonElement> entry : gson.fromJson(wfInputString, JsonObject.class).entrySet()) {
-                wfInput.put(entry.getKey(),StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
+                wfInput.put(entry.getKey(), StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
             }
             List<String> prefixes = new ArrayList<>();
             if (input.allTrue(Option.VRO_EMBEDDED)) {


### PR DESCRIPTION
### Description

Add Support for YAML input format for the workflow inputs / outputs when workflow is ran via the installer. 
If the input / output files that is specified via the installer parameters are in YAML format it will be used as workflow input. / output. 
JSON format is still supported as well.

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

The testing procedure is following:
1. Create a VRO project that has at least one workflow that contains input and output parameters.
2. Push the project to an environment
3. Create package installer (-Pbundle-with-installer)
4. Create inputs.yaml and outputs.yaml files. Define the input parameters in the first file.
5. Create an environment.properties file that contains the id of the pushed workflow and paths to the files created in step 4.
6. Run the installer script.

### Release Notes

Add Support for YAML input format for the workflow inputs / outputs when workflow is ran via the installer. 
If the input / output files that is specified via the installer parameters are in YAML format it will be used as workflow input. / output. 
JSON format is still supported as well.

### Related issues and PRs

#467 
