### PR TITLE
[artifact-manager] (#533) Better error handling when parameters are missing types

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVro.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVro.java
@@ -863,6 +863,13 @@ public class RestClientVro extends RestClient {
 				keyType = inputParametersTypes.get(entry.getKey()).toString();
 			}
 
+			// Prevents a NullPointerException when the keyType is null. Can't switch null
+			if (keyType == null) {
+				throw new RuntimeException(
+						String.format("Unable to find type for parameter '%s' in input parameters types",
+								entry.getKey()));
+			}
+
 			switch (keyType) {
 				case "Array/string":
 					ArrayStringValue arrayStringValue = new ArrayStringValue();

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/rest/vro/RestClientVroTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/rest/vro/RestClientVroTest.java
@@ -34,56 +34,47 @@ import com.vmware.pscoe.iac.artifact.helpers.vro.RestClientVroTestDouble;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class RestClientVroTest {    
+public class RestClientVroTest {
 	protected RestTemplate restTemplate;
 	protected ConfigurationVro config;
 	protected RestClientVroTestDouble restClient;
 
 	@BeforeEach
-	void init() {	
+	void init() {
 		restTemplate = Mockito.mock(RestTemplate.class);
 		config = Mockito.mock(ConfigurationVro.class);
 		restClient = new RestClientVroTestDouble(config, restTemplate);
 		when(config.getHost()).thenReturn("vra-l-01a.corp.local");
-		when(config.getPort()).thenReturn(443);            
-		System.out.println( "==========================================================" );
-		System.out.println( "START" );
-		System.out.println( "==========================================================" );
+		when(config.getPort()).thenReturn(443);
+		System.out.println("==========================================================");
+		System.out.println("START");
+		System.out.println("==========================================================");
 	}
 
 	@AfterEach
 	void tearDown() {
-		System.out.println( "==========================================================" );
-		System.out.println( "END" );
-		System.out.println( "==========================================================" );
+		System.out.println("==========================================================");
+		System.out.println("END");
+		System.out.println("==========================================================");
 	}
 
 	@Test
 	void testGetInputParametersTypes() {
 
-		// GIVEN        
-		String responseBody = String.join("\n"
-		 , "{"
-		 , "    \"display-name\": \"Install\","
-		 , "    \"input\": {"
-		 , "        \"param\": ["
-		 , "            { \"name\": \"jsonString\", \"type\": \"string\" },"
-		 , "            { \"name\": \"tags\", \"type\": \"Array/string\" },"
-		 , "            { \"name\": \"blacklist\", \"type\": \"Array/string\" }"
-		 , "        ]"
-		 , "    }"
-		 , "}"
-		);
-		
-		// WHEN                        
+		// GIVEN
+		String responseBody = String.join("\n", "{", "    \"display-name\": \"Install\",", "    \"input\": {",
+				"        \"param\": [", "            { \"name\": \"jsonString\", \"type\": \"string\" },",
+				"            { \"name\": \"tags\", \"type\": \"Array/string\" },",
+				"            { \"name\": \"blacklist\", \"type\": \"Array/string\" }", "        ]", "    }", "}");
+
+		// WHEN
 		when(
-			restTemplate.exchange(
-				any(URI.class),
-				any(HttpMethod.class),
-				any(HttpEntity.class),
-				any(Class.class)
-			)
-		).thenReturn(new ResponseEntity<String>(responseBody, HttpStatus.OK));
+				restTemplate.exchange(
+						any(URI.class),
+						any(HttpMethod.class),
+						any(HttpEntity.class),
+						any(Class.class)))
+				.thenReturn(new ResponseEntity<String>(responseBody, HttpStatus.OK));
 
 		Properties parametersTypes = restClient.getInputParametersTypes("1490692845582937823496790834565483423");
 
@@ -95,9 +86,9 @@ public class RestClientVroTest {
 
 	@Test
 	void testBuildParametersJsonForNumberType() {
-		
+
 		// GIVEN
-		Properties params = new Properties(); 
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
 
 		params.put("foo", 9);
@@ -106,29 +97,28 @@ public class RestClientVroTest {
 		inputParametersTypes.put("foo", "number");
 		inputParametersTypes.put("bar", "number");
 
-		String expectedResult = String.join("", 
-			"{",
-				"\"parameters\":[{", 
-					"\"name\":\"bar\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"number\",", 
-					"\"value\":{",
-						"\"number\":{",
-							"\"value\":11",
-						"}",
-					"}",
+		String expectedResult = String.join("",
+				"{",
+				"\"parameters\":[{",
+				"\"name\":\"bar\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"number\",",
+				"\"value\":{",
+				"\"number\":{",
+				"\"value\":11",
+				"}",
+				"}",
 				"},{",
-					"\"name\":\"foo\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"number\",", 
-					"\"value\":{",
-						"\"number\":{",
-							"\"value\":9",
-						"}",
-					"}",
+				"\"name\":\"foo\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"number\",",
+				"\"value\":{",
+				"\"number\":{",
+				"\"value\":9",
+				"}",
+				"}",
 				"}]",
-			"}"
-		);
+				"}");
 
 		// WHEN
 		String actualResult = restClient.buildParametersJson(params, inputParametersTypes);
@@ -139,9 +129,9 @@ public class RestClientVroTest {
 
 	@Test
 	void testBuildParametersJsonForBooleanType() {
-		
+
 		// GIVEN
-		Properties params = new Properties(); 
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
 
 		params.put("foo", false);
@@ -150,29 +140,28 @@ public class RestClientVroTest {
 		inputParametersTypes.put("foo", "boolean");
 		inputParametersTypes.put("bar", "boolean");
 
-		String expectedResult = String.join("", 
-			"{",
-				"\"parameters\":[{", 
-					"\"name\":\"bar\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"boolean\",", 
-					"\"value\":{",
-						"\"boolean\":{",
-							"\"value\":true",
-						"}",
-					"}",
+		String expectedResult = String.join("",
+				"{",
+				"\"parameters\":[{",
+				"\"name\":\"bar\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"boolean\",",
+				"\"value\":{",
+				"\"boolean\":{",
+				"\"value\":true",
+				"}",
+				"}",
 				"},{",
-					"\"name\":\"foo\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"boolean\",", 
-					"\"value\":{",
-						"\"boolean\":{",
-							"\"value\":false",
-						"}",
-					"}",
+				"\"name\":\"foo\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"boolean\",",
+				"\"value\":{",
+				"\"boolean\":{",
+				"\"value\":false",
+				"}",
+				"}",
 				"}]",
-			"}"
-		);
+				"}");
 
 		// WHEN
 		String actualResult = restClient.buildParametersJson(params, inputParametersTypes);
@@ -183,9 +172,9 @@ public class RestClientVroTest {
 
 	@Test
 	void testBuildParametersJsonForStringType() {
-		
+
 		// GIVEN
-		Properties params = new Properties(); 
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
 
 		params.put("foo", "abc");
@@ -194,29 +183,28 @@ public class RestClientVroTest {
 		inputParametersTypes.put("foo", "string");
 		inputParametersTypes.put("bar", "string");
 
-		String expectedResult = String.join("", 
-			"{",
-				"\"parameters\":[{", 
-					"\"name\":\"bar\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"string\",", 
-					"\"value\":{",
-						"\"string\":{",
-							"\"value\":\"def\"",
-						"}",
-					"}",
+		String expectedResult = String.join("",
+				"{",
+				"\"parameters\":[{",
+				"\"name\":\"bar\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"string\",",
+				"\"value\":{",
+				"\"string\":{",
+				"\"value\":\"def\"",
+				"}",
+				"}",
 				"},{",
-					"\"name\":\"foo\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"string\",", 
-					"\"value\":{",
-						"\"string\":{",
-							"\"value\":\"abc\"",
-						"}",
-					"}",
+				"\"name\":\"foo\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"string\",",
+				"\"value\":{",
+				"\"string\":{",
+				"\"value\":\"abc\"",
+				"}",
+				"}",
 				"}]",
-			"}"
-		);
+				"}");
 
 		// WHEN
 		String actualResult = restClient.buildParametersJson(params, inputParametersTypes);
@@ -227,9 +215,9 @@ public class RestClientVroTest {
 
 	@Test
 	void testBuildParametersJsonForNonExistentType() {
-		
+
 		// GIVEN
-		Properties params = new Properties(); 
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
 
 		params.put("foo", "abc");
@@ -238,30 +226,29 @@ public class RestClientVroTest {
 		inputParametersTypes.put("foo", "nonExistentType");
 		inputParametersTypes.put("bar", "nonExistentType");
 
-		//all non-existent types should be handled as String
-		String expectedResult = String.join("", 
-			"{",
-				"\"parameters\":[{", 
-					"\"name\":\"bar\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"string\",", 
-					"\"value\":{",
-						"\"string\":{",
-							"\"value\":\"def\"",
-						"}",
-					"}",
+		// all non-existent types should be handled as String
+		String expectedResult = String.join("",
+				"{",
+				"\"parameters\":[{",
+				"\"name\":\"bar\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"string\",",
+				"\"value\":{",
+				"\"string\":{",
+				"\"value\":\"def\"",
+				"}",
+				"}",
 				"},{",
-					"\"name\":\"foo\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"string\",", 
-					"\"value\":{",
-						"\"string\":{",
-							"\"value\":\"abc\"",
-						"}",
-					"}",
+				"\"name\":\"foo\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"string\",",
+				"\"value\":{",
+				"\"string\":{",
+				"\"value\":\"abc\"",
+				"}",
+				"}",
 				"}]",
-			"}"
-		);
+				"}");
 
 		// WHEN
 		String actualResult = restClient.buildParametersJson(params, inputParametersTypes);
@@ -272,37 +259,36 @@ public class RestClientVroTest {
 
 	@Test
 	void testBuildParametersJsonForStringArrayType() {
-		
+
 		// GIVEN
-		Properties params = new Properties(); 
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
 
 		params.put("foo", "[\"git\", \"avi\"]");
 
 		inputParametersTypes.put("foo", "Array/string");
 
-		String expectedResult = String.join("", 
-			"{",
-				"\"parameters\":[{", 
-					"\"name\":\"foo\",",
-					"\"scope\":\"local\",",
-					"\"type\":\"Array/string\",", 
-					"\"value\":{",
-						"\"array\":{",
-							"\"elements\":[{",
-								"\"string\":{",
-									"\"value\":\"git\"",
-								"}",
-							"},{",
-								"\"string\":{",
-									"\"value\":\"avi\"",
-								"}",
-							"}]",
-						"}",
-					"}",
+		String expectedResult = String.join("",
+				"{",
+				"\"parameters\":[{",
+				"\"name\":\"foo\",",
+				"\"scope\":\"local\",",
+				"\"type\":\"Array/string\",",
+				"\"value\":{",
+				"\"array\":{",
+				"\"elements\":[{",
+				"\"string\":{",
+				"\"value\":\"git\"",
+				"}",
+				"},{",
+				"\"string\":{",
+				"\"value\":\"avi\"",
+				"}",
 				"}]",
-			"}"
-		);
+				"}",
+				"}",
+				"}]",
+				"}");
 
 		// WHEN
 		String actualResult = restClient.buildParametersJson(params, inputParametersTypes);
@@ -313,35 +299,39 @@ public class RestClientVroTest {
 
 	@Test
 	void testStartWorkflow() {
-		//GIVEN
-		Properties params = new Properties(); 
+		// GIVEN
+		Properties params = new Properties();
 		Properties inputParametersTypes = new Properties();
-		
+
 		String workflowId = "1490692845582937823496790834565483423";
 		String expectedResult = "9e63824b-0612-41dd-9e69-8f7bb8c7846c";
-		String responseBody = String.join("\n"
-			, "{"
-			, "    \"id\": \"" + expectedResult + "\","
-			, "    \"state\": \"running\","
-			, "    \"start-date\": \"2022-05-27T09:05:27.587+00:00\","
-			, "    \"started-by\": \"configurationadmin\","
-			, "    \"running-instance-id\": \"vra-l-01a.corp.local-vco-app-77844f5fb9-csdlw\","
-			, "    \"name\": \"Install\","
-			, "    \"current-item-for-display\": \"__item-undefined__\""
-			, "}"
-		);
+		String responseBody = String.join("\n", "{", "    \"id\": \"" + expectedResult + "\",",
+				"    \"state\": \"running\",", "    \"start-date\": \"2022-05-27T09:05:27.587+00:00\",",
+				"    \"started-by\": \"configurationadmin\",",
+				"    \"running-instance-id\": \"vra-l-01a.corp.local-vco-app-77844f5fb9-csdlw\",",
+				"    \"name\": \"Install\",", "    \"current-item-for-display\": \"__item-undefined__\"", "}");
 
 		// WHEN
 		when(
-			restTemplate.exchange(
-				any(RequestEntity.class),
-				any(Class.class)
-			)
-		).thenReturn(new ResponseEntity<String>(responseBody, HttpStatus.OK));
+				restTemplate.exchange(
+						any(RequestEntity.class),
+						any(Class.class)))
+				.thenReturn(new ResponseEntity<String>(responseBody, HttpStatus.OK));
 
 		String actualResult = restClient.startWorkflow(workflowId, params, inputParametersTypes);
 
 		// THEN
-		assertEquals(expectedResult, actualResult);		
+		assertEquals(expectedResult, actualResult);
+	}
+
+	@Test
+	void testStartWorkflowWhenKeyTypeIsNullThrows() {
+		Properties params = new Properties();
+		params.put("foo", "abc");
+		Properties inputParametersTypes = new Properties();
+
+		String workflowId = "1490692845582937823496790834565483423";
+
+		assertThrows(RuntimeException.class, () -> restClient.startWorkflow(workflowId, params, inputParametersTypes));
 	}
 }

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -39,6 +39,14 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### *Better error handling when starting vro workflow*
+
+#### Previous Behavior
+When starting a vro workflow, the error handling was not very clear and the error message was not very helpful when the params were missing the types.
+
+#### New Behavior
+The error handling has been improved and the error message is more helpful when the params are missing the types.
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
### Description

When there was a disparity between the parameters provided for the vro workflow and their types, a NullPointerException was thrown. Now there is a clearer message.

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Added unit tests.

Closes: #533 