### PR TITLE
[artifact-manager] (#562) Unreleasing blueprint versions fails

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNgPrimitive.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/rest/RestClientVraNgPrimitive.java
@@ -696,7 +696,7 @@ public class RestClientVraNgPrimitive extends RestClient {
 	public void unreleaseBlueprintVersionPrimitive(final String blueprintId, final String versionId)
 			throws URISyntaxException {
 		URI url = getURI(getURIBuilder().setPath(SERVICE_BLUEPRINT + "/" + blueprintId + SERVICE_BLUEPRINT_VERSIONS
-				+ "/" + versionId + "/" + SERVICE_BLUEPRINT_UNRELEASE_VERSIONS_ACTION));
+				+ "/" + versionId + SERVICE_BLUEPRINT_UNRELEASE_VERSIONS_ACTION));
 
 		try {
 			this.postJsonPrimitive(url, HttpMethod.POST, "");

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -64,6 +64,16 @@ The cheatsheet documents contained similar error:
 
 The cheatsheet documents are properly generated.
 
+### *Unreleasing BP versions would cause an exception*
+
+An exception was thrown like: `The request was rejected because the URL contained a potentially malicious String "//"","path":"/blueprint/api/blueprints/b355c354-a4b6-4d55-800a-8b4232f29b83/versions/2024-12-06-18-34-42//actions/unrelease`
+
+This was because of the `//` after the version id.
+
+#### New Behavior
+
+The extra `/` is removed when forming the url now
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
### Description


An exception was thrown like: `The request was rejected because the URL contained a potentially malicious String "//"","path":"/blueprint/api/blueprints/b355c354-a4b6-4d55-800a-8b4232f29b83/versions/2024-12-06-18-34-42//actions/unrelease`

This was because of the `//` after the version id.


### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing


Closes #562 