### PR TITLE
[installer] (#568) Default value of `Run vRO workflow?` interactive installer option changed to `N`

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -97,6 +97,29 @@ ABX packages are ignored in the bundle. The Installer completes the task without
 
 The Installer asks the user whether to install ABX packages and in case of positive response installs the packages.
 
+### *Change interactive installer default value of `Run vRO workflow?` option to `N`*
+
+#### Previous Behavior
+
+The default value was `Y` which often results in the user having to provide explicitly `N` as value.
+In interactive mode, it is assumed that the Java Installer is run manually by a user. In that case if the user wants to run a workflow it is more common to login into the Aria Automation Orchestrator UI and run the workflow from there benefiting from all of the tracking and monitoring offered by Aria Automation Orchestrator.
+
+#### New Behavior
+
+The default value is set to `N` enabling the user to just proceed to the next option without providing explicit value for the most common use cases.
+
+### *Fix interactive installer value hints for `Is single tenant environment?`*
+
+#### Previous Behavior
+
+There was a `(Y/N)` hardcoded in the question which resulted in double entry:
+`Is single tenant environment (Y/N)? (Y/N) [Y]:`
+
+#### New Behavior
+
+The question is updated:
+`Is single tenant environment? (Y/N) [Y]:`
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
+++ b/package-installer/src/main/java/com/vmware/pscoe/iac/installer/Installer.java
@@ -31,8 +31,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.beryx.textio.TextIO;
 import org.beryx.textio.TextIoFactory;
 import org.slf4j.Logger;
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.parser.ParserException;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -813,9 +814,9 @@ public final class Installer {
 	 */
 	private static final int EXIT_WF_EXEC_FAILED_CODE = -1;
 
-    /**
-     * Instance of the logger used in the installer.
-     */
+	/**
+	 * Instance of the logger used in the installer.
+	 */
 	private static final Logger LOGGER = LoggerFactory.getLogger(Installer.class);
 
 	private Installer() {
@@ -1113,7 +1114,7 @@ public final class Installer {
 			}
 			userInput(input, Option.VRO_DELETE_OLD_VERSIONS, "Clean up old vRO package versions?", true);
 		}
-		userInput(input, Option.VRO_RUN_WORKFLOW, "Run vRO workflow?", true);
+		userInput(input, Option.VRO_RUN_WORKFLOW, "Run vRO workflow?", false);
 		if (input.allTrue(Option.VRO_RUN_WORKFLOW)) {
 			if (input.anyTrue(Option.VRO_EMBEDDED)) {
 				readVroEmbeddedInVrangProperties(input, false);
@@ -1220,7 +1221,7 @@ public final class Installer {
 		Validate.hostAndPort(input.get(Option.VRO_SERVER), Integer.valueOf(input.get(Option.VRO_PORT)),
 				input.getText());
 		if (!input.getText().newBooleanInputReader().withDefaultValue(true)
-				.read("  Is single tenant environment (Y/N)?")) {
+				.read("  Is single tenant environment?")) {
 			userInput(input, Option.VRO_TENANT, "  vRO Tenant", "vsphere.local");
 		}
 		userInput(input, Option.VRO_USERNAME, "  vRO Username[@Domain]", "administrator@vsphere.local");
@@ -1389,7 +1390,8 @@ public final class Installer {
 			return new ArrayList<>();
 		}
 		if (!containerDir.isDirectory()) {
-			throw new RuntimeException(String.format("Cannot find any packages at %s .", containerDir.getAbsolutePath()));
+			throw new RuntimeException(
+					String.format("Cannot find any packages at %s .", containerDir.getAbsolutePath()));
 		}
 		List<File> packages = new ArrayList<>();
 		packages.addAll(FileUtils.listFiles(containerDir, new String[] { type.getPackageExtention() }, true));
@@ -1397,125 +1399,139 @@ public final class Installer {
 		return packages.stream().map(file -> PackageFactory.getInstance(type, file)).collect(Collectors.toList());
 	}
 
-    private static void runWorkflow(final Input input) throws ConfigurationException {
-        input.getText().getTextTerminal().println("Executing vRealize Orchestrator Workflow ...");
+	private static void runWorkflow(final Input input) throws ConfigurationException {
+		input.getText().getTextTerminal().println("Executing vRealize Orchestrator Workflow ...");
 
-        Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-        String wfID = input.get(Option.VRO_RUN_WORKFLOW_ID);
-        String wfInputFilePath = input.get(Option.VRO_RUN_WORKFLOW_INPUT_FILE_PATH);
-        String wfOutputFilePath = input.get(Option.VRO_RUN_WORKFLOW_OUTPUT_FILE);
-        String wfErrFilePath = input.get(Option.VRO_RUN_WORKFLOW_ERR_FILE);
-        wfErrFilePath = StringUtils.isEmpty(wfErrFilePath) && !StringUtils.isEmpty(wfOutputFilePath)
-                ? wfOutputFilePath + ".err"
-                : "workflow.err";
-        String wfTimeout = input.get(Option.VRO_RUN_WORKFLOW_TIMEOUT);
+		Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
+		String wfID = input.get(Option.VRO_RUN_WORKFLOW_ID);
+		String wfInputFilePath = input.get(Option.VRO_RUN_WORKFLOW_INPUT_FILE_PATH);
+		String wfOutputFilePath = input.get(Option.VRO_RUN_WORKFLOW_OUTPUT_FILE);
+		String wfErrFilePath = input.get(Option.VRO_RUN_WORKFLOW_ERR_FILE);
+		wfErrFilePath = StringUtils.isEmpty(wfErrFilePath) && !StringUtils.isEmpty(wfOutputFilePath)
+				? wfOutputFilePath + ".err"
+				: "workflow.err";
+		String wfTimeout = input.get(Option.VRO_RUN_WORKFLOW_TIMEOUT);
 
-        Properties wfInput = new Properties();
-        try {
-            String wfInputString = new String(Files.readAllBytes(Paths.get(wfInputFilePath)));
-            if (Installer.isValidYaml(wfInputFilePath, wfInputString)) {
-                wfInputString = Installer.convertYamlToJson(wfInputFilePath, wfInputString);
-            }
+		Properties wfInput = new Properties();
+		try {
+			String wfInputString = new String(Files.readAllBytes(Paths.get(wfInputFilePath)));
+			if (Installer.isValidYaml(wfInputFilePath, wfInputString)) {
+				wfInputString = Installer.convertYamlToJson(wfInputFilePath, wfInputString);
+			}
 
-            for (Map.Entry<String, JsonElement> entry : gson.fromJson(wfInputString, JsonObject.class).entrySet()) {
-                wfInput.put(entry.getKey(), StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
-            }
-            List<String> prefixes = new ArrayList<>();
-            if (input.allTrue(Option.VRO_EMBEDDED)) {
-                prefixes.add(ConfigurationPrefix.VRO.getValue());
-                prefixes.add(ConfigurationPrefix.VRANG.getValue());
-            } else {
-                prefixes.add(ConfigurationPrefix.VRO.getValue());
-            }
-            RestClientVro client = RestClientFactory.getClientVro(ConfigurationVro.fromProperties(input.getMappings(prefixes.toArray(new String[0]))));
-            WorkflowExecution workflowExecutionResult = new VroWorkflowExecutor(client).executeWorkflow(wfID, wfInput, Integer.parseInt(wfTimeout));
+			for (Map.Entry<String, JsonElement> entry : gson.fromJson(wfInputString, JsonObject.class).entrySet()) {
+				wfInput.put(entry.getKey(), StringEscapeUtils.escapeJava(gson.toJson(entry.getValue())));
+			}
+			List<String> prefixes = new ArrayList<>();
+			if (input.allTrue(Option.VRO_EMBEDDED)) {
+				prefixes.add(ConfigurationPrefix.VRO.getValue());
+				prefixes.add(ConfigurationPrefix.VRANG.getValue());
+			} else {
+				prefixes.add(ConfigurationPrefix.VRO.getValue());
+			}
+			RestClientVro client = RestClientFactory
+					.getClientVro(ConfigurationVro.fromProperties(input.getMappings(prefixes.toArray(new String[0]))));
+			WorkflowExecution workflowExecutionResult = new VroWorkflowExecutor(client).executeWorkflow(wfID, wfInput,
+					Integer.parseInt(wfTimeout));
 
-            JsonObject wfOutputJson = new JsonObject();
-            for (String key : workflowExecutionResult.getOutput().stringPropertyNames()) {
-                String value = StringEscapeUtils.unescapeJson(workflowExecutionResult.getOutput().getProperty(key));
-                wfOutputJson.add(key, gson.fromJson(value, JsonObject.class));
-            }
-            // write the workflow output
-            String outputString = gson.toJson(wfOutputJson);
-            if (Installer.endsWithIgnoreCase(wfOutputFilePath, "yaml") || Installer.endsWithIgnoreCase(wfOutputFilePath, "yml")) {
-                outputString = Installer.convertJsonObjectToYaml(wfOutputFilePath, wfOutputJson);
-            }
+			JsonObject wfOutputJson = new JsonObject();
+			for (String key : workflowExecutionResult.getOutput().stringPropertyNames()) {
+				String value = StringEscapeUtils.unescapeJson(workflowExecutionResult.getOutput().getProperty(key));
+				wfOutputJson.add(key, gson.fromJson(value, JsonObject.class));
+			}
+			// write the workflow output
+			String outputString = gson.toJson(wfOutputJson);
+			if (Installer.endsWithIgnoreCase(wfOutputFilePath, "yaml")
+					|| Installer.endsWithIgnoreCase(wfOutputFilePath, "yml")) {
+				outputString = Installer.convertJsonObjectToYaml(wfOutputFilePath, wfOutputJson);
+			}
 
-            Files.write(Paths.get(wfOutputFilePath), outputString.getBytes(), StandardOpenOption.CREATE);
-            // write the workflow error in a workflow error file (if any)
-            if (!StringUtils.isEmpty(workflowExecutionResult.getError())) {
-                Files.write(Paths.get(wfErrFilePath), workflowExecutionResult.getError().getBytes(), StandardOpenOption.CREATE);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-        } catch (JsonSyntaxException e) {
-            throw new RuntimeException("Unable to parse input / output file data: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-        } catch (WorkflowExecutionException e) {
-            try {
-                Files.write(Paths.get(wfErrFilePath), e.getMessage().getBytes(), StandardOpenOption.CREATE);
-            } catch (IOException e1) {
-                throw new RuntimeException("Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-            }
-            throw new RuntimeException("Workflow execution failed: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-        } catch (Exception e) {
-            throw new RuntimeException("General error during workflow execution: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
-        }
-    }
-	
-    private static boolean isValidYaml(String fileName, String yamlString) {
-        Yaml yaml = new Yaml();
-        try {
-            yaml.load(yamlString);
-            return true;
-        } catch (ParserException e) {
-            LOGGER.debug("Encountered an error while parsing workflow input file '{}' as YAML. File will be processed as JSON. Error: {}", fileName, e.getLocalizedMessage());
-            return false;
-        }
-    }
+			Files.write(Paths.get(wfOutputFilePath), outputString.getBytes(), StandardOpenOption.CREATE);
+			// write the workflow error in a workflow error file (if any)
+			if (!StringUtils.isEmpty(workflowExecutionResult.getError())) {
+				Files.write(Paths.get(wfErrFilePath), workflowExecutionResult.getError().getBytes(),
+						StandardOpenOption.CREATE);
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(
+					"Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+		} catch (JsonSyntaxException e) {
+			throw new RuntimeException("Unable to parse input / output file data: " + e.getClass().getName() + " : "
+					+ e.getLocalizedMessage(), e);
+		} catch (WorkflowExecutionException e) {
+			try {
+				Files.write(Paths.get(wfErrFilePath), e.getMessage().getBytes(), StandardOpenOption.CREATE);
+			} catch (IOException e1) {
+				throw new RuntimeException(
+						"Unable to perform file operation: " + e.getClass().getName() + " : " + e.getLocalizedMessage(),
+						e);
+			}
+			throw new RuntimeException(
+					"Workflow execution failed: " + e.getClass().getName() + " : " + e.getLocalizedMessage(), e);
+		} catch (Exception e) {
+			throw new RuntimeException("General error during workflow execution: " + e.getClass().getName() + " : "
+					+ e.getLocalizedMessage(), e);
+		}
+	}
 
-    private static String convertYamlToJson(String fileName, String yamlString) {
-        Yaml yaml = new Yaml();
-        ObjectMapper jsonMapper = new ObjectMapper();
-        jsonMapper.enable(SerializationFeature.INDENT_OUTPUT);
+	private static boolean isValidYaml(String fileName, String yamlString) {
+		Yaml yaml = new Yaml();
+		try {
+			yaml.load(yamlString);
+			return true;
+		} catch (ParserException e) {
+			LOGGER.debug(
+					"Encountered an error while parsing workflow input file '{}' as YAML. File will be processed as JSON. Error: {}",
+					fileName, e.getLocalizedMessage());
+			return false;
+		}
+	}
 
-        try {
-            // Parse YAML
-            Map<String, Object> yamlMap = yaml.load(yamlString);
-            // Convert to JSON
-            return jsonMapper.writeValueAsString(yamlMap);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(String.format("Unable to convert YAML file '%s' to JSON: '%s'", fileName, e.getLocalizedMessage()));
-        }
-    }
+	private static String convertYamlToJson(String fileName, String yamlString) {
+		Yaml yaml = new Yaml();
+		ObjectMapper jsonMapper = new ObjectMapper();
+		jsonMapper.enable(SerializationFeature.INDENT_OUTPUT);
 
-    private static String convertJsonObjectToYaml(String fileName, JsonObject jsonObject) {
-        if (jsonObject.isEmpty()) {
-            return "---";
-        }
-        ObjectMapper jsonMapper = new ObjectMapper();
-        DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        Yaml yaml = new Yaml(options);
+		try {
+			// Parse YAML
+			Map<String, Object> yamlMap = yaml.load(yamlString);
+			// Convert to JSON
+			return jsonMapper.writeValueAsString(yamlMap);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(
+					String.format("Unable to convert YAML file '%s' to JSON: '%s'", fileName, e.getLocalizedMessage()));
+		}
+	}
 
-        try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> jsonMap = jsonMapper.readValue(jsonObject.toString(), Map.class);
-            return yaml.dump(jsonMap);
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Unable to convert JSON object to YAML file '%s': '%s'", fileName, e.getLocalizedMessage()));
-        }
-    }
-    
-    private static boolean endsWithIgnoreCase(String str, String suffix) {
-        if (str == null || suffix == null) {
-            return false;
-        }
-        if (suffix.length() > str.length()) {
-            return false;
-        }
-        String lowerStr = str.toLowerCase();
-        String lowerSuffix = suffix.toLowerCase();
+	private static String convertJsonObjectToYaml(String fileName, JsonObject jsonObject) {
+		if (jsonObject.isEmpty()) {
+			return "---";
+		}
+		ObjectMapper jsonMapper = new ObjectMapper();
+		DumperOptions options = new DumperOptions();
+		options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		Yaml yaml = new Yaml(options);
 
-        return lowerStr.endsWith(lowerSuffix);
-    }    
+		try {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> jsonMap = jsonMapper.readValue(jsonObject.toString(), Map.class);
+			return yaml.dump(jsonMap);
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Unable to convert JSON object to YAML file '%s': '%s'", fileName,
+					e.getLocalizedMessage()));
+		}
+	}
+
+	private static boolean endsWithIgnoreCase(String str, String suffix) {
+		if (str == null || suffix == null) {
+			return false;
+		}
+		if (suffix.length() > str.length()) {
+			return false;
+		}
+		String lowerStr = str.toLowerCase();
+		String lowerSuffix = suffix.toLowerCase();
+
+		return lowerStr.endsWith(lowerSuffix);
+	}
 }


### PR DESCRIPTION
### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue



### Release Notes

### *Change interactive installer default value of `Run vRO workflow?` option to `N`*

#### Previous Behavior

The default value was `Y` which often results in the user having to provide explicitly `N` as value.
In interactive mode, it is assumed that the Java Installer is run manually by a user. In that case if the user wants to run a workflow it is more common to login into the Aria Automation Orchestrator UI and run the workflow from there benefiting from all of the tracking and monitoring offered by Aria Automation Orchestrator.

#### New Behavior

The default value is set to `N` enabling the user to just proceed to the next option without providing explicit value for the most common use cases.

### *Fix interactive installer value hints for `Is single tenant environment?`*

#### Previous Behavior

There was a `(Y/N)` hardcoded in the question which resulted in double entry:
`Is single tenant environment (Y/N)? (Y/N) [Y]:`

#### New Behavior

The question is updated:
`Is single tenant environment? (Y/N) [Y]:`

### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
Closes #568 
