### PR TITLE
[vro-scripting-api,vro-types] Add optional null output for `Server` class functions

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -28,6 +28,24 @@
 
 ## Improvements
 
+### *Improve type definitions of Server class functions*
+
+Improve type definitions of Server class functions by adding `| null` to the return type.
+
+#### Previous Behavior
+
+The return type of some function definitions in the Server class mismatched the actual return type.
+
+#### New Behavior
+
+The following function definitions have `| null` added to their return type:
+
+- `Server.getWorkflowCategoryWithPath`
+- `Server.getConfigurationElementCategoryWithPath`
+- `Server.getResourceElementCategoryWithPath`
+- `Server.getPackageWithName`
+- `Server.getPolicyTemplateCategoryWithPath`
+
 [//]: # (### *Improvement Name* )
 [//]: # (Talk ONLY regarding the improvement)
 [//]: # (Optional But higlhy recommended)

--- a/typescript/vro-scripting-api/src/api/Server.ts
+++ b/typescript/vro-scripting-api/src/api/Server.ts
@@ -219,7 +219,7 @@ namespace vroapi {
 		 * Return a configuration element category matching the given path or null if not found.
 		 * @param path The path to the configuration element category using forward slash(/) as separator.
 		 */
-		static getConfigurationElementCategoryWithPath(path: string): ConfigurationElementCategory {
+		static getConfigurationElementCategoryWithPath(path: string): ConfigurationElementCategory | null {
 			return configurations.getCategory(path);
 		}
 
@@ -282,9 +282,8 @@ namespace vroapi {
 		 * Return a package given its name or null if not found.
 		 * @param name The package name.
 		 */
-		static getPackageWithName(name: string): Package {
+		static getPackageWithName(name: string): Package | null {
 			throw new NotSupportedError();
-
 		}
 
 		/**
@@ -299,7 +298,7 @@ namespace vroapi {
 		 * Return a policy template category matching the given path or null if not found.
 		 * @param path The path to the policy template category using forward slash(/) as separator.
 		 */
-		static getPolicyTemplateCategoryWithPath(path: string): PolicyTemplateCategory {
+		static getPolicyTemplateCategoryWithPath(path: string): PolicyTemplateCategory | null {
 			throw new NotSupportedError();
 		}
 
@@ -307,7 +306,7 @@ namespace vroapi {
 		 * Return a resource element category matching the given path or null if not found.
 		 * @param path The path to the resource element category using forward slash(/) as separator.
 		 */
-		static getResourceElementCategoryWithPath(path: string): ResourceElementCategory {
+		static getResourceElementCategoryWithPath(path: string): ResourceElementCategory | null {
 			return resources.getCategory(path);
 		}
 
@@ -338,7 +337,7 @@ namespace vroapi {
 		 * Return a workflow category matching the given path or null if not found.
 		 * @param path The path to the workflow category using forward slash(/) as separator.
 		 */
-		static getWorkflowCategoryWithPath(path: string): WorkflowCategory {
+		static getWorkflowCategoryWithPath(path: string): WorkflowCategory | null {
 			throw new NotSupportedError();
 		}
 

--- a/typescript/vro-scripting-api/src/configurations.ts
+++ b/typescript/vro-scripting-api/src/configurations.ts
@@ -72,7 +72,7 @@ namespace vroapi {
         return Object.values(parentDescriptor.children || {}).map(child => getOrCreateCategory(child));
     }
 
-    function getCategory(categoryPath: string): ConfigurationElementCategory {
+    function getCategory(categoryPath: string): ConfigurationElementCategory | null {
         const categoryDescriptor = findDescriptorByPath(categoryPath);
         return categoryDescriptor ? getOrCreateCategory(categoryDescriptor) : null;
     }
@@ -96,7 +96,7 @@ namespace vroapi {
         return Object.values(categoryDescriptor.elements).map(elem => getOrCreateElement(elem, category));
     }
 
-    function getElement(categoryPath: string, name: string): ConfigurationElement {
+    function getElement(categoryPath: string, name: string): ConfigurationElement | null {
         const categoryDescriptor = findDescriptorByPath(categoryPath);
         if (!categoryDescriptor) {
             return null;

--- a/typescript/vro-scripting-api/src/resources.ts
+++ b/typescript/vro-scripting-api/src/resources.ts
@@ -65,7 +65,7 @@ namespace vroapi {
         return Object.values(parentDescriptor.children || {}).map(child => getOrCreateCategory(child));
     }
 
-    function getCategory(categoryPath: string): ResourceElementCategory {
+    function getCategory(categoryPath: string): ResourceElementCategory | null {
         const categoryDescriptor = findDescriptorByPath(categoryPath);
         return categoryDescriptor ? getOrCreateCategory(categoryDescriptor) : null;
     }
@@ -89,7 +89,7 @@ namespace vroapi {
         return Object.values(categoryDescriptor.elements).map(elem => getOrCreateElement(elem, category));
     }
 
-    function getElement(categoryPath: string, name: string): ResourceElement {
+    function getElement(categoryPath: string, name: string): ResourceElement | null {
         const categoryDescriptor = findDescriptorByPath(categoryPath);
         if (!categoryDescriptor) {
             return null;
@@ -136,7 +136,7 @@ namespace vroapi {
         }
     }
 
-    function getElementContent(categoryPath: string, elementName: string): string {
+    function getElementContent(categoryPath: string, elementName: string): string | null {
         const categoryDescriptor = findDescriptorByPath(categoryPath);
         if (!categoryDescriptor) {
             return null;

--- a/vro-types/o11n-core/index.d.ts
+++ b/vro-types/o11n-core/index.d.ts
@@ -1764,27 +1764,27 @@ declare namespace Server {
 	 * Return a workflow category matching the given path or null if not found.
 	 * @param path The path to the workflow category using forward slash(/) as separator.
 	 */
-	function getWorkflowCategoryWithPath(path: string): WorkflowCategory;
+	function getWorkflowCategoryWithPath(path: string): WorkflowCategory | null;
 	/**
 	 * Return a configuration element category matching the given path or null if not found.
 	 * @param path The path to the configuration element category using forward slash(/) as separator.
 	 */
-	function getConfigurationElementCategoryWithPath(path: string): ConfigurationElementCategory;
+	function getConfigurationElementCategoryWithPath(path: string): ConfigurationElementCategory | null;
 	/**
 	 * Return a resource element category matching the given path or null if not found.
 	 * @param path The path to the resource element category using forward slash(/) as separator.
 	 */
-	function getResourceElementCategoryWithPath(path: string): ResourceElementCategory;
+	function getResourceElementCategoryWithPath(path: string): ResourceElementCategory | null;
 	/**
 	 * Return a package given its name or null if not found.
 	 * @param name The package name.
 	 */
-	function getPackageWithName(name: string): Package;
+	function getPackageWithName(name: string): Package | null;
 	/**
 	 * Return a policy template category matching the given path or null if not found.
 	 * @param path The path to the policy template category using forward slash(/) as separator.
 	 */
-	function getPolicyTemplateCategoryWithPath(path: string): PolicyTemplateCategory;
+	function getPolicyTemplateCategoryWithPath(path: string): PolicyTemplateCategory | null;
 	/**
 	 * Return all policy template categories.
 	 */


### PR DESCRIPTION
### Description

Noticed that when working with `Server.getConfigurationElementCategoryWithPath` it could return `null`, while the type definition does not reflect that.

I hope I adjusted the correct files. Reading #351, I updated the definitions in `vro-scripting-api` and in `vro-types`.

The unit tests already assert the return value `.not.tobeNull()`. This PR only updates the return types of these functions.

The changes are based on the JSDoc comment mentioning "or null if not found".
But verified this in an actual vRO environment.

### Checklist

- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**

### Testing

Tested in a live vRO tenant that the functions indeed do return `null` if not found.

### Release Notes

Improve type definitions of Server class functions by adding `| null` to the return type.

