### PR TITLE
[vrotsc] (#615) Fix incorrectly transpiled `DecisionItem` Workflow decorator

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -28,6 +28,17 @@
 
 ## Improvements
 
+[//]: # (### *Improvement Name* )
+[//]: # (Talk ONLY regarding the improvement)
+[//]: # (Optional But higlhy recommended)
+[//]: # (#### Previous Behavior)
+[//]: # (Explain how it used to behave, regarding to the change)
+[//]: # (Optional But higlhy recommended)
+[//]: # (#### New Behavior)
+[//]: # (Explain how it behaves now, regarding to the change)
+[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
+[//]: # (#### Relevant Documentation:)
+
 ### *Improve type definitions of Server class functions*
 
 Improve type definitions of Server class functions by adding `| null` to the return type.
@@ -46,16 +57,17 @@ The following function definitions have `| null` added to their return type:
 - `Server.getPackageWithName`
 - `Server.getPolicyTemplateCategoryWithPath`
 
-[//]: # (### *Improvement Name* )
-[//]: # (Talk ONLY regarding the improvement)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### Previous Behavior)
-[//]: # (Explain how it used to behave, regarding to the change)
-[//]: # (Optional But higlhy recommended)
-[//]: # (#### New Behavior)
-[//]: # (Explain how it behaves now, regarding to the change)
-[//]: # (Optional But higlhy recommended Specify *NONE* if missing)
-[//]: # (#### Relevant Documentation:)
+### *Fix Decision element transpilation issue*
+
+In Typescript workflow classes, methods with the DecisionItem decorator were transpiled incorrectly into Javascript.
+
+#### Previous Behavior
+
+Closing brackets ('{'), e.g in if blocks, were missing from the contents of the transpiled Decision element.
+
+#### New Behavior
+
+Closing brackets are no longer missing from the contents of the transpiled Decision element.
 
 ## Upgrade procedure
 

--- a/typescript/vrotsc/src/compiler/transformer/fileTransformers/workflow/decorators/decisionItemDecoratorStrategy.ts
+++ b/typescript/vrotsc/src/compiler/transformer/fileTransformers/workflow/decorators/decisionItemDecoratorStrategy.ts
@@ -150,7 +150,7 @@ export default class DecisionItemDecoratorStrategy extends BaseItemDecoratorStra
 	 * @param sourceText The source text to clear the `wrapper` function from
 	 * @returns The source text without the `wrapper` function
 	 */
-	private clearWrapperFunction(sourceText: string): string {
-		return sourceText.replace(/function wrapper\(\) \{|}$/gm, '').trim();
+    private clearWrapperFunction(sourceText: string): string {
+        return sourceText.replace(/function wrapper\(\) \{([\s\S]*)\}$/gm, '$1').trim();
 	}
 }


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->
### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [ ] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [ ] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Confirmed issue on v3.2.0. Tested fix by building a project inWF containing DecisionItem with closing brackets in its contents.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->

### Related issues and PRs
Closes #615 
<!-- Link any related issues and pull requests here using #number or user/repo#number -->
