### PR TITLE
[maven/plugins] Update Javadoc

### DIFF
--- a/maven/plugins/common/pom.xml
+++ b/maven/plugins/common/pom.xml
@@ -53,17 +53,4 @@
 		</dependency>
 	</dependencies>
 
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-
 </project>

--- a/maven/plugins/common/src/main/java/com/vmware/pscoe/maven/plugins/AbstractVroTestMojo.java
+++ b/maven/plugins/common/src/main/java/com/vmware/pscoe/maven/plugins/AbstractVroTestMojo.java
@@ -69,8 +69,8 @@ public abstract class AbstractVroTestMojo extends AbstractMojo {
     /**
      * Converts the path argument so that it is platform independent.
      *
-     * @param first first path argument
-     * @param MojoFailureException other path arguments.
+     * @param first first path argument.
+     * @param more next path argument.
      *
      * @return path argument that is platform independent.
      */

--- a/maven/plugins/typescript/pom.xml
+++ b/maven/plugins/typescript/pom.xml
@@ -36,17 +36,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.11.2</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/maven/plugins/typescript/src/main/java/com/vmware/pscoe/maven/plugins/TypescriptTestMojo.java
+++ b/maven/plugins/typescript/src/main/java/com/vmware/pscoe/maven/plugins/TypescriptTestMojo.java
@@ -44,7 +44,6 @@ public class TypescriptTestMojo extends AbstractVroTestMojo {
      * @param cmd command line arguments
      * @param config configuration object.
      *
-     * @return true if there are files in the test path otherwise false.
      */
 	protected void addTestbedPaths(List<String> cmd, Configuration config) {
 		String projectRoot = project.getBasedir().toPath().toString();


### PR DESCRIPTION
[vrotsc, maven] Update Javadoc. 

### Description

Updated java doc and removed dependency to the javadoc plugin in the maven/plugins/common and vrotsc modules.

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Run build of those components locally using
```bash
mvn clean install
```

### Release Notes

Updated java doc and removed dependency to the javadoc plugin in the maven/plugins/common and vrotsc modules.

