### PR TITLE
[installer] (#658) Add Logging Configuration for the Installer

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -43,7 +43,7 @@
 
 #### Previous Behavior
 
-During deploying a package via the package installer, the logs were missing, hence making hard to trace errors during deploymeng.
+During package deployment via package installer, the logs were missing, hence making it hard to trace errors.
 
 #### New Behavior
 

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -39,6 +39,16 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### *Fixed Missing Logs During Installer Run
+
+#### Previous Behavior
+
+During deploying a package via the package installer, the logs were missing, hence making hard to trace errors during deploymeng.
+
+#### New Behavior
+
+Log messages are now appearing during package deployment via the installer. Additional logging configuration file called *logback.xml* was added to the *etc* directory in the installer that configures the logging severity.
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)

--- a/package-installer/etc/logback.xml
+++ b/package-installer/etc/logback.xml
@@ -1,17 +1,53 @@
 <configuration>
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- Console appender for INFO logs -->
+    <appender name="INFO_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <!-- Set the root logger level -->
+    <!-- Console appender for WARN logs -->
+    <appender name="WARN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Console appender for DEBUG logs -->
+    <appender name="DEBUG_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Root logger with level INFO -->
     <root level="INFO">
-        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="INFO_CONSOLE" />
+        <appender-ref ref="WARN_CONSOLE" />
+        <appender-ref ref="DEBUG_CONSOLE" />
     </root>
 
-    <!-- Set logger level for the installer package to INFO or WARN -->
-    <logger name="com.vmware.pscoe.iac.installer.Installer" level="INFO, WARN" />
-    <!-- Uncomment the below line if DEBUG logging is needed as well -->
-    <!-- <logger name="com.vmware.pscoe.iac.installer" level="INFO, WARN, DEBUG" /> -->    
+    <!-- Uncomment the below tag if you need to enable DEBUG logging as well -->
+    <!--
+    <root level="DEBUG">
+        <appender-ref ref="INFO_CONSOLE" />
+        <appender-ref ref="WARN_CONSOLE" />
+        <appender-ref ref="DEBUG_CONSOLE" />
+    </root>
+    -->
 </configuration>

--- a/package-installer/etc/logback.xml
+++ b/package-installer/etc/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Set the root logger level -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <!-- Set logger level for the installer package to INFO or WARN -->
+    <logger name="com.vmware.pscoe.iac.installer.Installer" level="INFO, WARN" />
+    <!-- Uncomment the below line if DEBUG logging is needed as well -->
+    <!-- <logger name="com.vmware.pscoe.iac.installer" level="INFO, WARN, DEBUG" /> -->    
+</configuration>

--- a/package-installer/pom.xml
+++ b/package-installer/pom.xml
@@ -49,6 +49,12 @@
 			<version>${revision}</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+ 			<groupId>ch.qos.logback</groupId>
+ 			<artifactId>logback-classic</artifactId>
+ 			<version>1.5.18</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/package-installer/src/assembly/package-installer.xml
+++ b/package-installer/src/assembly/package-installer.xml
@@ -25,5 +25,10 @@
             <directory>target/appassembler</directory>
             <outputDirectory>.</outputDirectory>
         </fileSet>
+        <!-- Include the config directory -->
+        <fileSet>
+            <directory>etc</directory>
+            <outputDirectory>etc</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
[installer] Add Logging Configuration for the Installer

### Description

Added logging configuration file *etc/logback.xml* in the installer bundle where the logging severity can be configured during running installer (or installer.bat). By default the logging severity is set to *INFO* and *WARN*, You can set it to *DEBUG* if further tracing is needed.

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1. Create a mixed archetype project.
2. Go to the project and execute
```bash
mvn clean package -Pbundle-with-installer
```
3. Go to the project's target directory and invoke
```bash
unzip <project_name>-bundle.zip
```
4. Go to the unzipped directory and run
(on Linux )
```bash
installer environment.properties
```
(on Windows) 
```bash
installer.bat environment.properties
```
Note: You need to create the *environment.properties* file separately where the environment data (such target system information) is stored.

You should observe data similar to
```bash
???? 25, 2025 11:33:23 ??.??. com.vmware.pscoe.iac.artifact.aria.orchestrator.configuration.ConfigurationVro validate
INFO: Checking if exists refresh token
???? 25, 2025 11:33:23 ??.??. com.vmware.pscoe.iac.artifact.aria.orchestrator.configuration.ConfigurationVro validate
INFO: Refresh token not detected using BASIC Authentication
2025-03-25 11:33:23 [main] INFO  c.v.p.i.a.c.Configuration - Refresh token not detected. Checking username and password on configuration
2025-03-25 11:33:23 [main] INFO  c.v.p.i.artifact.PackageStoreFactory - Searching for Package Store for type VRO
2025-03-25 11:33:23 [main] INFO  c.v.p.i.artifact.PackageStoreFactory - Detected ConfigurationVro
2025-03-25 11:33:23 [main] WARN  c.v.p.i.a.rest.RestClientFactory - SSL: You are now ignoring certificate verification.
2025-03-25 11:33:23 [main] WARN  c.v.p.i.a.rest.RestClientFactory - SSL: You are now ignoring hostname verification.
...
```

### Release Notes

The *logback.xml* located in the *etc* directory can be used to tweak the logging severity.  The example below can be used to log *DEBUG* messages as well:
```xml
<configuration>
    <!-- Console appender for INFO logs -->
    <appender name="INFO_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
        <filter class="ch.qos.logback.classic.filter.LevelFilter">
            <level>INFO</level>
            <onMatch>ACCEPT</onMatch>
            <onMismatch>DENY</onMismatch>
        </filter>
        <encoder>
            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
        </encoder>
    </appender>

    <!-- Console appender for WARN logs -->
    <appender name="WARN_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
        <filter class="ch.qos.logback.classic.filter.LevelFilter">
            <level>WARN</level>
            <onMatch>ACCEPT</onMatch>
            <onMismatch>DENY</onMismatch>
        </filter>
        <encoder>
            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
        </encoder>
    </appender>

    <!-- Console appender for DEBUG logs -->
    <appender name="DEBUG_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
        <filter class="ch.qos.logback.classic.filter.LevelFilter">
            <level>DEBUG</level>
            <onMatch>ACCEPT</onMatch>
            <onMismatch>DENY</onMismatch>
        </filter>
        <encoder>
            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
        </encoder>
    </appender>

    <!-- Root logger with level DEBUG -->
    <root level="DEBUG">
        <appender-ref ref="INFO_CONSOLE" />
        <appender-ref ref="WARN_CONSOLE" />
        <appender-ref ref="DEBUG_CONSOLE" />
    </root>
</configuration>
```

### Related issues and PRs

#658 
