### PR TITLE
[artifact-manager] Remove fetching of Content Sharing Policies before creation

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/rest/RestClientVraNgPrimitive.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/rest/RestClientVraNgPrimitive.java
@@ -2419,12 +2419,6 @@ public class RestClientVraNgPrimitive extends RestClient {
 	 */
 	protected void createContentSharingPolicyPrimitive(final VraNgContentSharingPolicy csPolicy)
 			throws URISyntaxException {
-		VraNgContentSharingPolicy existingPolicy = this.getContentSharingPolicyPrimitive(csPolicy.getId());
-		// if the policy does not exist remove its id in order to be created, otherwise
-		// update it
-		if (existingPolicy == null) {
-			csPolicy.setId(null);
-		}
 		URI url = getURIBuilder().setPath(SERVICE_POLICIES).build();
 		String jsonBody = new Gson().toJson(csPolicy);
 		this.postJsonPrimitive(url, HttpMethod.POST, jsonBody);

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -39,6 +39,18 @@
 [//]: # (Optional But higlhy recommended Specify *NONE* if missing)
 [//]: # (#### Relevant Documentation:)
 
+### *Content Sharing Policies Import*
+
+CSPs could not be imported due to a forgotten fetch before creation.
+
+#### Previous Behavior
+
+When importing we were getting an error that id is expected of type UUID.String but was null
+
+#### New Behavior
+
+CSPs are no longer fetched prior to updating to set their ID.
+
 ## Upgrade procedure
 
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
### Description

CSPs could not be imported due to a forgotten fetch before creation.

#### Previous Behavior

When importing we were getting an error that id is expected of type UUID.String but was null

#### New Behavior

CSPs are no longer fetched prior to updating to set their ID.


### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [ ] I have tested against live environment, if applicable
- [x] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue
