### PR TITLE
[vro-scripting-api,vro-types] Improve type definitions of `ConfigurationElement`, `Properties`, and `Workflow` properties/functions

### DIFF
--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -28,6 +28,28 @@
 
 ## Improvements
 
+### Improve type definition in o11n-core
+
+Improve type definitions in o11n-core by replacing `any` with a more precise type or adding optional `null` or `undefined` values.
+
+#### Previous Behavior
+
+The types mismatched the actual type or were defined as `any`.
+
+#### New Behavior
+
+The following function definitions have been changed:
+
+- `ConfigurationElement.getAttributeWithKey` has `| null` added to its return type.
+- `Properties.get` has `| null` added to its return type.
+- `Properties.remove` from `any` to `void`.
+- Global `workflow` has `| undefined` added to its type.
+- `Workflow.workflowCategory` from `any` to `WorkflowCategory`.
+- `WorkflowToken.rootWorkflow` from `any` to `Workflow`.
+- `WorkflowToken.currentWorkflow` from `any` to `Workflow`.
+- `WorkflowToken.startDateAsDate` from `any` to `Date`.
+- `WorkflowToken.endDateAsDate` from `any` to `Date`.
+
 [//]: # (### *Improvement Name* )
 [//]: # (Talk ONLY regarding the improvement)
 [//]: # (Optional But higlhy recommended)

--- a/typescript/vro-scripting-api/src/api/ConfigurationElement.ts
+++ b/typescript/vro-scripting-api/src/api/ConfigurationElement.ts
@@ -34,10 +34,10 @@ namespace vroapi {
         }
 
         /**
-        * Returns the attribute of the configuration element for the specified key.
+        * Returns the attribute of the configuration element for the specified key or null if not found.
         * @param key
         */
-        getAttributeWithKey(key: string): Attribute {
+        getAttributeWithKey(key: string): Attribute | null {
             const attribute = this.attributes.find(a => a.name === key);
           
             return typeof attribute === 'undefined' ? null : attribute;

--- a/typescript/vro-scripting-api/src/api/Workflow.ts
+++ b/typescript/vro-scripting-api/src/api/Workflow.ts
@@ -22,7 +22,7 @@ namespace vroapi {
 
         description: string;
 
-        workflowCategory: any;
+        workflowCategory: WorkflowCategory;
 
         version: string;
 

--- a/typescript/vro-scripting-api/src/api/WorkflowToken.ts
+++ b/typescript/vro-scripting-api/src/api/WorkflowToken.ts
@@ -20,9 +20,9 @@ namespace vroapi {
 
         name: string;
 
-        rootWorkflow: any;
+        rootWorkflow: Workflow;
 
-        currentWorkflow: any;
+        currentWorkflow: Workflow;
 
         state: string;
 
@@ -36,9 +36,9 @@ namespace vroapi {
 
         endDate: string;
 
-        startDateAsDate: any;
+        startDateAsDate: Date;
 
-        endDateAsDate: any;
+        endDateAsDate: Date;
 
         logEvents: LogEvent[] = [];
 

--- a/vro-types/o11n-core/index.d.ts
+++ b/vro-types/o11n-core/index.d.ts
@@ -23,9 +23,9 @@ declare interface Trigger {
 }
 
 /**
- * Object representing the current instance of a Workflow
+ * Object representing the current instance of a Workflow or undefined if not in a workflow.
  */
-declare var workflow: WorkflowToken;
+declare var workflow: WorkflowToken | undefined;
 
 /**
  * Object used to call custom action in the system.
@@ -264,10 +264,10 @@ declare interface ConfigurationElement {
 	attributes: Attribute[];
 	configurationElementCategory: any;
 	/**
-	 * Returns the attribute of the configuration element for the specified key.
+	 * Returns the attribute of the configuration element for the specified key or null if not found.
 	 * @param key
 	 */
-	getAttributeWithKey(key: string): Attribute;
+	getAttributeWithKey(key: string): Attribute | null;
 	/**
 	 * Sets the attribute value of the configuration element for the specified key.
 	 * @param key
@@ -751,13 +751,12 @@ declare interface Properties {
 	 * Remove a property to the property list.
 	 * @param key
 	 */
-	remove(key: string): any;
+	remove(key: string): void;
 	/**
-	 * Returns the property entry for the given key.
+	 * Returns the property entry for the given key or null if not found.
 	 * @param key
 	 */
-	get(key: string): any;
-	get<T>(key: string): T;
+	get<T>(key: string): T | null;
 	/**
 	 * Loads properties from a File, an URL or a String object
 	 * @param input
@@ -1013,7 +1012,7 @@ declare interface VersionHistoryItem {
 declare class Workflow {
 	name: string;
 	description: string;
-	workflowCategory: any;
+	workflowCategory: WorkflowCategory;
 	version: string;
 	firstItem: any;
 	numberOfItem: number;
@@ -1218,16 +1217,16 @@ declare interface WorkflowItemWaitingTimer {
  */
 declare class WorkflowToken {
 	name: string;
-	rootWorkflow: any;
-	currentWorkflow: any;
+	rootWorkflow: Workflow;
+	currentWorkflow: Workflow;
 	state: string;
 	exception: string;
 	businessState: string;
 	workflowInputId: string;
 	startDate: string;
 	endDate: string;
-	startDateAsDate: any;
-	endDateAsDate: any;
+	startDateAsDate: Date;
+	endDateAsDate: Date;
 	logEvents: LogEvent[];
 	isStillValid: boolean;
 	attributesStack: Attribute[];


### PR DESCRIPTION
### Description

Similar as #627. Noticed some inaccurate type definitions with the following items:

- `ConfigurationElement.getAttributeWithKey` function might return `null`. Implementation can be seen here: https://github.com/vmware/build-tools-for-vmware-aria/blob/main/typescript/vro-scripting-api/src/api/ConfigurationElement.ts#L40 ![Pasted image 20250512143307](https://github.com/user-attachments/assets/6d036d8c-2fad-4dd8-aa5f-71302f13b6e5)

- `Properties`
	- `.get()` add optional null output to type definition. Possible value can be seen in the implementation here: https://github.com/vmware/build-tools-for-vmware-aria/blob/main/typescript/vro-scripting-api/src/api/Properties.ts#L33
	- `.remove()` change return type from `any` to `void`. It doesn't return a value, as can be seen in the implementation here: https://github.com/vmware/build-tools-for-vmware-aria/blob/main/typescript/vro-scripting-api/src/api/Properties.ts#L37

- `Workflow`
	- Global. Added `| undefined`, since it's undefined when the code is not ran inside a workflow (e.g. just an Action) 
![Pasted image 20250512161318](https://github.com/user-attachments/assets/236efebe-c821-4752-ab5c-f0ef6c28f64c)
	- `workflowCategory` had the `any` type while a `WorkflowCategory` type is available.
	- `startDateAsDate & endDateAsDate` seem to be equal to the JavaScript Date type. As methods like `.getFullYear()` work on it. ![Pasted image 20250512151816](https://github.com/user-attachments/assets/de779aa7-e579-45fb-98c4-d091cd935604) ![Pasted image 20250512151743](https://github.com/user-attachments/assets/7bae2d10-fe0b-415b-8fa1-007e9c19dd9f)

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [ ] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**

### Testing

Tested in a live vRO tenant that the definition changes are correct.

### Release Notes

Improve type definitions of `ConfigurationElement`, `Properties`, `Workflow` and `WorkflowToken` class properties/functions.

### Related issues and PRs

#627
