### PR TITLE
[artifact-manager](#830)Add support for push/pull of different aria operation types with same name

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/cli/CliManagerVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/cli/CliManagerVrops.java
@@ -123,7 +123,8 @@ public class CliManagerVrops implements AutoCloseable {
 
 	// IMPORT
 	public void addViewToImportList(File file) {
-		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + file.getName();
+		String resourceType = file.getParentFile().getName();
+		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + resourceType + "-" + file.getName();
 		String command = String.format(VROPS_SSH_COMMAND_1,
 				escapeShellCharacters(OPSCLI_PATH), escapeShellCharacters(VIEW),
 				escapeShellCharacters(IMPORT), escapeShellCharacters(remoteFilePath),
@@ -134,7 +135,8 @@ public class CliManagerVrops implements AutoCloseable {
 	}
 
 	public void addDashboardToImportList(File file) {
-		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + file.getName();
+		String resourceType = file.getParentFile().getName();
+		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + resourceType + "-" + file.getName();
 		String command = String.format(VROPS_SSH_COMMAND_2,
 				escapeShellCharacters(OPSCLI_PATH), escapeShellCharacters(DASHBOARD),
 				escapeShellCharacters(IMPORT), "all",
@@ -222,7 +224,8 @@ public class CliManagerVrops implements AutoCloseable {
 	}
 
 	public void addReportToImportList(File file) {
-		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + file.getName();
+		String resourceType = file.getParentFile().getName();
+		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + resourceType + "-" + file.getName();
 		String command = String.format(VROPS_SSH_COMMAND_1,
 				escapeShellCharacters(OPSCLI_PATH), escapeShellCharacters(REPORT),
 				escapeShellCharacters(IMPORT), escapeShellCharacters(remoteFilePath),
@@ -233,7 +236,8 @@ public class CliManagerVrops implements AutoCloseable {
 	}
 
 	public void addSuperMetricsToImportList(File file) {
-		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + file.getName();
+		String resourceType = file.getParentFile().getName();
+		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + resourceType + "-" + file.getName();
 		String command = String.format(VROPS_SSH_COMMAND_3,
 				escapeShellCharacters(OPSCLI_PATH), escapeShellCharacters(SUPER_METRIC),
 				escapeShellCharacters(IMPORT), escapeShellCharacters(remoteFilePath), escapeShellCharacters(FORCE),
@@ -244,7 +248,8 @@ public class CliManagerVrops implements AutoCloseable {
 	}
 
 	public void addMetricConfigsToImportList(File file) {
-		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + file.getName();
+		String resourceType = file.getParentFile().getName();
+		String remoteFilePath = importRemotePath + UNIX_PATH_SEPARATOR + resourceType + "-" + file.getName();
 		String command = String.format(VROPS_SSH_COMMAND_4,
 				escapeShellCharacters(OPSCLI_PATH),
 				escapeShellCharacters(FILE),

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/common/cli/SshClient.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/common/cli/SshClient.java
@@ -149,7 +149,8 @@ public final class SshClient {
 			createDirectory(sftpChannel, dest, false);
 			sftpChannel.cd(dest);
 			fileList.forEach(file -> {
-				String destinationFile = dest + "/" + file.getName();
+				String resourceType = file.getParentFile().getName();
+				String destinationFile = dest + "/" + resourceType + "-" + file.getName();
 				LOGGER.info("Copy file with path '{}' to '{}'", file.getAbsolutePath(), destinationFile);
 				try {
 					sftpChannel.put(file.getAbsolutePath(), destinationFile);


### PR DESCRIPTION
### Description

Adding support for different operation types with the same name. Currently from the UI is posible to create for instance Dashboard and a View with the same name, but the existing implemantation will ovverride one of the resources.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
If you skip any of the tasks from the checklist, add a comment explaining why that task might be irrelevant to your contribution.

Sample PR title:
[artifact-manager] (#220) Update the package.json template for generating ABX actions
-->

- [ ] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have added labels for implementation kind (kind/*) and version type (version/*)
- [x] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

<!-- Please provide a brief description of how were the changes tested -  -->
It is tested on Aria Operations 8.18. Here are the logs:

[INFO] Copying files to vrops appliance
[INFO] Destination path: '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9'
[INFO] Copy file with path '/var/folders/15/8rnjflfx6j94_2k509kns1780000gq/T/iac-vrops-imp-13337599795126582414/vrops-import/import-VROPS-0-d91dc570-6f5d-4543-8767-cc9d48eb1a56-1755526087236/views/testIssue1.zip' to '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/views-testIssue1.zip'
[INFO] Copy file with path '/var/folders/15/8rnjflfx6j94_2k509kns1780000gq/T/iac-vrops-imp-13337599795126582414/vrops-import/import-VROPS-0-d91dc570-6f5d-4543-8767-cc9d48eb1a56-1755526087236/views/testIssue2.zip' to '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/views-testIssue2.zip'
[INFO] Copy file with path '/var/folders/15/8rnjflfx6j94_2k509kns1780000gq/T/iac-vrops-imp-13337599795126582414/vrops-import/import-VROPS-0-d91dc570-6f5d-4543-8767-cc9d48eb1a56-1755526087236/dashboards/testIssue1.zip' to '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/dashboards-testIssue1.zip'
[INFO] Executing vROps SSH remote command(s):
$VMWARE_PYTHON_3_BIN '/usr/lib/vmware-vcops/tools/opscli/ops-cli.py' 'view' 'import' '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/views-testIssue1.zip' '--force'
$VMWARE_PYTHON_3_BIN '/usr/lib/vmware-vcops/tools/opscli/ops-cli.py' 'view' 'import' '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/views-testIssue2.zip' '--force'
$VMWARE_PYTHON_3_BIN '/usr/lib/vmware-vcops/tools/opscli/ops-cli.py' 'dashboard' 'import' all '/tmp/vrops-import/1755526086204-605c41ad-a9f3-4254-8a2d-f43a57cda1c9/dashboards-testIssue1.zip' '--force'

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Build Tools for VMware Aria's release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

-->
Add support for different resource types with the same name for Aria Operations
### Related issues and PRs

<!-- Link any related issues and pull requests here using #number or user/repo#number -->
