### PR TITLE
[artifact-manager] (#1108) Fix for import of `vrops` Alert Definition that contains symptoms with alert conditions

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/models/AlertDefinitionDTO.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/models/AlertDefinitionDTO.java
@@ -291,7 +291,7 @@ public class AlertDefinitionDTO implements Serializable {
 		}
 
 		@JsonInclude(JsonInclude.Include.NON_NULL)
-		@JsonPropertyOrder({ "type", "relation", "aggregation", "symptomSetOperator", "symptomDefinitionIds", "symptomSets", "alertConditions" })
+		@JsonPropertyOrder({ "type", "relation", "aggregation", "symptomSetOperator", "symptomDefinitionIds", "symptom-sets", "alertConditions" })
 		public static class BaseSymptomSet implements Serializable {
 			private static final long serialVersionUID = 7061962708255866132L;
 
@@ -310,7 +310,7 @@ public class AlertDefinitionDTO implements Serializable {
 			@JsonProperty("symptomDefinitionIds")
 			private List<String> symptomDefinitionIds = new ArrayList<>();
 
-			@JsonProperty("symptomSets")
+			@JsonProperty("symptom-sets")
 			private List<SymptomSet> symptomSets = new ArrayList<>();
 
 			@JsonProperty("alertConditions")
@@ -369,12 +369,12 @@ public class AlertDefinitionDTO implements Serializable {
 				this.symptomDefinitionIds = symptomDefinitionIds;
 			}
 
-			@JsonProperty("symptomSets")
+			@JsonProperty("symptom-sets")
 			public List<SymptomSet> getSymptomSets() {
 				return symptomSets;
 			}
 
-			@JsonProperty("symptomSets")
+			@JsonProperty("symptom-sets")
 			public void setSymptomSets(List<SymptomSet> symptomSets) {
 				this.symptomSets = symptomSets;
 			}

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/rest/RestClientVrops.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/operations/rest/RestClientVrops.java
@@ -1708,6 +1708,7 @@ public class RestClientVrops extends RestClient {
 		String definitionId = getDefinitionId(definition, definitionType);
 		HttpMethod method = HttpMethod.POST;
 		if (!StringUtils.isEmpty(definitionId)) {
+			removeIdFromDefinitionPayload(definitionId, definitionType);
 			updateDefinitionId(definition, definitionType, definitionId);
 			method = HttpMethod.PUT;
 		}

--- a/docs/versions/latest/Release.md
+++ b/docs/versions/latest/Release.md
@@ -111,4 +111,11 @@ The Promise now resolves only when the `output` stream emits the `'close'` event
 
 ## Upgrade procedure
 
+### *Fix `vrops` issue 1108 failing to push alert Definitions with alertConditions set*
+#### Previous Behavior
+Pushing AlertDefinitions from one environment to anther is failing becuause of wrong DTO structure. Updating alert definitions (PUT request) taken from one environment to another was failing due to mismatch of the alert conditions id's
+#### New Behavior
+Fixed AlertDefinitionDTO.java
+Before pushing the same alert condition again the id's of the alert condition are set to null.
+
 [//]: # (Explain in details if something needs to be done)


### PR DESCRIPTION
### Description

The DTO for the alert definitions is fixed as per the VCF/Aria REST API documentation + the method importDefinitions is fixed for update of alert definitions (PUT reqeust) due to the different id's of the alert conditions inside the alert definition DTO on the target server

### Checklist

- [X] I have added relevant error handling and logging messages to help troubleshooting
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation, relevant usage information (if applicable)
- [X] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [ ] I have added labels for implementation kind (kind/*) and version type (version/*)
- [X] I have tested against live environment, if applicable
- [ ] I have synced any structure and/or content vRA-NG improvements with vra-ng and ts-vra-ng archetypes (if applicable)
- [X] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [ ] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

1. Pulled an alert definition with symptoms and alert condition from one Aria Operations server
2. Pushed the alert definition to a VCF Operations server
3. Pushed again the alert definition
4. Pulled again from the source Aria Operations server
5. Pushed the alert definition to a VCF Operations server
6. Pushed again the alert definition

### Release Notes

Fix of the Alert Definition DTO

### Related issues and PRs
(https://github.com/vmware/build-tools-for-vmware-aria/pull/1011)

#1108 