### PR TITLE
[artifact-manager] (#1205) Add Support for CSS Form Styles for Resource Actions

### DIFF
--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgBlueprintStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgBlueprintStore.java
@@ -45,6 +45,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
 import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgBlueprint;
+import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm;
 import com.vmware.pscoe.iac.artifact.aria.automation.store.helpers.VraNgReleaseManager;
 import com.vmware.pscoe.iac.artifact.common.store.Package;
 import com.vmware.pscoe.iac.artifact.common.store.filters.CustomFolderFolderFilter;
@@ -332,17 +333,17 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 	}
 
 	/**
-	 * REPLICATED DESIGN: Scans the companion layout paths to check for incoming
-	 * custom
-	 * request form adjustments and updates to enforce synchronized release
-	 * deployments.
+	 * Scans the companion layout paths to check for incoming custom request form
+	 * adjustments and updates to enforce synchronised release deployments.
+	 *
+	 * @param bpDir blueprint directory
+	 * @param bp    blueprint
+	 * @return true if the custom form has changed and a force-release is required
 	 */
 	private boolean processBlueprintFormCustomForm(final File bpDir, final VraNgBlueprint bp) {
 		File sourceDirectory = bpDir.getParentFile().getParentFile();
 		String bpName = bp.getName();
 
-		// Map companion resources under catalog-items relative workspace directory
-		// structure
 		File customFormsFolder = Paths.get(sourceDirectory.getPath(), "catalog-items", "custom-forms").toFile();
 		File customFormDataFile = new File(customFormsFolder, bpName + "__FormData.json");
 		File customFormStylesFile = new File(customFormsFolder, bpName + "__FormStyles.css");
@@ -352,7 +353,7 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 		// Step 1: Handle cleanup mapping transitions if local assets are missing
 		if (!customFormDataFile.exists()) {
 			try {
-				Object rawServerForm = this.restClient.getCustomFormByTypeAndSource("blueprint", bp.getId());
+				VraNgCustomForm rawServerForm = this.restClient.getCustomFormByTypeAndSource("blueprint", bp.getId());
 				if (rawServerForm != null) {
 					logger.info(
 							"Orphaned custom request form detected on server for blueprint '{}'. Forcing state-change release version.",
@@ -369,45 +370,28 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 
 		// Step 2: Compare working structures to detect updates
 		try {
-			String localFormContent = new String(Files.readAllBytes(customFormDataFile.toPath()),
-					StandardCharsets.UTF_8);
+			String localFormContent = new String(Files.readAllBytes(customFormDataFile.toPath()), StandardCharsets.UTF_8);
 			JsonElement localFormJson = JsonParser.parseString(localFormContent);
 			String localFormNormalized = gson.toJson(localFormJson);
 
 			String localCssContent = "";
 			if (customFormStylesFile.exists()) {
-				localCssContent = new String(Files.readAllBytes(customFormStylesFile.toPath()), StandardCharsets.UTF_8)
-						.trim();
+				localCssContent = new String(Files.readAllBytes(customFormStylesFile.toPath()), StandardCharsets.UTF_8).trim();
 			}
 
 			boolean formChanged = true;
 			try {
-				Object rawServerForm = this.restClient.getCustomFormByTypeAndSource("blueprint", bp.getId());
-				if (rawServerForm != null) {
+				VraNgCustomForm serverForm = this.restClient.getCustomFormByTypeAndSource("blueprint", bp.getId());
+				if (serverForm != null) {
 					String serverFormJsonNormalized = "";
 					String serverStyles = "";
 
-					// Safe evaluation against internal VraNgCustomForm model schema structure
-					if (rawServerForm instanceof com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm) {
-						com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm vf = (com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm) rawServerForm;
-
-						if (vf.getForm() != null) {
-							serverFormJsonNormalized = gson.toJson(JsonParser.parseString(vf.getForm()));
-						}
-						if (vf.getStyles() != null) {
-							serverStyles = vf.getStyles().trim();
-						}
-					} else {
-						// Dynamic fallback parsing layer if API maps directly into linked
-						// arrays/structures
-						JsonObject serverObj = gson.toJsonTree(rawServerForm).getAsJsonObject();
-						if (serverObj.has("form") && !serverObj.get("form").isJsonNull()) {
-							serverFormJsonNormalized = gson
-									.toJson(JsonParser.parseString(serverObj.get("form").getAsString()));
-						}
-						if (serverObj.has("styles") && !serverObj.get("styles").isJsonNull()) {
-							serverStyles = serverObj.get("styles").getAsString().trim();
-						}
+					// getCustomFormByTypeAndSource always returns VraNgCustomForm — cast directly
+					if (serverForm.getForm() != null) {
+						serverFormJsonNormalized = gson.toJson(JsonParser.parseString(serverForm.getForm()));
+					}
+					if (serverForm.getStyles() != null) {
+						serverStyles = serverForm.getStyles().trim();
 					}
 
 					if (localFormNormalized.equals(serverFormJsonNormalized) && localCssContent.equals(serverStyles)) {
@@ -432,7 +416,7 @@ public class VraNgBlueprintStore extends AbstractVraNgStore {
 
 		return false;
 	}
-
+	
 	/*
 	 * ==============
 	 * Helper methods

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgResourceActionStore.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgResourceActionStore.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * artifact-manager
  * %%
@@ -6,14 +6,11 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
- */
-/** 
- * Package
  */
 package com.vmware.pscoe.iac.artifact.aria.automation.store;
 
@@ -35,7 +32,10 @@ import org.apache.commons.io.FilenameUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm;
 import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgResourceAction;
 import com.vmware.pscoe.iac.artifact.aria.automation.store.helpers.VraNgCustomFormSerializer;
 import com.vmware.pscoe.iac.artifact.aria.automation.utils.VraNgProjectUtil;
@@ -47,12 +47,16 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 
 	/**
 	 * Separator for the Resource Type and the Resource Action Name. Used so we can
-	 * have unique names even if we have
-	 * two resource actions of same name with different types. You can have a
-	 * resource action with __ in the name
-	 * but not Source name with it.
+	 * have unique names even if we have two resource actions of same name with
+	 * different types.
 	 */
 	private static final String RESOURCE_ACTION_SEPARATOR = "__";
+
+	/**
+	 * The sourceType string used by vRA NG when a custom form belongs to a
+	 * resource action.
+	 */
+	private static final String RESOURCE_ACTION_FORM_SOURCE_TYPE = "resource.action";
 
 	/**
 	 * Get all server contents.
@@ -64,7 +68,7 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 	}
 
 	/**
-	 * The deleteResourecAction takes in name just for logging purposes...
+	 * The deleteResourceAction takes in name just for logging purposes.
 	 *
 	 * @param resId resource id
 	 */
@@ -74,7 +78,7 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 
 	/**
 	 * Import Content.
-	 * 
+	 *
 	 * @param sourceDirectory source directory
 	 */
 	public void importContent(final File sourceDirectory) {
@@ -123,8 +127,8 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 	}
 
 	/**
-	 * Exports all resource actions that do not match the filter passed.
-	 * 
+	 * Exports all resource actions that match the filter passed.
+	 *
 	 * @param resourceActionsToExport filtered list of resource actions to export
 	 */
 	protected void exportStoreContent(final List<String> resourceActionsToExport) {
@@ -164,30 +168,28 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 	/**
 	 * Sanitize ResourceAction json from unnecessary elements that prevent store or
 	 * publish later the content.
-	 * 
+	 *
 	 * @param resourceActionJsonElement Resource Action Json Element
 	 */
 	private void sanitizeResourceActionJsonElement(final JsonObject resourceActionJsonElement) {
-
 		// leaving orgId in the JSON prevents pushing to different vRA organizations
-		// orgId is optional when importing in vRA, so it can be safely removed
 		resourceActionJsonElement.remove("orgId");
 
 		logger.debug("Removing id property from formDefinition element ...");
 		String formDefinitionItemName = "formDefinition";
 		String formDefinitionIdName = "id";
-		// When create new resource action, formDefinition element do not have to
-		// contain id property. See IAC-400.
+		// When creating a new resource action, formDefinition element must not
+		// contain an id property. See IAC-400.
 		resourceActionJsonElement.getAsJsonObject(formDefinitionItemName).remove(formDefinitionIdName);
 	}
 
 	/**
 	 * Save a resource action to a JSON file.
-	 * 
+	 *
 	 * @param pkg                source package
 	 * @param resourceActionName source resource action name
 	 * @param resourceActionJson source resource action json
-	 * @return Resoruce Action File
+	 * @return Resource Action File
 	 */
 	private File storeResourceActionOnFilesystem(final Package pkg, final String resourceActionName,
 			final String resourceActionJson) {
@@ -213,8 +215,10 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 	}
 
 	/**
-	 * Import resource actions from a file.
-	 * 
+	 * Import resource action from a file. After the two-phase import the companion
+	 * catalog-item custom form (if present) is applied via
+	 * {@link #processResourceActionCustomForm}.
+	 *
 	 * @param jsonFile file of the resource action
 	 */
 	private void importResourceAction(final File jsonFile) {
@@ -234,10 +238,8 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 			VraNgProjectUtil.changeProjectIdBetweenOrganizations(this.restClient, resourceActionJsonElement,
 					"projectId");
 
-			// Get resource action id property and use it to try to delete existing one
-			// resource action
+			// Get resource action id and try to delete existing one
 			String resourceActionId = resourceActionJsonElement.get("id").getAsString();
-			// Let's try to delete resource action first before import it.
 			try {
 				logger.info("Deleting resource action '{}' ('{}') if exists ...", resourceActionName, resourceActionId);
 				restClient.deleteResourceAction(resourceActionName, resourceActionId);
@@ -249,10 +251,19 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 			VraNgCustomFormSerializer.serialize(resourceActionJsonElement);
 			resourceActionJson = gson.toJson(resourceActionJsonElement);
 
+			// Phase 1: create the resource action → server returns the assigned form id
 			String resultResourceActionJson = restClient.importResourceAction(resourceActionName, resourceActionJson);
 			JsonObject resultJsonObject = updateFormInfoOnTopOfResult(
 					gson.fromJson(resultResourceActionJson, JsonObject.class), resourceActionJsonElement);
+
+			// Phase 2: re-import with the correct form id wired in
 			restClient.importResourceAction(resourceActionName, gson.toJson(resultJsonObject));
+
+			// Apply catalog-item-level custom form if one exists alongside this action
+			File sourceDirectory = jsonFile.getParentFile().getParentFile();
+			String resultResourceActionId = resultJsonObject.get("id").getAsString();
+			this.processResourceActionCustomForm(sourceDirectory, resourceActionName, resultResourceActionId);
+
 		} catch (ConfigurationException e) {
 			logger.error("Error importing resource action {}...", resourceActionName);
 			throw new RuntimeException(e);
@@ -265,28 +276,27 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 
 	/**
 	 * Populate Vro Endpoint.
-	 * 
-	 * @param resourceActionJsonElement file of the resource action
+	 *
+	 * @param resourceActionJsonElement the resource action JSON element
 	 */
 	private void populateVroEndpoint(final JsonObject resourceActionJsonElement) throws ConfigurationException {
 		String runnableItemName = "runnableItem";
 		String endpointLinkName = "endpointLink";
 
-		// remove endpointLink from the runnable item, it will be populated automaticaly
+		// remove endpointLink from the runnable item, it will be populated automatically
 		resourceActionJsonElement.getAsJsonObject(runnableItemName).remove(endpointLinkName);
 
-		// add the updated endpointLink fetched from the target
-		// environment/configuration
+		// add the updated endpointLink fetched from the target environment/configuration
 		resourceActionJsonElement.getAsJsonObject(runnableItemName).addProperty(endpointLinkName,
 				this.getVroTargetIntegrationEndpointLink());
 	}
 
 	/**
 	 * Update Form Info On Top Of Result.
-	 * 
-	 * @param resultJsonObject file of the resource action
-	 * @param sourceJsonObject file of the resource action
-	 * @return Json Object
+	 *
+	 * @param resultJsonObject the JSON returned by the first import call
+	 * @param sourceJsonObject the local JSON that was sent
+	 * @return updated Json Object
 	 */
 	private JsonObject updateFormInfoOnTopOfResult(final JsonObject resultJsonObject,
 			final JsonObject sourceJsonObject) {
@@ -296,5 +306,111 @@ public class VraNgResourceActionStore extends AbstractVraNgStore {
 		sourceForm.addProperty("id", newFormId);
 		resultJsonObject.add("formDefinition", sourceForm);
 		return resultJsonObject;
+	}
+
+	/**
+	 * Mirrors the blueprint companion-form detection pattern for resource actions.
+	 * <p>
+	 * Looks for {@code catalog-items/custom-forms/<resourceActionName>__FormData.json}
+	 * (and an optional {@code __FormStyles.css}) relative to the package root.
+	 * If the file does not exist, any orphaned server form is logged but left
+	 * unchanged. If the file exists and differs from the server form, the updated
+	 * form is applied via {@link com.vmware.pscoe.iac.artifact.aria.automation.rest.RestClientVraNg#importCustomForm}.
+	 * </p>
+	 *
+	 * @param sourceDirectory    the package root directory (parent of resource-actions/)
+	 * @param resourceActionName the resource action name, without the .json extension
+	 * @param resourceActionId   the resource action id returned after import
+	 */
+	private void processResourceActionCustomForm(final File sourceDirectory, final String resourceActionName,
+			final String resourceActionId) {
+
+		File customFormsFolder = Paths.get(sourceDirectory.getPath(), "catalog-items", "custom-forms").toFile();
+		File customFormDataFile = new File(customFormsFolder, resourceActionName + "__FormData.json");
+		File customFormStylesFile = new File(customFormsFolder, resourceActionName + "__FormStyles.css");
+
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+		// Step 1: If no local form file exists, check whether an orphaned one is
+		//         still on the server and log a notice.
+		if (!customFormDataFile.exists()) {
+			try {
+				VraNgCustomForm serverForm = this.restClient.getCustomFormByTypeAndSource(
+						RESOURCE_ACTION_FORM_SOURCE_TYPE, resourceActionId);
+				if (serverForm != null) {
+					logger.info(
+							"Orphaned catalog-item custom form detected on server for resource action '{}'. "
+									+ "No local form file found; server form remains unchanged.",
+							resourceActionName);
+				}
+			} catch (Exception e) {
+				logger.debug(
+						"No catalog-item custom form on server for resource action '{}'. Skipping.",
+						resourceActionName);
+			}
+			return;
+		}
+
+		// Step 2: Read local form, compare with server, apply if different.
+		try {
+			String localFormContent = new String(Files.readAllBytes(customFormDataFile.toPath()),
+					StandardCharsets.UTF_8);
+			JsonElement localFormJson = JsonParser.parseString(localFormContent);
+			String localFormNormalized = gson.toJson(localFormJson);
+
+			String localCssContent = "";
+			if (customFormStylesFile.exists()) {
+				localCssContent = new String(Files.readAllBytes(customFormStylesFile.toPath()),
+						StandardCharsets.UTF_8).trim();
+			}
+
+			boolean formChanged = true;
+			try {
+				VraNgCustomForm serverForm = this.restClient.getCustomFormByTypeAndSource(
+						RESOURCE_ACTION_FORM_SOURCE_TYPE, resourceActionId);
+				if (serverForm != null) {
+					String serverFormJsonNormalized = "";
+					String serverStyles = "";
+
+					if (serverForm.getForm() != null) {
+						serverFormJsonNormalized = gson.toJson(JsonParser.parseString(serverForm.getForm()));
+					}
+					if (serverForm.getStyles() != null) {
+						serverStyles = serverForm.getStyles().trim();
+					}
+
+					if (localFormNormalized.equals(serverFormJsonNormalized)
+							&& localCssContent.equals(serverStyles)) {
+						logger.debug(
+								"Catalog-item custom form for resource action '{}' matches server. Skipping update.",
+								resourceActionName);
+						formChanged = false;
+					}
+				}
+			} catch (Exception fe) {
+				logger.info(
+						"No catalog-item custom form on server for resource action '{}'. Treating as new.",
+						resourceActionName);
+			}
+
+			if (formChanged) {
+				logger.info("Applying catalog-item custom form for resource action '{}'.", resourceActionName);
+				VraNgCustomForm customForm = new VraNgCustomForm(
+						null,
+						resourceActionName,
+						localFormContent,
+						localCssContent.isEmpty() ? null : localCssContent,
+						resourceActionId,
+						RESOURCE_ACTION_FORM_SOURCE_TYPE,
+						"requestForm",
+						"ON",
+						"JSON");
+				this.restClient.importCustomForm(customForm, resourceActionId);
+			}
+
+		} catch (Exception e) {
+			logger.error("Failed to process catalog-item custom form for resource action '{}': {}",
+					resourceActionName, e.getMessage());
+		}
 	}
 }

--- a/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/helpers/VraNgReleaseManager.java
+++ b/common/artifact-manager/src/main/java/com/vmware/pscoe/iac/artifact/aria/automation/store/helpers/VraNgReleaseManager.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * artifact-manager
  * %%
@@ -6,9 +6,9 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -80,19 +80,17 @@ public class VraNgReleaseManager {
 
 	/**
 	 * Attempt to generate a next version and release it.
-	 * 
+	 *
 	 * @param blueprint    blueprint
 	 * @param forceRelease true if a companion asset (like a custom form) changed,
-	 *                     forcing a version release
+	 *                     forcing a version release even when blueprint YAML is
+	 *                     unchanged
 	 */
 	public void releaseNextVersion(VraNgBlueprint blueprint, boolean forceRelease) {
-		// vRA Ng native limitation bypass: if only the form changed, the version API
-		// will throw an exception.
-		// Tweak the description field to force a valid draft change if a release is
-		// forced.
+		// vRA NG native limitation bypass: if only the form changed, the release API
+		// will throw an exception unless the blueprint draft has been touched.
 		if (forceRelease) {
 			logger.info("Force release triggered for blueprint '{}' due to custom form updates.", blueprint.getName());
-			// Append a subtle tracking tag to force a blueprint drift recognition
 			this.restClient.updateBlueprint(blueprint);
 		}
 
@@ -101,13 +99,12 @@ public class VraNgReleaseManager {
 		logger.debug("Next version of blueprint {}: {}", blueprint.getName(), nextVersion);
 
 		try {
-			this.releaseVersion(blueprint, nextVersion);
+			this.releaseVersion(blueprint, nextVersion, forceRelease);
 		} catch (Exception e) {
-			// Attempt to fix versions imported in reverse order, which produces an Error on
-			// imports
+			// Attempt to fix versions imported in reverse order, which produces an Error on imports
 			logger.warn("Couldn't release version '{}'. Attempting to release date version", nextVersion);
 			try {
-				this.releaseVersion(blueprint, this.getDateVersion());
+				this.releaseVersion(blueprint, this.getDateVersion(), forceRelease);
 			} catch (Exception ex) {
 				// If it fails because there are genuinely no changes and forceRelease wasn't
 				// active, log gracefully
@@ -122,9 +119,8 @@ public class VraNgReleaseManager {
 	}
 
 	/**
-	 * Backwards compatible overload for standard single-parameter calls across your
-	 * framework.
-	 * 
+	 * Backwards compatible overload for standard single-parameter calls.
+	 *
 	 * @param blueprint blueprint
 	 */
 	public void releaseNextVersion(VraNgBlueprint blueprint) {
@@ -133,15 +129,17 @@ public class VraNgReleaseManager {
 
 	/**
 	 * Release a new version of the blueprint provided that there is no previous
-	 * version or there are
-	 * changes in the content since the latest released version.
-	 * 
-	 * @param blueprint blueprint
-	 * @param version   new version
+	 * version or there are changes in the content since the latest released version.
+	 * When {@code forceRelease} is {@code true} the isUpdated check is bypassed —
+	 * used when only a companion asset (custom form) changed.
+	 *
+	 * @param blueprint    blueprint
+	 * @param version      new version string
+	 * @param forceRelease bypass the isUpdated check
 	 */
-	public void releaseVersion(VraNgBlueprint blueprint, String version) {
+	public void releaseVersion(VraNgBlueprint blueprint, String version, boolean forceRelease) {
 		String latestVersion = this.restClient.getBlueprintLastUpdatedVersion(blueprint.getId());
-		if (latestVersion == null || this.isUpdated(blueprint, latestVersion)) {
+		if (forceRelease || latestVersion == null || this.isUpdated(blueprint, latestVersion)) {
 			this.restClient.releaseBlueprintVersion(blueprint.getId(), version);
 			logger.info("Released blueprint " + blueprint.getName() + " version " + version);
 		} else {
@@ -150,9 +148,19 @@ public class VraNgReleaseManager {
 	}
 
 	/**
+	 * Backward-compatible overload — never forces release.
+	 *
+	 * @param blueprint blueprint
+	 * @param version   new version string
+	 */
+	public void releaseVersion(VraNgBlueprint blueprint, String version) {
+		this.releaseVersion(blueprint, version, false);
+	}
+
+	/**
 	 * Perform a check whether the blueprint content has been updated since the
 	 * latest released version.
-	 * 
+	 *
 	 * @param blueprint     blueprint
 	 * @param latestVersion latest version
 	 * @return true if there are changes
@@ -160,27 +168,21 @@ public class VraNgReleaseManager {
 	private boolean isUpdated(VraNgBlueprint blueprint, String latestVersion) {
 		String draftContent = blueprint.getContent();
 		String latestVersionContent = this.restClient.getBlueprintVersionContent(blueprint.getId(), latestVersion);
-		
+
 		return !draftContent.equals(latestVersionContent);
 	}
 
 	/**
 	 * Generate next version based on the previous version format.
-	 * Supported version formats are:
-	 * * MAJOR
-	 * * MAJOR.MINOR
-	 * * MAJOR.MINOR.PATCH
-	 * A datetime-based version will be returned if the previous version format does
-	 * not match
-	 * any of the supported formats.
-	 * 
+	 * Supported version formats: MAJOR, MAJOR.MINOR, MAJOR.MINOR.PATCH.
+	 * A datetime-based version is returned when none match.
+	 *
 	 * @param version previous version
 	 * @return next version
 	 */
 	private String getNextVersion(String version) {
 
 		if (version == null) {
-			// create a version based on the date and time
 			return getDateVersion();
 		}
 
@@ -191,18 +193,15 @@ public class VraNgReleaseManager {
 		if (majorMinorPatch.matches()) {
 			logger.debug("Detected version pattern MAJOR.MINOR.PATCH from {} with incrementable segment '{}'", version,
 					majorMinorPatch.group(THIRD_SEGMENT));
-			// increment the patch segment
 			return majorMinorPatch.group(FIRST_SEGMENT) + "." + majorMinorPatch.group(SECOND_SEGMENT) + "."
 					+ (Integer.parseInt(majorMinorPatch.group(THIRD_SEGMENT)) + 1);
 		} else if (majorMinor.matches()) {
 			logger.debug("Detected version pattern MAJOR.MINOR from '{}' with incrementable segment '{}'", version,
 					majorMinor.group(SECOND_SEGMENT));
-			// increment the minor segment
 			return majorMinor.group(FIRST_SEGMENT) + "." + (Integer.parseInt(majorMinor.group(SECOND_SEGMENT)) + 1);
 		} else if (major.matches()) {
 			logger.debug("Detected version pattern MAJOR from '{}' with incrementable segment '{}'", version,
 					major.group(FIRST_SEGMENT));
-			// increment the major segment
 			return Integer.toString(Integer.parseInt(major.group(FIRST_SEGMENT)) + 1);
 		} else {
 			logger.debug("Could not determine version pattern from {}", version);
@@ -213,7 +212,7 @@ public class VraNgReleaseManager {
 
 	/**
 	 * Create a version based on the current date and time.
-	 * 
+	 *
 	 * @return datetime-based version
 	 */
 	private String getDateVersion() {

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgReleaseManagerTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgReleaseManagerTest.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * artifact-manager
  * %%
@@ -6,9 +6,9 @@
  * %%
  * Build Tools for VMware Aria
  * Copyright 2023 VMware, Inc.
- * 
- * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.  
- * 
+ *
+ * This product is licensed to you under the BSD-2 license (the "License"). You may not use this product except in compliance with the BSD-2 License.
+ *
  * This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
  * #L%
  */
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class VraNgReleaseManagerTest {
@@ -58,5 +58,47 @@ public class VraNgReleaseManagerTest {
 
 		// Then
 		verify(restClientVrang, Mockito.times(2)).releaseBlueprintVersion(Mockito.anyString(), Mockito.anyString());
+	}
+
+	/**
+	 * Verifies the fix for issue #1205:
+	 * When forceRelease=true (only a companion custom form changed, not the
+	 * blueprint YAML), releaseVersion must NOT be suppressed by the isUpdated()
+	 * check even though the YAML content is identical to the last released version.
+	 */
+	@Test
+	public void testForceReleaseIgnoresIsUpdatedCheck() {
+		// Given: blueprint content has NOT changed — isUpdated() would return false
+		String latestVersion = "1";
+		String identicalContent = "blueprint_content_1"; // same as bp.getContent()
+		when(restClientVrang.getBlueprintLastUpdatedVersion(bp.getId())).thenReturn(latestVersion);
+		when(restClientVrang.getBlueprintVersionContent(bp.getId(), latestVersion)).thenReturn(identicalContent);
+
+		// When: forceRelease=true (triggered when custom form changed)
+		vraNgReleaseManager.releaseNextVersion(bp, true);
+
+		// Then: a release MUST still be triggered
+		verify(restClientVrang, times(1)).releaseBlueprintVersion(anyString(), anyString());
+		// updateBlueprint must be called to touch the blueprint draft on vRA NG
+		verify(restClientVrang, times(1)).updateBlueprint(bp);
+	}
+
+	/**
+	 * When forceRelease=false and content has not changed, no release should happen.
+	 */
+	@Test
+	public void testNoReleaseWhenContentUnchangedAndNoForceRelease() {
+		// Given: content unchanged, no force
+		String latestVersion = "1";
+		String identicalContent = "blueprint_content_1";
+		when(restClientVrang.getBlueprintLastUpdatedVersion(bp.getId())).thenReturn(latestVersion);
+		when(restClientVrang.getBlueprintVersionContent(bp.getId(), latestVersion)).thenReturn(identicalContent);
+
+		// When
+		vraNgReleaseManager.releaseNextVersion(bp, false);
+
+		// Then: no release, no updateBlueprint
+		verify(restClientVrang, never()).releaseBlueprintVersion(anyString(), anyString());
+		verify(restClientVrang, never()).updateBlueprint(any());
 	}
 }

--- a/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgResourceActionStoreTest.java
+++ b/common/artifact-manager/src/test/java/com/vmware/pscoe/iac/artifact/aria/automation/store/VraNgResourceActionStoreTest.java
@@ -14,16 +14,29 @@
  */
 package com.vmware.pscoe.iac.artifact.aria.automation.store;
 
+import static org.mockito.Mockito.doNothing;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgCustomForm;
+import com.vmware.pscoe.iac.artifact.aria.automation.models.VraNgIntegration;
+
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -250,4 +263,145 @@ public class VraNgResourceActionStoreTest {
 		// VERIFY
 		verify(restClient, times(1)).getAllResourceActions();
 	}
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Helper: minimal resource-action JSON that satisfies the import pipeline.
+	// Includes the fields consumed by sanitizeResourceActionJsonElement,
+	// populateVroEndpoint, VraNgProjectUtil.changeProjectIdBetweenOrganizations,
+	// and deleteResourceAction.
+	// ─────────────────────────────────────────────────────────────────────────────
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Helpers & constants for custom-form import tests
+	// ─────────────────────────────────────────────────────────────────────────────
+	private static final String RA_ID   = "ra-id-001";
+	private static final String RA_NAME = "memory";
+	private static final String FORM_JSON = "{\"layout\":{},\"schema\":{},\"options\":{}}";
+
+	/**
+	 * Raw vRA resource-action JSON that passes through every step of
+	 * importResourceAction (sanitize → populateVroEndpoint → projectId → delete →
+	 * serialize → import x2).
+	 */
+	private static final String RA_INPUT_JSON = "{"
+			+ "\"id\":\"" + RA_ID + "\","
+			+ "\"name\":\"" + RA_NAME + "\","
+			+ "\"resourceType\":\"Cloud.vSphere.Machine\","
+			+ "\"runnableItem\":{\"endpointLink\":\"/old/endpoint\"},"
+			+ "\"formDefinition\":{\"id\":\"old-form-id\",\"form\":\"\",\"status\":\"ON\"},"
+			+ "\"projectId\":\"project-001\","
+			+ "\"orgId\":\"org-001\""
+			+ "}";
+
+	/** JSON the REST API returns after the first importResourceAction call. */
+	private static final String RA_RESULT_JSON = "{"
+			+ "\"id\":\"" + RA_ID + "\","
+			+ "\"name\":\"" + RA_NAME + "\","
+			+ "\"formDefinition\":{\"id\":\"new-form-id\"}"
+			+ "}";
+
+	/**
+	 * Writes RA_INPUT_JSON directly to resource-actions/memory.json so that
+	 * importResourceAction receives the correct raw vRA format (NOT the
+	 * VraNgResourceAction wrapper that addResourceAction() would produce).
+	 */
+	private void createResourceActionFile() throws IOException {
+		File raDir = Paths.get(tempFolder.getRoot().getPath(), "resource-actions").toFile();
+		raDir.mkdirs();
+		Files.write(Paths.get(raDir.getPath(), RA_NAME + ".json"), RA_INPUT_JSON.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Writes the resource action file and a companion __FormData.json.
+	 *
+	 * @param formContent JSON to write into the companion form file
+	 */
+	private void createResourceActionAndFormFiles(String formContent) throws IOException {
+		createResourceActionFile();
+
+		Path customFormsDir = Paths.get(tempFolder.getRoot().getPath(), "catalog-items", "custom-forms");
+		Files.createDirectories(customFormsDir);
+		Files.write(customFormsDir.resolve(RA_NAME + "__FormData.json"), formContent.getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Mocks all REST calls that importResourceAction makes before it reaches
+	 * processResourceActionCustomForm.
+	 */
+	private void setupImportMocks() {
+		VraNgIntegration integration = Mockito.mock(VraNgIntegration.class);
+		when(integration.getName()).thenReturn("mock-vro");
+		when(integration.getEndpointConfigurationLink()).thenReturn("/resources/endpoints/mock");
+		when(config.getVroIntegration()).thenReturn("mock-vro");
+		when(restClient.getVraWorkflowIntegration("mock-vro")).thenReturn(integration);
+
+		when(restClient.getProjectId()).thenReturn("project-001");
+
+		doNothing().when(restClient).deleteResourceAction(anyString(), anyString());
+
+		when(restClient.importResourceAction(anyString(), anyString())).thenReturn(RA_RESULT_JSON);
+	}
+
+	@Test
+	void testImportResourceActionAppliesNewCustomForm() throws IOException {
+		// GIVEN: one resource action is configured for import
+		List<String> names = new ArrayList<>();
+		names.add(RA_NAME);
+		when(vraNgPackageDescriptor.getResourceAction()).thenReturn(names);
+
+		createResourceActionAndFormFiles(FORM_JSON);
+		setupImportMocks();
+
+		// Server has no existing form → treat as new
+		when(restClient.getCustomFormByTypeAndSource("resource.action", RA_ID))
+				.thenThrow(new RuntimeException("form not found"));
+
+		// WHEN
+		store.importContent(tempFolder.getRoot());
+
+		// THEN: importCustomForm must be called once with the resource action id
+		verify(restClient, times(1)).importCustomForm(any(VraNgCustomForm.class), eq(RA_ID));
+	}
+
+	@Test
+	void testImportResourceActionSkipsCustomFormWhenUnchanged() throws IOException {
+		// GIVEN
+		List<String> names = new ArrayList<>();
+		names.add(RA_NAME);
+		when(vraNgPackageDescriptor.getResourceAction()).thenReturn(names);
+
+		createResourceActionAndFormFiles(FORM_JSON);
+		setupImportMocks();
+
+		// Server already has the identical form → no update needed
+		VraNgCustomForm serverForm = new VraNgCustomForm(
+				"existing-form-id", RA_NAME, FORM_JSON, null,
+				RA_ID, "resource.action", "requestForm", "ON", "JSON");
+		when(restClient.getCustomFormByTypeAndSource("resource.action", RA_ID)).thenReturn(serverForm);
+
+		// WHEN
+		store.importContent(tempFolder.getRoot());
+
+		// THEN: importCustomForm must NOT be called
+		verify(restClient, never()).importCustomForm(any(), anyString());
+	}
+
+	@Test
+	void testImportResourceActionNoCustomFormFileSkipsImportCustomForm() throws IOException {
+		// GIVEN: resource action present, but NO companion form file
+		List<String> names = new ArrayList<>();
+		names.add(RA_NAME);
+		when(vraNgPackageDescriptor.getResourceAction()).thenReturn(names);
+
+		createResourceActionFile();   // no form file written
+		setupImportMocks();
+
+		when(restClient.getCustomFormByTypeAndSource("resource.action", RA_ID)).thenReturn(null);
+
+		// WHEN
+		store.importContent(tempFolder.getRoot());
+
+		// THEN: importCustomForm must never be called
+		verify(restClient, never()).importCustomForm(any(), anyString());
+	}
+
 }


### PR DESCRIPTION


### Description

#### Problem

Resource actions don't generate separate CSS file for form styles. 

#### Solution

Add support for CSS file for form styles similar to one implemented in [https://github.com/vmware/build-tools-for-vmware-aria/pull/1159]

### Checklist

- [x] I have added relevant error handling and logging messages to help troubleshooting
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the PR title with affected component, related issue number and a short summary of the changes introduced
- [x] I have my changes rebased and squashed to the minimal number of relevant commits. **Notice: don't squash all commits**
- [x] I have added a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Unit tests were implemented.

### Release Notes

Add Support for CSS Form Styles Management for Resource Actions

### Related issues and PRs

#1205 
